### PR TITLE
fix: Blender --use-extension option requires value 1

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Set shell scripts to always have 'lf' line endings
+*.sh text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+job_bundles/blender_render/output/

--- a/job_bundles/blender_render/template.yaml
+++ b/job_bundles/blender_render/template.yaml
@@ -2,6 +2,7 @@ specificationVersion: 'jobtemplate-2023-09'
 name: Blender Render
 
 parameterDefinitions:
+
 # Render Parameters
 - name: BlenderSceneFile
   type: PATH
@@ -53,6 +54,7 @@ parameterDefinitions:
   description: Choose the file format to render as.
   default: JPEG
   allowedValues: [TGA, RAWTGA, JPEG, IRIS, IRIZ, PNG, HDR, TIFF, OPEN_EXR, OPEN_EXR_MULTILAYER, CINEON, DPX, DDS, JP2, WEBP]
+
 # Software Environment
 - name: CondaPackages
   type: STRING
@@ -99,5 +101,5 @@ steps:
           blender --background '{{Param.BlenderSceneFile}}' \
                   --render-output '{{Param.OutputDir}}/{{Param.OutputPattern}}' \
                   --render-format {{Param.Format}} \
-                  --use-extension true \
+                  --use-extension 1 \
                   --render-frame {{Task.Param.Frame}}


### PR DESCRIPTION
### Description

The blender_render example prints an error message about --use-extension when it runs, and submitting
the example .sh files from a Windows workstation to a Linux fleet, it can fail.

* Fix blender_render to have --use-extension 1 instead of --use-extension true.
* Add the blender_render default output directory to .gitignore.
* Modify .gitattributes to always give .sh files lf end of lines.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.