### PR TITLE
fix: A failing edge case in the caching conda queue env

### DIFF
--- a/queue_environments/conda_queue_env_improved_caching.yaml
+++ b/queue_environments/conda_queue_env_improved_caching.yaml
@@ -181,6 +181,9 @@ environment:
         elif [ -n "$NAMED_CONDA_ENV" ]; then
             echo "Named Conda environment $NAMED_CONDA_ENV not found, creating it."
 
+            # Make sure there's no incomplete environment hanging around
+            conda remove --yes --name "$NAMED_CONDA_ENV" --all
+
             # Create the virtual environment
             conda create --yes \
                 --name "$NAMED_CONDA_ENV" \


### PR DESCRIPTION
### Description

In testing, found an edge case in the conda_queue_env_improved_caching.yaml queue environment.

Under some circumstances involving repeatedly canceling and retrying jobs, the environment creation for this queue environment fails. This happens when the conda virtual environment is not complete, so doesn't show up in the `conda env list` output but the directory for it exists anyway.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.