### PR TITLE
chore: support datetime utc in lower python versions

### DIFF
--- a/job_bundles/copy_s3_prefix_to_job_attachments/scripts/save_manifest.py
+++ b/job_bundles/copy_s3_prefix_to_job_attachments/scripts/save_manifest.py
@@ -61,7 +61,7 @@ manifest = AssetManifest(
 )
 
 now_timestamp = (
-    datetime.datetime.now(tz=datetime.UTC)
+    datetime.datetime.now(tz=datetime.timezone.utc)
     .isoformat(timespec="minutes")
     .replace("+00:00", "Z")
 )


### PR DESCRIPTION
### Description
`datetime.UTC` caused an error in CMF when using Python 3.9. Since `datetime.UTC` was introduced since 3.11 as per https://docs.python.org/3/library/datetime.html#datetime.UTC, we could consider supporting lower versions.

```
AttributeError: module 'datetime' has no attribute 'UTC'
```

