### PR TITLE
chore: Add default directory for Blender render bundle

### DIFF
--- a/job_bundles/blender_render/template.yaml
+++ b/job_bundles/blender_render/template.yaml
@@ -34,6 +34,7 @@ parameterDefinitions:
     control: CHOOSE_DIRECTORY
     label: Output Directory
     groupLabel: Render Parameters
+  default: "./output"
   description: Choose the render output directory.
 - name: OutputPattern
   type: STRING


### PR DESCRIPTION
### Description
Users are supposed to choose the output directory. However, if a customer is testing with a sample blender render with the blender_render template, they might be new to the tool. To prevent an error after submission as below, we could provide a default output directory in the template.


<img width="657" alt="image" src="https://github.com/aws-deadline/deadline-cloud-samples/assets/162955484/6815dbaf-c224-4831-a020-e14b541ef8c0">
