### PR TITLE
fix: allow patches to get processed by index job

### DIFF
--- a/conda_recipes/conda_build_linux_package/scripts/reindex-conda-channel.sh
+++ b/conda_recipes/conda_build_linux_package/scripts/reindex-conda-channel.sh
@@ -71,6 +71,9 @@ for CHANNEL_DIR in $CHANNEL_DIRS; do
             mkdir -p "$CHANNEL_INDEXING_DIR/$(basename $CHANNEL_DIR)/.cache"
             cp "$CHANNEL_DIR/.cache/cache.db" "$CHANNEL_INDEXING_DIR/$(basename $CHANNEL_DIR)/.cache/"
         fi
+        if [ -f "$CHANNEL_DIR/patch_instructions.json" ]; then
+            cp "$CHANNEL_DIR/patch_instructions.json" "$CHANNEL_INDEXING_DIR/$(basename $CHANNEL_DIR)/"
+        fi
     fi
 done
 


### PR DESCRIPTION
Fixes:  Patch instructions not carried out

### What was the problem/requirement? (What/Why)
Packages are copied out of S3 to run conda reindex command.  Package patching metadata was left behind

### What was the solution? (How)
Copy over metadata patching instructions when cloning S3 directories

### What is the impact of this change?
Patching instructions are typically small, should be insignificant.  Compression can be applied if this is a problem

### How was this change tested?
1. Inspect repodata.json, notice some package dependency is incorrect.
2. Upload patch_instructions.json metadata to replace package dependency data.
3. Execute this modified deadline ReindexCondaChannel task
4. Inspect new repodata.json, find same package dependencies have been patched.

- If this is a sample, then please describe the steps that you took to test it.
- Include output from your testing to demonstrate it working as expected if possible.

### Was this change documented?
Not applicable

- For instance, if applicable, has the sample's description been updated?

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*