### PR TITLE
fix: include bzip2 packages when reindexing

### DIFF
--- a/conda_recipes/conda_build_linux_package/scripts/reindex-conda-channel.sh
+++ b/conda_recipes/conda_build_linux_package/scripts/reindex-conda-channel.sh
@@ -63,7 +63,7 @@ for CHANNEL_DIR in $CHANNEL_DIRS; do
         echo "Found $(basename $CHANNEL_DIR) in the channel"
         mkdir -p $CHANNEL_INDEXING_DIR/$(basename $CHANNEL_DIR)
         for PACKAGE in $(cd $CHANNEL_DIR; \
-                        shopt -s nullglob; echo *.conda); do
+                        shopt -s nullglob; echo *.conda *.tar.bz2); do
             ln -r -s $CHANNEL_DIR/$PACKAGE \
                 $CHANNEL_INDEXING_DIR/$(basename $CHANNEL_DIR)/$PACKAGE
         done


### PR DESCRIPTION
Fixes: Reindex Conda channel job will not include bzip2 packages

### What was the problem/requirement? (What/Why)
Packages in the tar.bz2 format will not be included in the rebuild index

### What was the solution? (How)
Include *.tar.bz2 in the wildcard glob

### What is the impact of this change?
Full catalog of conda packages will be indexed

### How was this change tested?
1. repodata.json includes tar.bz2 packages
2. reindex job eliminates tar.bz2 packages
3. repodata.json reinstated and includes tar.bz2 packages
4. this change applied
5. reindex job properly indexes tar.bz2 packages

### Was this change documented?
Not applicable

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*