### PR TITLE
feat: Add a sample that copies S3 objects to a job attachments bucket

### DIFF
--- a/job_bundles/copy_s3_prefix_to_job_attachments/README.md
+++ b/job_bundles/copy_s3_prefix_to_job_attachments/README.md
@@ -1,0 +1,85 @@
+# Job bundle: Copy S3 prefix to job attachments
+
+## Use case for this job
+
+With AWS Deadline Cloud job attachments, you can attach files and directories to the jobs you submit, and that
+data gets uploaded to the job attachments S3 bucket that is configured on your queue. Any files that were already uploaded
+do not need to be uploaded again. If you are adding a Deadline Cloud farm to a project that already has a large
+volume of data, or are submitting a job that depends on a lot of new data like a fluid simulation output, there
+can be a longer wait for the job attachments upload.
+
+Because job attachments never re-uploads files that are already in job attachments, you can use alternative
+upload tools like [AWS Snowball](https://aws.amazon.com/snowball/), [AWS DataSync](https://aws.amazon.com/datasync/),
+or [Nimble Studio File Transfer](https://docs.aws.amazon.com/nimble-studio/latest/filetransfer-guide/what-is-file-transfer.html)
+to first copy that data to S3, then use this job to copy it into the job attachments for your queue.
+
+## How to submit this job
+
+Use the [AWS Deadline Cloud client](https://github.com/aws-deadline/deadline-cloud) to submit this job, either
+as a CLI command or with a GUI. Here's an example command to submit the job, if you want to process the copy across 20 workers.
+
+```
+$ deadline bundle submit copy_s3_prefix_to_job_attachments \
+    -p S3CopySource=s3://SOURCE_BUCKET_NAME/prefix/to/copy \
+    -p Parallelism=20
+```
+
+## Required IAM permissions
+
+Here are the IAM permissions you will need to add to your queue IAM role. The role already has permissions
+to read and write the job attachments bucket prefix, those do not need modification.
+
+```json
+{
+    "Effect": "Allow",
+    "Sid": "DeadlineQueueReadOnly",
+    "Action": [
+        "deadline:GetQueue"
+    ],
+    "Resource": [
+        "arn:aws:deadline:REGION:ACCOUNT_ID:farm/FARM_ID/queue/QUEUE_ID"
+    ]
+},
+{
+    "Effect": "Allow",
+    "Sid": "SourceBucketAccess",
+    "Action": [
+        "s3:ListBucket",
+        "s3:GetObjectTagging",
+        "s3:PutObjectTagging",
+        "s3:GetObject"
+    ],
+    "Resource": [
+        "arn:aws:s3:::SOURCE_BUCKET_NAME",
+        "arn:aws:s3:::SOURCE_BUCKET_NAME/*"
+    ]
+}
+```
+
+## Estimating costs
+
+This job calls Amazon S3 APIs, and makes copies of data into your queue's job attachments bucket,
+that will incur additional costs on your AWS bill.
+
+You can use information from the [Amazon S3 pricing](https://aws.amazon.com/s3/pricing/) page and the
+[AWS Pricing Calculator](https://calculator.aws) to estimate the costs of this job. Here is
+a summary of the API calls this job will make:
+
+1. A paginated s3:ListObjectsV2 to get the full list of objects with the specified prefix.
+2. For each object with the specified prefix:
+    1. An s3:GetObjectTagging to get the tags and see if we already computed the job attachments hash.
+    2. If the object does not have a tag with the job attachments hash:
+        1. An s3:GetObject to read the full contents and compute the job attachments hash.
+        2. An s3:PutObjectTagging to save the job attachments hash.
+    3. If the object has a tag with the job attachments hash:
+        1. An s3:HeadObject to read the POSIX mtime Metadata.
+    4. An s3:HeadObject to determine whether the object is already in the Job Attachments bucket.
+    5. If the object is not in the Job Attachments bucket:
+        1. Various of s3:CopyObject, s3:HeadObject, s3:CreateMultipartUpload, s3:ListParts,
+           s3:UploadPartCopy, etc. as necessary to transfer the object as a single or multiple part copy.
+3. An s3:PutObject to write a manifest file for all the objects in the specified prefix.
+
+## Implementation details
+
+Objects in the input bucket are tagged with a key `"B64DeadlineJobAttachmentsXXH128"` with base64-encoded value
+`"<etag>|<xxh128-hash>"`. When the etag matches, this tag is used instead of recomputing the hash.

--- a/job_bundles/copy_s3_prefix_to_job_attachments/parameter_values.yaml
+++ b/job_bundles/copy_s3_prefix_to_job_attachments/parameter_values.yaml
@@ -1,0 +1,5 @@
+parameterValues:
+- name: deadline:maxFailedTasksCount
+  value: 0
+- name: deadline:maxRetriesPerTask
+  value: 2

--- a/job_bundles/copy_s3_prefix_to_job_attachments/scripts/collect_objects.py
+++ b/job_bundles/copy_s3_prefix_to_job_attachments/scripts/collect_objects.py
@@ -1,0 +1,68 @@
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from pprint import pprint
+from urllib.parse import urlparse
+
+import boto3
+
+parser = argparse.ArgumentParser(prog="collect_object.py")
+parser.add_argument("workspace_path", type=Path)
+parser.add_argument("--parallelism", type=int, required=True)
+parser.add_argument("--copy-source", type=str, required=True)
+args = parser.parse_args()
+
+# Initialize the workspace
+os.makedirs(args.workspace_path, exist_ok=True)
+os.chdir(args.workspace_path)
+
+session = boto3.Session()
+deadline_client = session.client("deadline")
+s3_client = session.client("s3")
+
+# Get the queue and save it into the workspace
+response = deadline_client.get_queue(
+    farmId=os.environ["DEADLINE_FARM_ID"], queueId=os.environ["DEADLINE_QUEUE_ID"]
+)
+with open(args.workspace_path / "job_attachment_settings.json", "w") as fh:
+    json.dump(response["jobAttachmentSettings"], fh)
+
+# Split the S3 copy source into bucket and prefix
+url = urlparse(args.copy_source, allow_fragments=False)
+if url.scheme != "s3":
+    print(f"openjd_fail: Input S3 prefix {args.copy_source} is not an s3:// URL")
+    sys.exit(1)
+s3_bucket_name = url.netloc
+s3_prefix = url.path.strip("/")
+
+# Collect all the S3 objects under the prefix, skipping any
+# that end with "/" as those are directory markers.
+s3_objects = []
+paginator = s3_client.get_paginator("list_objects_v2")
+for page in paginator.paginate(Bucket=s3_bucket_name, Prefix=f"{s3_prefix}/"):
+    s3_objects.extend(
+        {
+            "key": obj["Key"],
+            "size": obj["Size"],
+            "etag": obj["ETag"],
+            "mtime": int(obj["LastModified"].timestamp() * 1e9),
+        }
+        for obj in page["Contents"]
+        if not obj["Key"].endswith("/")
+    )
+
+total_size = sum(obj["size"] for obj in s3_objects)
+print(
+    f"openjd_status: Collected {len(s3_objects)} objects in {total_size / 1024 / 1024:.2f}MB containing the bucket prefix"
+)
+print("The first 20 objects:")
+pprint(s3_objects[:20])
+
+# Sort by size and then deal the S3 objects to the tasks.
+# This will roughly distribute by both amount of data and file count.
+s3_objects.sort(key=lambda v: v["size"])
+for i in range(args.parallelism):
+    with open(args.workspace_path / f"s3_objects_{i + 1}.json", "w") as fh:
+        json.dump(s3_objects[i :: args.parallelism], fh)

--- a/job_bundles/copy_s3_prefix_to_job_attachments/scripts/copy_objects.py
+++ b/job_bundles/copy_s3_prefix_to_job_attachments/scripts/copy_objects.py
@@ -1,0 +1,69 @@
+import argparse
+import json
+import sys
+from pathlib import Path
+from urllib.parse import urlparse
+
+import boto3
+from botocore.exceptions import ClientError
+
+parser = argparse.ArgumentParser(prog="collect_object.py")
+parser.add_argument("workspace_path", type=Path)
+parser.add_argument("--index", type=int, required=True)
+parser.add_argument("--copy-source", type=str, required=True)
+args = parser.parse_args()
+
+workspace_path = Path(sys.argv[1])
+
+session = boto3.Session()
+s3_client = session.client("s3")
+
+url = urlparse(args.copy_source, allow_fragments=False)
+s3_bucket_name = url.netloc
+
+# Load the job attachments S3 settings
+with open(workspace_path / "job_attachment_settings.json") as fh:
+    ja_settings = json.load(fh)
+ja_s3_bucket_name = ja_settings["s3BucketName"]
+ja_root_prefix = ja_settings["rootPrefix"]
+
+# Load the list of objects this task will process
+with open(workspace_path / f"s3_objects_{args.index}.json") as fh:
+    s3_objects = json.load(fh)
+
+# Copy all the objects to the job attachments bucket
+print(f"openjd_status: Processing {len(s3_objects)} objects...")
+copied_object_count = 0
+copied_bytes_count = 0
+for i, s3_object in enumerate(s3_objects):
+    print(f"openjd_progress: {100 * i / len(s3_objects):.1f}")
+    print(f"Processing key {s3_object['key']} with hash {s3_object['xxh128_hash']}")
+    ja_key = f"{ja_root_prefix}/Data/{s3_object['xxh128_hash']}.xxh128"
+    # Check if the object exists, and skip the copy if it does
+    try:
+        s3_client.head_object(Bucket=ja_s3_bucket_name, Key=ja_key)
+        print("Skipping copy, it is already there")
+        continue
+    except ClientError as exc:
+        error_code = int(exc.response["ResponseMetadata"]["HTTPStatusCode"])
+        if error_code != 404:
+            raise
+    copied_object_count += 1
+    copied_bytes_count += s3_object["size"]
+    print(f"Copying {s3_object['size']} bytes...")
+    # Copy using the S3 managed copy operation that does a multi-threaded multi-part
+    # copy when applicable.
+    s3_client.copy(
+        CopySource={"Bucket": s3_bucket_name, "Key": s3_object["key"]},
+        Bucket=ja_s3_bucket_name,
+        Key=ja_key,
+        ExtraArgs={
+            "CopySourceIfMatch": s3_object["etag"],
+            "MetadataDirective": "REPLACE",
+            "TaggingDirective": "REPLACE",
+        },
+    )
+print(
+    f"openjd_status: Processed {len(s3_objects)} objects (copied {copied_bytes_count} bytes in {copied_object_count} objects)"
+)
+print("openjd_progress: 100")

--- a/job_bundles/copy_s3_prefix_to_job_attachments/scripts/hash_objects.py
+++ b/job_bundles/copy_s3_prefix_to_job_attachments/scripts/hash_objects.py
@@ -1,0 +1,134 @@
+import argparse
+import json
+import os
+import sys
+from base64 import b64decode, b64encode
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from urllib.parse import urlparse
+
+import boto3
+from xxhash import xxh3_128
+
+parser = argparse.ArgumentParser(prog="collect_object.py")
+parser.add_argument("workspace_path", type=Path)
+parser.add_argument("--index", type=int, required=True)
+parser.add_argument("--copy-source", type=str, required=True)
+args = parser.parse_args()
+
+workspace_path = Path(sys.argv[1])
+
+session = boto3.Session()
+s3_client = session.client("s3")
+
+url = urlparse(args.copy_source, allow_fragments=False)
+s3_bucket_name = url.netloc
+
+# Load the list of objects this task will process
+with open(workspace_path / f"s3_objects_{args.index}.json") as fh:
+    s3_objects = json.load(fh)
+
+
+def update_mtime_from_metadata(s3_object, metadata):
+    """Modifies the 'mtime' entry in s3_object from the S3 object metadata."""
+    if posix_mtime_metadata := metadata.get("file-mtime"):
+        # DataSync, FSx for Lustre, among others use x-amz-meta-file-mtime,
+        # which is nanoseconds if it has an "ns" suffix, otherwise milliseconds.
+        if posix_mtime_metadata[-2:] == "ns":
+            s3_object["mtime"] = int(posix_mtime_metadata[:-2])
+        else:
+            s3_object["mtime"] = int(float(posix_mtime_metadata) * 1e6)
+    elif posix_mtime_metadata := metadata.get("mtime"):
+        # S3FS, RClone, among others use x-amz-meta-mtime, which is seconds
+        # and may be floating point
+        s3_object["mtime"] = int(float(posix_mtime_metadata) * 1e9)
+
+
+# Check all the objects for the hash tag, and hash the data if it's missing or doesn't match the etag
+hashed_object_count = 0
+hashed_bytes_count = 0
+
+
+def process_s3_object(i, s3_object):
+    # NOTE: If we don't combine "\n" inside the main string of print(), it interleaves the "\n" with
+    #       the bodies, and some lines get doubled up while others are empty.
+    print(f"{i}: Processing key {s3_object['key']}\n", end="")
+    response = s3_client.get_object_tagging(Bucket=s3_bucket_name, Key=s3_object["key"])
+    tag_set = response["TagSet"]
+    tag_set_dict = {obj["Key"]: obj["Value"] for obj in tag_set}
+    etag_and_hash_encoded = tag_set_dict.get("B64DeadlineJobAttachmentsXXH128")
+    if etag_and_hash_encoded:
+        etag, ja_hash = (
+            b64decode(etag_and_hash_encoded.encode("ascii")).decode("utf-8").split("|")
+        )
+        if etag == s3_object["etag"]:
+            # If it's tagged, and the etag matches, use the JA hash from the tag
+            s3_object["xxh128_hash"] = ja_hash
+            print(f"{i}: Using the tagged hash {ja_hash}\n", end="")
+            # Get the POSIX mtime if it's set
+            response = s3_client.head_object(
+                Bucket=s3_bucket_name, Key=s3_object["key"]
+            )
+            update_mtime_from_metadata(s3_object, response["Metadata"])
+            return
+
+    # We don't know the hash, so we need to compute it
+    global hashed_object_count, hashed_bytes_count
+    hashed_object_count += 1
+    hashed_bytes_count += s3_object["size"]
+    hasher = xxh3_128()
+    if s3_object["size"] > 0:
+        response = s3_client.get_object(
+            Bucket=s3_bucket_name, Key=s3_object["key"], IfMatch=s3_object["etag"]
+        )
+        update_mtime_from_metadata(s3_object, response["Metadata"])
+        for chunk in response["Body"].iter_chunks(2**20):
+            hasher.update(chunk)
+    else:
+        # Get the POSIX mtime if it's set
+        response = s3_client.head_object(Bucket=s3_bucket_name, Key=s3_object["key"])
+        update_mtime_from_metadata(s3_object, response["Metadata"])
+    ja_hash = hasher.hexdigest()
+    s3_object["xxh128_hash"] = ja_hash
+    print(f"{i}: Calculated hash {ja_hash}\n", end="")
+
+    # Save the hash as an object tag
+    etag_and_hash = b64encode(f"{s3_object['etag']}|{ja_hash}".encode("utf-8")).decode(
+        "ascii"
+    )
+    tag_set = [
+        obj for obj in tag_set if obj["Key"] != "B64DeadlineJobAttachmentsXXH128"
+    ]
+    tag_set.append({"Key": "B64DeadlineJobAttachmentsXXH128", "Value": etag_and_hash})
+    s3_client.put_object_tagging(
+        Bucket=s3_bucket_name,
+        Key=s3_object["key"],
+        Tagging={"TagSet": tag_set},
+    )
+
+
+# Get the available vcpus using the API recommended in Python documentation, then use 2 threads for each
+available_vcpus = len(os.sched_getaffinity(0))
+thread_count = 2 * available_vcpus
+# Use multithreaded scheduling, as the xxhash function always releases the GIL
+print(
+    f"openjd_status: Processing {len(s3_objects)} objects using {thread_count} threads..."
+)
+with ThreadPoolExecutor(max_workers=thread_count) as executor:
+    # Start the load operations and mark each future with its URL
+    future_list = [
+        executor.submit(process_s3_object, i, s3_object)
+        for i, s3_object in enumerate(s3_objects)
+    ]
+    for i, future in enumerate(as_completed(future_list)):
+        # Get the result so it re-raises any exceptions
+        future.result()
+        print(f"openjd_progress: {100 * i / len(s3_objects):.1f}\n", end="")
+print(
+    f"openjd_status: Processed {len(s3_objects)} objects (hashed {hashed_bytes_count} bytes in {hashed_object_count} objects)"
+)
+print("openjd_progress: 100")
+
+# Update the metadata about these objects in the workspace
+with open(workspace_path / f"s3_objects_{args.index}.json", "w") as fh:
+    json.dump(s3_objects, fh)

--- a/job_bundles/copy_s3_prefix_to_job_attachments/scripts/save_manifest.py
+++ b/job_bundles/copy_s3_prefix_to_job_attachments/scripts/save_manifest.py
@@ -1,0 +1,76 @@
+import argparse
+import datetime
+import json
+import subprocess
+import sys
+from io import BytesIO
+from pathlib import Path
+from urllib.parse import urlparse
+
+import boto3
+
+subprocess.check_call([sys.executable, "-m", "pip", "install", "deadline"])
+from deadline.job_attachments.asset_manifests.v2023_03_03 import (
+    AssetManifest,
+    ManifestPath,
+)
+
+parser = argparse.ArgumentParser(prog="collect_object.py")
+parser.add_argument("workspace_path", type=Path)
+parser.add_argument("--parallelism", type=int, required=True)
+parser.add_argument("--copy-source", type=str, required=True)
+args = parser.parse_args()
+
+workspace_path = Path(sys.argv[1])
+
+session = boto3.Session()
+s3_client = session.client("s3")
+
+url = urlparse(args.copy_source, allow_fragments=False)
+s3_bucket_name = url.netloc
+s3_prefix = url.path.strip("/")
+
+# Load the job attachments S3 settings
+with open(workspace_path / "job_attachment_settings.json") as fh:
+    ja_settings = json.load(fh)
+ja_s3_bucket_name = ja_settings["s3BucketName"]
+ja_root_prefix = ja_settings["rootPrefix"]
+
+total_size = 0
+paths = []
+
+for index in range(1, args.parallelism + 1):
+    with open(workspace_path / f"s3_objects_{index}.json") as fh:
+        for s3_object in json.load(fh):
+            total_size += s3_object["size"]
+            paths.append(
+                ManifestPath(
+                    path=s3_object["key"][len(s3_prefix) + 1 :],
+                    hash=s3_object["xxh128_hash"],
+                    mtime=s3_object["mtime"],
+                    size=s3_object["size"],
+                )
+            )
+
+paths.sort(key=lambda x: x.path, reverse=True)
+
+manifest = AssetManifest(
+    hash_alg="xxh128",
+    paths=paths,
+    total_size=total_size,
+)
+
+now_timestamp = (
+    datetime.datetime.now(tz=datetime.UTC)
+    .isoformat(timespec="minutes")
+    .replace("+00:00", "Z")
+)
+manifest_key = f"{ja_root_prefix}/Manifests/bucket-prefix-snapshot-{s3_bucket_name}/{s3_prefix}/{now_timestamp}-manifest.json"
+
+print(f"Saving manifest with {len(paths)} paths, total {total_size} bytes")
+s3_client.upload_fileobj(
+    Fileobj=BytesIO(manifest.encode().encode("utf-8")),
+    Bucket=ja_s3_bucket_name,
+    Key=manifest_key,
+)
+print(f"openjd_status: Saved manifest url s3://{ja_s3_bucket_name}/{manifest_key}")

--- a/job_bundles/copy_s3_prefix_to_job_attachments/template.yaml
+++ b/job_bundles/copy_s3_prefix_to_job_attachments/template.yaml
@@ -1,0 +1,147 @@
+specificationVersion: 'jobtemplate-2023-09'
+
+name: Copy {{Param.S3CopySource}} to Job Attachments
+description: |
+  This job copies all the objects that have a particular prefix in the S3CopySource bucket
+  prefix to the job attachments bucket of youar AWS Deadline Cloud queue. See README.md
+  in this job bundle for details about the permissions your queue's IAM role will need.
+
+parameterDefinitions:
+# S3 Copy Parameters
+- name: S3CopySource
+  description: The input data prefix, as 's3://<BUCKET_NAME>/prefix'.
+  userInterface:
+    control: LINE_EDIT
+    groupLabel: S3 Copy Parameters
+  type: STRING
+- name: Parallelism
+  description: How many tasks to spread the copy across.
+  userInterface:
+    control: SPIN_BOX
+    groupLabel: S3 Copy Parameters
+  type: INT
+  minValue: 1
+  default: 3
+# Software
+- name: CondaPackages
+  description: A list of conda packages to install. The job expects a Queue Environment to handle this.
+  userInterface:
+    control: LINE_EDIT
+    groupLabel: Software
+  type: STRING
+  default: python boto3 python-xxhash
+- name: CondaChannels
+  description: A list of conda channels to get packages from. The job expects a Queue Environment to handle this.
+  userInterface:
+    control: LINE_EDIT
+    groupLabel: Software
+  type: STRING
+  default: conda-forge
+# Hidden
+- name: WorkspacePath
+  description: A temporary directory for the job to use.
+  userInterface:
+    control: HIDDEN
+  type: PATH
+  objectType: DIRECTORY
+  dataFlow: OUT
+  default: workspace
+- name: JobScriptDir
+  description: Directory containing bundled scripts.
+  userInterface:
+    control: HIDDEN
+  type: PATH
+  objectType: DIRECTORY
+  dataFlow: IN
+  default: scripts
+
+jobEnvironments:
+- name: UnbufferedOutput
+  variables:
+    # Turn off buffering of Python's output
+    PYTHONUNBUFFERED: "True"
+
+steps:
+- name: CollectObjects
+  description: |
+    This step lists all the objects in the bucket under the specified prefix, and divides them up evenly
+    to process as different tasks. Each object is collected along with its etag and other metadata.
+  script:
+    actions:
+      onRun:
+        command: python
+        args:
+        - '{{Param.JobScriptDir}}/collect_objects.py'
+        - '{{Param.WorkspacePath}}'
+        - '--parallelism'
+        - '{{Param.Parallelism}}'
+        - '--copy-source'
+        - '{{Param.S3CopySource}}'
+
+- name: HashObjects
+  description: |
+    This step gets the xxh128 hash of each object, either from the "B64DeadlineJobAttachmentsXXH128"
+    object tag, or by calculating it. If it calculates the hash, it saves the tag. The etag is used
+    to ensure that the object being hashed is the exact same one that was listed in the CollectObjects
+    step.
+  dependencies:
+  - dependsOn: CollectObjects
+  parameterSpace:
+    taskParameterDefinitions:
+    - name: Index
+      type: INT
+      range: "1-{{Param.Parallelism}}"
+  script:
+    actions:
+      onRun:
+        command: python
+        args:
+        - '{{Param.JobScriptDir}}/hash_objects.py'
+        - '{{Param.WorkspacePath}}'
+        - '--index'
+        - '{{Task.Param.Index}}'
+        - '--copy-source'
+        - '{{Param.S3CopySource}}'
+
+- name: CopyObjects
+  description: |
+    This step copies all the objects into the job attachments content addressable storage,
+    using the hashes calculated in HashObjects as the keys.
+  dependencies:
+  - dependsOn: CollectObjects
+  - dependsOn: HashObjects
+  parameterSpace:
+    taskParameterDefinitions:
+    - name: Index
+      type: INT
+      range: "1-{{Param.Parallelism}}"
+  script:
+    actions:
+      onRun:
+        command: python
+        args:
+        - '{{Param.JobScriptDir}}/copy_objects.py'
+        - '{{Param.WorkspacePath}}'
+        - '--index'
+        - '{{Task.Param.Index}}'
+        - '--copy-source'
+        - '{{Param.S3CopySource}}'
+
+- name: SaveManifest
+  description: |
+    This step saves a manifest file of all the files that were processed.
+  dependencies:
+  - dependsOn: CollectObjects
+  - dependsOn: HashObjects
+  - dependsOn: CopyObjects
+  script:
+    actions:
+      onRun:
+        command: python
+        args:
+        - '{{Param.JobScriptDir}}/save_manifest.py'
+        - '{{Param.WorkspacePath}}'
+        - '--parallelism'
+        - '{{Param.Parallelism}}'
+        - '--copy-source'
+        - '{{Param.S3CopySource}}'


### PR DESCRIPTION
### Description

This adds a sample job bundle that copies all the S3 objects containing a particular S3 bucket prefix
into the job attachments of the queue it's submitted to. See the included README.md for more details,
such as how to submit the job and the IAM permissions it needs in the queue IAM role.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.