### PR TITLE
feat: add tile rendering job bundle example using Maya, Arnold, and ffmpeg

### DIFF
--- a/job_bundles/tile_render_maya_ffmpeg/README.md
+++ b/job_bundles/tile_render_maya_ffmpeg/README.md
@@ -1,0 +1,68 @@
+# Tile Render with Maya/Arnold and Ffmpeg
+
+## Introduction
+This job is designed to submit a tile rendering job using Maya, Arnold, and ffmpeg. A tile render divides an image into evenly sized regions for rendering, then assembles the tiles to get the whole image. 
+
+This job bundle requires a modified Maya Arnold render handler for Deadline Cloud. It uses a bash script to call ffmpeg which requires Linux workers and access to the ffmpeg command from the workers. The template uses job parameter values (NumXTiles and NumYTiles) to specify the number of tiles, which are then used to define task parameter values (TileNumberX and TileNumberY) for the tile numbers, which are all added to the runData for the Maya render step. A second step is defined to have a dependency on the render step, which uses a bash script to call ffmpeg to assemble the tiles. 
+
+## Arnold Render Handler Modifications
+As on 7/2024, modifications to the Deadline Cloud Maya adaptor are needed to render the tiles for this job. To do this, a local copy of the [deadline-cloud-for-maya](https://github.com/aws-deadline/deadline-cloud-for-maya/tree/mainline) repository can be used to create a development version of the Maya adaptor. The following code can be added to the `start_render` function in [arnold_renderer.py](https://github.com/aws-deadline/deadline-cloud-for-maya/blob/mainline/src/deadline/maya_adaptor/MayaClient/render_handlers/arnold_handler.py) after the width and height of the image are confirmed. After making changes, [rebuild the wheels](https://github.com/aws-deadline/deadline-cloud-for-maya/blob/mainline/DEVELOPMENT.md#application-interface-adaptor-development-workflow) for the package. 
+
+```
+numXTiles = data.get("numXTiles")
+numYTiles = data.get("numYTiles")
+
+# Check if this is a tile rendering job (numXTiles and numYTiles are specified as job parameters)
+if (numXTiles is not None) and (numYTiles is not None):
+
+    # Check that numXTiles and numYTiles are integers
+    if (not isinstance(numXTiles, int)) or (not isinstance(numYTiles, int)):
+        raise RuntimeError(
+            "numXTiles and numYTiles variables from run-data must be integers"
+        )
+
+    # Tile num uses 1 based indexing. First tile (top left) is x=1, y=1
+    tileNumX = data.get("tileNumX")
+    tileNumY = data.get("tileNumY")
+    
+    # Check that tileNumX and tileNumY are integers
+    if (not isinstance(tileNumX, int)) or (not isinstance(tileNumY, int)):
+        raise RuntimeError("tileNumX and tileNumY variables from run-data must be integers")
+
+    deltaX, widthRemainder = divmod(self.render_kwargs["width"], numXTiles)
+    deltaY, heightRemainder = divmod(self.render_kwargs["height"], numYTiles)
+
+    # Calculate the border values for the tile
+    # -1 from tilenums for minimums to get the end of the previous tile or 0. This is not done for max values as the max values need to reference the start of the next tile
+    # -1 from max values because Maya uses inclusive ranges and 0 based indexing for coordinates
+    # minX = left, maxX = right, minY = top, maxY = bottom
+    minX = deltaX * (tileNumX - 1)
+    maxX = (deltaX * tileNumX) - 1
+    minY = deltaY * (tileNumY - 1)
+    maxY = (deltaY * tileNumY) - 1
+
+    # Add any remainder to the last row and column
+    if tileNumX == numXTiles:
+        maxX += widthRemainder
+    if tileNumY == numYTiles:
+        maxY += heightRemainder
+
+    # Set the border ranges for the tile (left, right, top, bottom)
+    maya.cmds.setAttr("defaultArnoldRenderOptions.regionMinX", minX)
+    maya.cmds.setAttr("defaultArnoldRenderOptions.regionMaxX", maxX)
+    maya.cmds.setAttr("defaultArnoldRenderOptions.regionMinY", minY)
+    maya.cmds.setAttr("defaultArnoldRenderOptions.regionMaxY", maxY)
+    print(f"minX={minX}, maxX={maxX}, minY={minY}, maxY={maxY}")
+
+    prefix = data.get("output_file_prefix")
+
+    # Set an ffmpeg glob pattern type compatible prefix for the tile (_tile_<y-coord>x<x_coord>_<numYtiles>x<numXtiles>_<prefix>) where x-coord and y-coord use 1-based indexing
+    # This command takes inputs in sequential order and assembles them from left to right, top to down which is why the Y value needs to be first
+    maya.cmds.setAttr(
+        "defaultRenderGlobals.imageFilePrefix",
+        f"_tile_{tileNumY}x{tileNumX}_{numYTiles}x{numXTiles}_{prefix}",
+        type="string"
+    )
+
+    print(f'Output file name: {maya.cmds.getAttr("defaultRenderGlobals.imageFilePrefix")}')
+```

--- a/job_bundles/tile_render_maya_ffmpeg/template.yaml
+++ b/job_bundles/tile_render_maya_ffmpeg/template.yaml
@@ -263,7 +263,7 @@ steps:
           mode: NOTIFY_THEN_TERMINATE
 - name: tile assembly
   dependencies:
-  - dependsOn: masterLayer tile render
+  - dependsOn: tile render
   script:
     actions:
       onRun:

--- a/job_bundles/tile_render_maya_ffmpeg/template.yaml
+++ b/job_bundles/tile_render_maya_ffmpeg/template.yaml
@@ -1,0 +1,329 @@
+specificationVersion: jobtemplate-2023-09
+name: tile render maya ffmpeg
+parameterDefinitions:
+- name: MayaSceneFile
+  type: PATH
+  objectType: FILE
+  dataFlow: IN
+  userInterface:
+    control: CHOOSE_INPUT_FILE
+    label: Maya Scene File
+    groupLabel: Maya Settings
+    fileFilters:
+    - label: Maya Scene Files
+      patterns:
+      - '*.mb'
+      - '*.ma'
+    - label: All Files
+      patterns:
+      - '*'
+  description: The Maya scene file to render.
+- name: Frames
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Frames
+    groupLabel: Maya Settings
+  description: The frames to render. E.g. 1-3,8,11-15
+  minLength: 1
+- name: ProjectPath
+  type: PATH
+  objectType: DIRECTORY
+  dataFlow: NONE
+  userInterface:
+    control: CHOOSE_DIRECTORY
+    label: Project Path
+    groupLabel: Maya Settings
+  description: The Maya project path.
+- name: OutputFilePath
+  type: PATH
+  objectType: DIRECTORY
+  dataFlow: OUT
+  userInterface:
+    control: CHOOSE_DIRECTORY
+    label: Output File Path
+    groupLabel: Maya Settings
+  description: The render output path.
+- name: RenderSetupIncludeLights
+  type: STRING
+  userInterface:
+    control: CHECK_BOX
+    label: Include All Lights
+    groupLabel: Maya Settings
+  description: Include all lights in the render.
+  default: 'true'
+  allowedValues:
+  - 'true'
+  - 'false'
+- name: StrictErrorChecking
+  type: STRING
+  userInterface:
+    control: CHECK_BOX
+    label: Strict Error Checking
+    groupLabel: Maya Settings
+  description: Fail when errors occur.
+  default: 'false'
+  allowedValues:
+  - 'true'
+  - 'false'
+- name: OutputFilePrefix
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Output File Prefix
+    groupLabel: Maya Settings
+  description: The output filename prefix.
+- name: ImageWidth
+  type: INT
+  userInterface:
+    control: SPIN_BOX
+    label: Image Width
+    groupLabel: Maya Settings
+  minValue: 1
+  description: The image width of the output.
+- name: ImageHeight
+  type: INT
+  userInterface:
+    control: SPIN_BOX
+    label: Image Height
+    groupLabel: Maya Settings
+  minValue: 1
+  description: The image height of the output.
+- name: NumXTiles
+  type: INT
+  userInterface:
+    control: SPIN_BOX
+    label: Tiles across width
+    groupLabel: Tile Rendering Settings
+  minValue: 1
+  description: The number of tiles across the x axis.
+- name: NumYTiles
+  type: INT
+  userInterface:
+    control: SPIN_BOX
+    label: Tiles across height
+    groupLabel: Tile Rendering Settings
+  minValue: 1
+  description: The number of tiles across the y axis.
+- name: ArnoldErrorOnLicenseFailure
+  type: STRING
+  userInterface:
+    control: CHECK_BOX
+    label: Error on License Failure
+    groupLabel: Arnold Renderer Settings
+  description: Whether to produce an error when there is an Arnold license failure.
+  default: 'false'
+  allowedValues:
+  - 'true'
+  - 'false'
+- name: OverrideAdaptorWheels
+  type: PATH
+  objectType: DIRECTORY
+  dataFlow: IN
+  userInterface:
+    control: CHOOSE_DIRECTORY
+    label: Wheels directory
+    groupLabel: Override settings
+  description: A directory that contains wheels for openjd, deadline, and the overridden
+    adaptor.
+- name: OverrideAdaptorName
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Adaptor Name
+    groupLabel: Override settings
+  description: The name of the adaptor to override, for example NukeAdaptor or MayaAdaptor.
+  default: MayaAdaptor
+steps:
+- name: masterLayer tile render
+  parameterSpace:
+    taskParameterDefinitions:
+    - name: Frame
+      type: INT
+      range: '{{Param.Frames}}'
+    - name: Camera
+      type: STRING
+      range:
+      - RenderCam
+    - name: TileNumberX
+      type: INT
+      range: '1-{{Param.NumXTiles}}'
+    - name: TileNumberY
+      type: INT
+      range: '1-{{Param.NumYTiles}}'
+  stepEnvironments:
+  - name: Maya
+    description: Runs Maya in the background.
+    script:
+      embeddedFiles:
+      - name: initData
+        filename: init-data.yaml
+        type: TEXT
+        data: |
+          renderer: arnold
+          render_layer: masterLayer
+          scene_file: '{{Param.MayaSceneFile}}'
+          project_path: '{{Param.ProjectPath}}'
+          output_file_path: '{{Param.OutputFilePath}}'
+          render_setup_include_lights: {{Param.RenderSetupIncludeLights}}
+          strict_error_checking: {{Param.StrictErrorChecking}}
+          output_file_prefix: '{{Param.OutputFilePrefix}}'
+          image_width: {{Param.ImageWidth}}
+          image_height: {{Param.ImageHeight}}
+          error_on_arnold_license_fail: {{Param.ArnoldErrorOnLicenseFailure}}
+      actions:
+        onEnter:
+          command: MayaAdaptor
+          args:
+          - daemon
+          - start
+          - --path-mapping-rules
+          - file://{{Session.PathMappingRulesFile}}
+          - --connection-file
+          - '{{Session.WorkingDirectory}}/connection.json'
+          - --init-data
+          - file://{{Env.File.initData}}
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+        onExit:
+          command: MayaAdaptor
+          args:
+          - daemon
+          - stop
+          - --connection-file
+          - '{{ Session.WorkingDirectory }}/connection.json'
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+  script:
+    embeddedFiles:
+    - name: runData
+      filename: run-data.yaml
+      type: TEXT
+      data: |
+        frame: {{Task.Param.Frame}}
+        camera: '{{Task.Param.Camera}}'
+        numXTiles: {{Param.NumXTiles}}
+        numYTiles: {{Param.NumYTiles}}
+        tileNumX: {{Task.Param.TileNumberX}}
+        tileNumY: {{Task.Param.TileNumberY}}
+        output_file_prefix: '{{Param.OutputFilePrefix}}'
+    actions:
+      onRun:
+        command: MayaAdaptor
+        args:
+        - daemon
+        - run
+        - --connection-file
+        - '{{ Session.WorkingDirectory }}/connection.json'
+        - --run-data
+        - file://{{ Task.File.runData }}
+        cancelation:
+          mode: NOTIFY_THEN_TERMINATE
+- name: ffmpeg tile assembly
+  dependencies:
+  - dependsOn: masterLayer tile render
+  script:
+    actions:
+      onRun:
+        command: bash
+        args: [ "{{Task.File.Encode}}"]
+    embeddedFiles:
+    - name: Encode
+      type: TEXT
+      runnable: True
+      data: |
+        #!/bin/env bash
+
+        set -xeuo pipefail
+
+        # ASSUMPTION: output folder will either contain tiles, or folders with tiles, never both. Does not account for nested subdirectories.
+
+        has_subdirs=true
+
+        # If there are sub-directories in the output path, iterate over each item in the output file path directory and call ffmpeg for the sub-directory
+        for item in "{{Param.OutputFilePath}}"/*; do
+          # Check if the item is a directory
+          if [ -d "$item" ]; then
+            ffmpeg -y -pattern_type glob -i "/$item/*.png" -filter_complex tile={{Param.NumXTiles}}x{{Param.NumYTiles}}  "/$item/output.png"
+          else
+            has_subdirs=false
+            break
+          fi
+        done
+
+        if [ "$has_subdirs" = false ]; then
+          ffmpeg -y -pattern_type glob -i "{{Param.OutputFilePath}}/*.png" -filter_complex tile={{Param.NumXTiles}}x{{Param.NumYTiles}}  "{{Param.OutputFilePath}}/output.png"
+        fi
+jobEnvironments:
+- name: OverrideAdaptor
+  description: |
+    Replaces the default Adaptor in the environment's PATH with one from the packages in the OverrideAdaptorWheels attached directory.
+  script:
+    actions:
+      onEnter:
+        command: '{{Env.File.Enter}}'
+    embeddedFiles:
+    - name: Enter
+      filename: override-adaptor-enter.sh
+      type: TEXT
+      runnable: true
+      data: |
+        #!/bin/env bash
+
+        set -euo pipefail
+
+        echo "The adaptor wheels that are attached to the job:"
+        ls '{{Param.OverrideAdaptorWheels}}'
+        echo ""
+
+        # Create a venv and activate it in this environment
+        echo "Creating Python venv for the {{Param.OverrideAdaptorName}} command"
+        /usr/local/bin/python3 -m venv '{{Session.WorkingDirectory}}/venv'
+        {{Env.File.InitialVars}}
+        . '{{Session.WorkingDirectory}}/venv/bin/activate'
+        {{Env.File.CaptureVars}}
+        echo ""
+
+        echo "Installing adaptor into the venv"
+        pip install '{{Param.OverrideAdaptorWheels}}'/openjd*.whl
+        pip install '{{Param.OverrideAdaptorWheels}}'/deadline*.whl
+        echo ""
+
+        if [ ! -f '{{Session.WorkingDirectory}}/venv/bin/{{Param.OverrideAdaptorName}}' ]; then
+          echo "The Override Adaptor {{Param.OverrideAdaptorName}} was not installed as expected."
+          exit 1
+        fi
+    - name: InitialVars
+      filename: initial-vars
+      type: TEXT
+      runnable: true
+      data: |
+        #!/usr/bin/env python3
+        import os, json
+        envfile = "{{Session.WorkingDirectory}}/.envInitial"
+        with open(envfile, "w", encoding="utf8") as f:
+            json.dump(dict(os.environ), f)
+    - name: CaptureVars
+      filename: capture-vars
+      type: TEXT
+      runnable: true
+      data: |
+        #!/usr/bin/env python3
+        import os, json, sys
+        envfile = "{{Session.WorkingDirectory}}/.envInitial"
+        if os.path.isfile(envfile):
+            with open(envfile, "r", encoding="utf8") as f:
+                before = json.load(f)
+        else:
+            print("No initial environment found, must run Env.File.CaptureVars script first")
+            sys.exit(1)
+        after = dict(os.environ)
+
+        put = {k: v for k, v in after.items() if v != before.get(k)}
+        delete = {k for k in before if k not in after}
+
+        for k, v in put.items():
+            print(f"updating {k}={v}")
+            print(f"openjd_env: {k}={v}")
+        for k in delete:
+            print(f"openjd_unset_env: {k}")

--- a/job_bundles/tile_render_maya_ffmpeg/template.yaml
+++ b/job_bundles/tile_render_maya_ffmpeg/template.yaml
@@ -17,6 +17,12 @@ description: |
 
   1. Render the images as tiles using the modified Arnold render handler.
   2. Uses ffmpeg to assemble the tiles into the whole image.
+
+  Next steps:
+  This job bundle could handle the tile rendering calculations that currently need to be added
+  to the Maya adaptor in the render step, leaving the Maya adaptor to simply handle region rendering.
+  Refer to https://github.com/mwiebe/deadline-cloud-samples/commit/ca4fa1162f504c92798536e1931b6b1c6df90285
+  for sample changes to this template.
 parameterDefinitions:
 
 # Render Parameters

--- a/job_bundles/tile_render_maya_ffmpeg/template.yaml
+++ b/job_bundles/tile_render_maya_ffmpeg/template.yaml
@@ -1,6 +1,25 @@
 specificationVersion: jobtemplate-2023-09
-name: tile render maya ffmpeg
+name: Maya Tiled Render
+description: |
+  This job uses Maya, Arnold for Maya and ffmpeg to do tile rendering and assembly.
+  Tile rendering divides an image into evenly sized regions, and assembly stiches the tiles
+  back together. 
+  
+  As of 07/2024, this example requires modifications to the arnold render handler in the 
+  Deadline Cloud Maya Adaptor to successfully run. It also requires Linux render workers to
+  execute the assembly step as it is a bash script.
+
+  It uses two conda channels to get software. Maya and Arnold is acquired from the
+  deadline-cloud channel accessible from Deadline Cloud service-managed fleets, and FFmpeg
+  is from the conda-forge community channel.
+
+  This job bundle has 2 steps:
+
+  1. Render the images as tiles using the modified Arnold render handler.
+  2. Uses ffmpeg to assemble the tiles into the whole image.
 parameterDefinitions:
+
+# Render Parameters
 - name: MayaSceneFile
   type: PATH
   objectType: FILE
@@ -27,6 +46,14 @@ parameterDefinitions:
   description: The frames to render. E.g. 1-3,8,11-15
   default: '1'
   minLength: 1
+- name: RenderLayer
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Render Layer
+    groupLabel: Maya Settings
+  description: The name of the layer to render.
+  default: 'masterLayer'
 - name: ProjectPath
   type: PATH
   objectType: DIRECTORY
@@ -91,6 +118,8 @@ parameterDefinitions:
     groupLabel: Maya Settings
   minValue: 1
   description: The image height of the output.
+
+# Tile Render Parameters
 - name: NumXTiles
   type: INT
   userInterface:
@@ -107,6 +136,8 @@ parameterDefinitions:
     groupLabel: Tile Rendering Settings
   minValue: 1
   description: The number of tiles across the y axis.
+
+# Arnold Renderer Settings
 - name: ArnoldErrorOnLicenseFailure
   type: STRING
   userInterface:
@@ -118,6 +149,8 @@ parameterDefinitions:
   allowedValues:
   - 'true'
   - 'false'
+
+# Override Parameters
 - name: OverrideAdaptorWheels
   type: PATH
   objectType: DIRECTORY
@@ -135,7 +168,8 @@ parameterDefinitions:
     label: Adaptor Name
     groupLabel: Override settings
   description: The name of the adaptor to override, for example NukeAdaptor or MayaAdaptor.
-  default: MayaAdaptor
+  default: maya-openjd
+
 steps:
 - name: masterLayer tile render
   parameterSpace:
@@ -163,7 +197,7 @@ steps:
         type: TEXT
         data: |
           renderer: arnold
-          render_layer: masterLayer
+          render_layer: '{{Param.RenderLayer}}'
           scene_file: '{{Param.MayaSceneFile}}'
           project_path: '{{Param.ProjectPath}}'
           output_file_path: '{{Param.OutputFilePath}}'
@@ -175,7 +209,7 @@ steps:
           error_on_arnold_license_fail: {{Param.ArnoldErrorOnLicenseFailure}}
       actions:
         onEnter:
-          command: MayaAdaptor
+          command: maya-openjd
           args:
           - daemon
           - start
@@ -188,7 +222,7 @@ steps:
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
         onExit:
-          command: MayaAdaptor
+          command: maya-openjd
           args:
           - daemon
           - stop
@@ -211,7 +245,7 @@ steps:
         output_file_prefix: '{{Param.OutputFilePrefix}}'
     actions:
       onRun:
-        command: MayaAdaptor
+        command: maya-openjd
         args:
         - daemon
         - run
@@ -238,15 +272,29 @@ steps:
 
         set -xeuo pipefail
 
-        # ASSUMPTION: output folder will either contain tiles, or folders with tiles, never both. Does not account for nested subdirectories.
+        # ASSUMPTIONS: 
+        # Output folder will either contain tiles, or folders with tiles, never both.
+        # No nested subdirectories (max one layer of subdirectories).
+        # Tiles are in correct sequential order given assembly goes left-right from top-bottom.
+        # Either the name.#.ext or name.ext Maya "Frame/Animation ext" render setting is used.
+        # Output tiles are pngs. Swap png with the desired file ext in the script as needed.
 
         has_subdirs=true
-
+        FRAMES={{Param.Frames}}
+        startFrame=${FRAMES%-*}
+        endFrame=${FRAMES#*-}
+        
         # If there are sub-directories in the output path, iterate over each item in the output file path directory and call ffmpeg for the sub-directory
         for item in "{{Param.OutputFilePath}}"/*; do
           # Check if the item is a directory
           if [ -d "$item" ]; then
-            ffmpeg -y -pattern_type glob -i "/$item/*.png" -filter_complex tile={{Param.NumXTiles}}x{{Param.NumYTiles}}  "/$item/output.png"
+            if [[ "$startFrame" == "$endFrame" ]]; then
+              ffmpeg -y -pattern_type glob -i "/$item/*.png" -filter_complex tile={{Param.NumXTiles}}x{{Param.NumYTiles}}  "/$item/output.png"
+            else
+              for frame in $(seq "$startFrame" "$endFrame"); do
+                ffmpeg -y -pattern_type glob -i "/$item/*$frame.png" -filter_complex tile={{Param.NumXTiles}}x{{Param.NumYTiles}}  "/$item/output.$frame.png"
+              done
+            fi
           else
             has_subdirs=false
             break
@@ -254,7 +302,13 @@ steps:
         done
 
         if [ "$has_subdirs" = false ]; then
-          ffmpeg -y -pattern_type glob -i "{{Param.OutputFilePath}}/*.png" -filter_complex tile={{Param.NumXTiles}}x{{Param.NumYTiles}}  "{{Param.OutputFilePath}}/output.png"
+          if [[ "$startFrame" == "$endFrame" ]]; then
+              ffmpeg -y -pattern_type glob -i "{{Param.OutputFilePath}}/*.png" -filter_complex tile={{Param.NumXTiles}}x{{Param.NumYTiles}}  "{{Param.OutputFilePath}}/output.png"
+          else
+            for frame in $(seq "$startFrame" "$endFrame"); do
+              ffmpeg -y -pattern_type glob -i "{{Param.OutputFilePath}}/*$frame.png" -filter_complex tile={{Param.NumXTiles}}x{{Param.NumYTiles}}  "{{Param.OutputFilePath}}/output.$frame.png"
+            done
+          fi
         fi
 jobEnvironments:
 - name: OverrideAdaptor

--- a/job_bundles/tile_render_maya_ffmpeg/template.yaml
+++ b/job_bundles/tile_render_maya_ffmpeg/template.yaml
@@ -177,7 +177,7 @@ parameterDefinitions:
   default: maya-openjd
 
 steps:
-- name: masterLayer tile render
+- name: tile render
   parameterSpace:
     taskParameterDefinitions:
     - name: Frame
@@ -261,7 +261,7 @@ steps:
         - file://{{ Task.File.runData }}
         cancelation:
           mode: NOTIFY_THEN_TERMINATE
-- name: ffmpeg tile assembly
+- name: tile assembly
   dependencies:
   - dependsOn: masterLayer tile render
   script:

--- a/job_bundles/tile_render_maya_ffmpeg/template.yaml
+++ b/job_bundles/tile_render_maya_ffmpeg/template.yaml
@@ -25,6 +25,7 @@ parameterDefinitions:
     label: Frames
     groupLabel: Maya Settings
   description: The frames to render. E.g. 1-3,8,11-15
+  default: '1'
   minLength: 1
 - name: ProjectPath
   type: PATH
@@ -73,6 +74,7 @@ parameterDefinitions:
     label: Output File Prefix
     groupLabel: Maya Settings
   description: The output filename prefix.
+  default: '<Scene>'
 - name: ImageWidth
   type: INT
   userInterface:


### PR DESCRIPTION
### Description

This job template is designed to submit a simple one frame tile rendering job using Maya, Arnold, and ffmpeg. This job bundle would be used with a modified Maya Arnold render handler, as specified in this [fork of the deadline-cloud-for-maya repository](https://github.com/alichiba/deadline-cloud-for-maya). It uses a bash script to call ffmpeg which requires Linux workers and access to the ffmpeg command from the workers. 

This template uses job parameter values (NumXTiles and NumYTiles) to specify the number of tiles which is used to define task parameter values (TileNumberX and TileNumberY) for the tile numbers, and is added to the runData for the Maya render step. A second step is defined to have a dependency on the render step, which uses a bash script to call ffmpeg to assemble the tiles. As stated in the comment in the bash script, the script only works with up to one layer of subdirectories and also assumes that the tiles in each folder are only for one frame, and are in the correct sequential order. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.