### PR TITLE
feat: Add samples that show job environment use cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,6 @@ The [job_bundles](https://github.com/aws-deadline/deadline-cloud-samples/tree/ma
 directory contains sample jobs that you can submit to your Deadline Cloud queue. You can use the
 [Deadline Cloud CLI](https://github.com/aws-deadline/deadline-cloud) to submit these jobs to your queues.
 
-## Conda recipes
-
-The [conda_recipes](https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/conda_recipes)
-directory contains samples and tooling for building conda packages for your
-Deadline Cloud queues. You can use the `submit-package-job` tool to submit
-build jobs to your queue. See [this blog post](https://aws.amazon.com/blogs/media/create-a-conda-package-and-channel-for-aws-deadline-cloud/)
-for instructions on how to configure your Deadline Cloud farm for building and
-using an Amazon S3 conda channel.
-
 ### CLI job submission
 
 ```
@@ -32,6 +23,15 @@ $ deadline bundle gui-submit job_bundles/gui_control_showcase
 ```
 
 ![deadline bundle gui-submit showcase](.images/deadline-bundle-gui-submit-showcase.png)
+
+## Conda recipes
+
+The [conda_recipes](https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/conda_recipes)
+directory contains samples and tooling for building conda packages for your
+Deadline Cloud queues. You can use the `submit-package-job` tool to submit
+build jobs to your queue. See [this blog post](https://aws.amazon.com/blogs/media/create-a-conda-package-and-channel-for-aws-deadline-cloud/)
+for instructions on how to configure your Deadline Cloud farm for building and
+using an Amazon S3 conda channel.
 
 ## Queue environment samples
 

--- a/job_bundles/job_env_daemon_process/template.yaml
+++ b/job_bundles/job_env_daemon_process/template.yaml
@@ -1,0 +1,251 @@
+specificationVersion: jobtemplate-2023-09
+name: Job sample with a daemon process
+description: |
+  A job template can define and consume environments that run background
+  daemon processes shared with multiple tasks of a step. In many rendering
+  use cases, loading the application and scene data can take a significant
+  amount of time relative to the render of a frame, and this pattern amortizes
+  the loading time across all frames scheduled in a session.
+
+  This sample implements that pattern using self-contained Python and bash code.
+  See https://github.com/OpenJobDescription/openjd-adaptor-runtime-for-python
+  for a Python library that can assist to embed this pattern in application
+  scripting systems.
+
+parameterDefinitions:
+- name: Frames
+  description: The range of frames to process as separate tasks.
+  type: STRING
+  default: 1-50
+- name: FailureRate
+  description: The probability that a task should fail.
+  type: FLOAT
+  default: 0.1
+  minValue: 0
+  maxValue: 1
+
+steps:
+- name: EnvWithDaemonProcess
+  parameterSpace:
+    taskParameterDefinitions:
+    - name: Frame
+      type: INT
+      range: "{{Param.Frames}}"
+
+  stepEnvironments:
+  - name: DaemonProcess
+    description: Runs a daemon process for the step's tasks to share.
+    script:
+      actions:
+        onEnter:
+          command: bash
+          args:
+          - "{{Env.File.Enter}}"
+        onExit:
+          command: bash
+          args:
+          - "{{Env.File.Exit}}"
+      embeddedFiles:
+      - name: Enter
+        filename: enter-daemon-process-env.sh
+        type: TEXT
+        data: |
+          #!/bin/env bash
+          set -euo pipefail
+
+          DAEMON_LOG='{{Session.WorkingDirectory}}/daemon.log'
+          echo "openjd_env: DAEMON_LOG=$DAEMON_LOG"
+          nohup python {{Env.File.DaemonScript}} > $DAEMON_LOG 2>&1 &
+          echo "openjd_env: DAEMON_PID=$!"
+          echo "openjd_env: DAEMON_BASH_HELPER_SCRIPT={{Env.File.DaemonHelperFunctions}}"
+
+          echo 0 > 'daemon_log_cursor.txt'
+      - name: Exit
+        filename: exit-daemon-process-env.sh
+        type: TEXT
+        data: |
+          #!/bin/env bash
+          set -euo pipefail
+
+          # Stop the daemon process
+          kill -9 "$DAEMON_PID"
+
+          # Get the byte range to print within the log
+          DAEMON_LOG_CURSOR=$(( $(cat daemon_log_cursor.txt) + 1 ))
+          stat --format %s "$DAEMON_LOG" > 'daemon_log_cursor.txt'
+          DAEMON_LOG_CURSOR_END=$(cat daemon_log_cursor.txt)
+
+          # Print the selected byte range
+          echo ""
+          echo "=== Last output from daemon"
+          if [ "$DAEMON_LOG_CURSOR_END" -gt "$DAEMON_LOG_CURSOR" ]; then
+            cut -z -b "$DAEMON_LOG_CURSOR-$DAEMON_LOG_CURSOR_END" "$DAEMON_LOG"
+          fi
+          echo "==="
+          echo ""
+      - name: DaemonScript
+        filename: daemon-script.py
+        type: TEXT
+        data: |
+          """
+          This Python script runs as a daemon process in the background and listens for
+          SIGUSR1 signals. When it receives such a signal, it runs a single task by
+          reading its details from a JSON file, performing a simulated task run,
+          and then writing an output result JSON file.
+          """
+
+          import signal
+          import threading
+          import json
+          from pathlib import Path
+          import random
+
+          random.seed()
+
+          # File paths for communicating with the tasks
+          workdir = Path(r'{{Session.WorkingDirectory}}')
+          details_file = workdir / 'task_details.json'
+          task_result_partial_file = workdir / 'task_result.json.partial'
+          task_result_file = workdir / 'task_result.json'
+
+          # To coordinate from the signal handler to the processing thread
+          sigusr1_sema = threading.Semaphore(0)
+
+          # Release the thread once each time the USR1 signal is received
+          signal.signal(signal.SIGUSR1, lambda signum, frame: sigusr1_sema.release())
+
+          processed_task_count = 0
+
+          def process_task(task_details):
+              print(f"Processing frame number {task_details['frame']}")
+              random_value = random.random()
+              failure_rate = {{Param.FailureRate}}
+              result = "SUCCESS" if (random_value > failure_rate) else "FAILURE"
+              return {
+                  "result": result,
+                  "processedTaskCount": processed_task_count,
+                  "randomValue": random_value,
+                  "failureRate": failure_rate,
+              }
+
+          def task_processing_loop():
+              global processed_task_count
+              while True:
+                  print("Waiting until a USR1 signal is sent...", flush=True)
+                  sigusr1_sema.acquire()
+
+                  print("Loading the task details file", flush=True)
+                  task_details = json.loads(details_file.read_text())
+                  details_file.unlink()
+
+                  print("Received task details:", flush=True)
+                  print(json.dumps(task_details, indent=1), flush=True)
+
+                  task_result = process_task(task_details)
+                  processed_task_count += 1
+
+                  print("Writing result", flush=True)
+                  task_result_partial_file.write_text(json.dumps(task_result))
+                  # Rename into the result file, so the task sees its contents atomically
+                  task_result_partial_file.replace(task_result_file)
+
+          # Process the tasks in a separate thread
+          processing_thread = threading.Thread(target=task_processing_loop)
+          processing_thread.start()
+          processing_thread.join()
+      - name: DaemonHelperFunctions
+        filename: daemon-helper-functions.sh
+        type: TEXT
+        data: |
+          # This bash script contains helper functions for sending tasks
+          # to the background daemon process.
+
+          print_daemon_log () {
+            # Get the byte range to print within the log
+            DAEMON_LOG_CURSOR=$(( $(cat daemon_log_cursor.txt) + 1 ))
+            stat --format %s "$DAEMON_LOG" > 'daemon_log_cursor.txt'
+            DAEMON_LOG_CURSOR_END=$(cat daemon_log_cursor.txt)
+
+            # Print the selected byte range
+            echo ""
+            echo "=== $1"
+            if [ "$DAEMON_LOG_CURSOR_END" -gt "$DAEMON_LOG_CURSOR" ]; then
+              cut -z -b "$DAEMON_LOG_CURSOR-$DAEMON_LOG_CURSOR_END" "$DAEMON_LOG"
+            fi
+            echo "==="
+            echo ""
+          }
+
+          send_task_to_daemon () {
+            echo "Sending command to daemon"
+            echo "$1" > task_details.json
+            # This sends SIGUSR1 to the daemon, so it knows to process the command
+            kill -USR1 "$DAEMON_PID"
+          }
+
+          wait_for_daemon_task_result () {
+            local EXITCODE=2
+            while [ $EXITCODE = 2 ];
+              do sleep 0.3
+
+              if [ -f task_result.json ]; then
+                TASK_RESULT=$(cat task_result.json)
+                if [ $(jq '.result == "SUCCESS"' task_result.json) = true ]; then
+                  EXITCODE=0
+                else
+                  EXITCODE=1
+                  echo "Task failed:"
+                  echo "$TASK_RESULT" | jq .
+                fi
+                rm task_result.json
+              fi
+
+              if ! (ps -p "$DAEMON_PID" > /dev/null); then
+                echo "Daemon process exited unexpectedly."
+                break
+              fi
+            done
+
+            if ! [ "$EXITCODE" = 0 ]; then
+              print_daemon_log "Daemon log from running the task"
+              exit "$EXITCODE"
+            fi
+          }
+
+  script:
+    actions:
+      onRun:
+        timeout: 60
+        command: bash
+        args:
+        - '{{Task.File.Run}}'
+    embeddedFiles:
+    - name: Run
+      filename: run-task.sh
+      type: TEXT
+      data: |
+        # This bash script sends a task to the background daemon process,
+        # then waits for it to respond with the output result.
+
+        set -euo pipefail
+
+        source "$DAEMON_BASH_HELPER_SCRIPT"
+
+        echo "Daemon PID is $DAEMON_PID"
+        echo "Daemon log file is $DAEMON_LOG"
+
+        print_daemon_log "Previous output from daemon"
+
+        send_task_to_daemon "{\"pid\": $$, \"frame\": {{Task.Param.Frame}} }"
+        wait_for_daemon_task_result
+
+        echo Received task result:
+        echo "$TASK_RESULT" | jq .
+
+        print_daemon_log "Daemon log from running the task"
+
+  hostRequirements:
+    attributes:
+    - name: attr.worker.os.family
+      anyOf:
+      - linux

--- a/job_bundles/job_env_vars/template.yaml
+++ b/job_bundles/job_env_vars/template.yaml
@@ -1,0 +1,59 @@
+specificationVersion: 'jobtemplate-2023-09'
+name: Job sample with environment variables
+description: |
+  A job template can set environment variables for the whole job or for a particular step
+  by specifying Open Job Description environments.
+
+parameterDefinitions:
+- name: ExampleParam
+  type: STRING
+  default: An example parameter value
+
+jobEnvironments:
+- name: JobEnv
+  description: Job environments apply to everything in the job.
+  variables:
+    # When applications have options as environment variables, you can set them here.
+    JOB_VERBOSITY: MEDIUM
+    # You can use the value of job parameters when setting environment variables.
+    JOB_EXAMPLE_PARAM: "{{Param.ExampleParam}}"
+    # Some more ideas.
+    JOB_PROJECT_ID: project-12
+    JOB_ENDPOINT_URL: https://internal-host-name/some/path
+    # This variable lets applications using the Qt Framework run without a display
+    QT_QPA_PLATFORM: offscreen
+
+steps:
+- name: EnvSampleStep
+
+  stepEnvironments:
+  - name: StepEnv
+    description: Step environments apply to all the tasks in the step.
+    variables:
+      # These environment variables are only set within this step, not other steps.
+      STEP_VERBOSITY: HIGH
+      # Replace a variable value defined at the job level.
+      JOB_PROJECT_ID: step-project-12
+
+  script:
+    actions:
+      onRun:
+        command: bash
+        args:
+        - '{{Task.File.Run}}'
+    embeddedFiles:
+    - name: Run
+      type: TEXT
+      data: |
+        echo Running the task
+        echo ""
+
+        echo Environment variables starting with JOB_*:
+        set | grep ^JOB_
+        echo ""
+
+        echo Environment variables starting with STEP_*:
+        set | grep ^STEP_
+        echo ""
+
+        echo Done running the task

--- a/job_bundles/job_env_with_new_command/template.yaml
+++ b/job_bundles/job_env_with_new_command/template.yaml
@@ -1,0 +1,84 @@
+specificationVersion: 'jobtemplate-2023-09'
+name: Job sample with a new command in the PATH
+description: |
+  A job template can define Open Job Description environments that create new command
+  scripts and add them to the PATH environment variable for all steps of the job to use.
+
+jobEnvironments:
+- name: RandomSleepCommand
+  description: Adds a command 'random-sleep' to the environment.
+  script:
+    actions:
+      onEnter:
+        command: bash
+        args:
+        - "{{Env.File.Enter}}"
+    embeddedFiles:
+    - name: Enter
+      type: TEXT
+      data: |
+        #!/bin/env bash
+        set -euo pipefail
+
+        # Make a bin directory inside the session's working directory for providing new commands
+        mkdir -p '{{Session.WorkingDirectory}}/bin'
+
+        # If this bin directory is not already in the PATH, then add it
+        if ! [[ ":$PATH:" == *':{{Session.WorkingDirectory}}/bin:'* ]]; then
+          export "PATH={{Session.WorkingDirectory}}/bin:$PATH"
+
+          # This message to Open Job Description exports the new PATH value to the environment
+          echo "openjd_env: PATH=$PATH"
+        fi
+
+        # Copy the SleepScript embedded file into the bin directory
+        cp '{{Env.File.SleepScript}}' '{{Session.WorkingDirectory}}/bin/random-sleep'
+        chmod u+x '{{Session.WorkingDirectory}}/bin/random-sleep'
+    - name: SleepScript
+      type: TEXT
+      runnable: true
+      data: |
+        #!/bin/env python
+
+        """
+        Usage: random-sleep MIN MAX
+
+        Sleeps for a random number of seconds, between the MIN and MAX values.
+        """
+
+        import argparse
+        import random
+        import time
+
+        random.seed()
+
+        parser = argparse.ArgumentParser(prog='random-sleep')
+        parser.add_argument('min', type=float)
+        parser.add_argument('max', type=float)
+        args = parser.parse_args()
+
+        duration = random.uniform(args.min, args.max)
+        print(f"Sleeping for duration {duration:.2f}")
+        time.sleep(duration)
+
+steps:
+- name: EnvWithCommand
+  script:
+    actions:
+      onRun:
+        command: bash
+        args:
+        - '{{Task.File.Run}}'
+    embeddedFiles:
+    - name: Run
+      type: TEXT
+      data: |
+        set -xeuo pipefail
+
+        # Run the script installed into PATH by the job environment
+        random-sleep 12.5 27.5
+  hostRequirements:
+    attributes:
+    - name: attr.worker.os.family
+      anyOf:
+      - linux


### PR DESCRIPTION
### Description

This PR adds a set of samples demonstrating use cases for Open Job Description environments.

* The job_env_vars job bundle sets environment variables at both the job and step level, using the 'variables' field.
* The job_env_with_new_command job bundle creates a bin directory with a script in it, then adds it to the PATH so that all the tasks can run it as a command.
* The job_env_daemon_process is a standalone implementation of using a background daemon process to run tasks, where the tasks themselves communicate to it via inter-process communication.

It also contains an unrelated README fix:

* Made a small tweak to the README.md so that the job submission screenshots are subsections of the job bundles heading instead of the conda recipes heading.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.