### PR TITLE
update after effect job bundle

### DIFF
--- a/job_bundles/afterfx_render_one_task/README.md
+++ b/job_bundles/afterfx_render_one_task/README.md
@@ -3,19 +3,23 @@
 ## Use case for this job
 
 This is an After Effects job bundle that allows the user
-to submit a job that uses aerender to render a frame range
+to submit a job that uses the executable file aerender.exe to render a frame range
 as a single task. This means the entire workload will render
 on one worker.
 
 It accepts the following job parameters that modify the render:
+
 * Project file
 * Comp name
 * Input directory
 * Output directory
+* Output file
 * Start frame
 * End frame
 
 This job bundle expects a user to specify an input directory that
 contains all the file references that are required to render.
 Generally, the project file should be within this directory to
-ensure relative paths are preserved.
+ensure relative paths are preserved. 
+
+Note: If you are going to run this job on a Windows worker, you'll need bash available. git-bash is one way to get it.

--- a/job_bundles/afterfx_render_one_task/template.yaml
+++ b/job_bundles/afterfx_render_one_task/template.yaml
@@ -50,7 +50,16 @@ parameterDefinitions:
     control: CHOOSE_DIRECTORY
     label: Output directory
     groupLabel: Inputs/outputs
+  default: "./output"
   description: The render output directory
+- name: OutputFile
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Output File
+    groupLabel: Inputs/outputs
+  default: "output.mp4"
+  description: Enter the output filename. Ensure the file extension is the same in the Comp Setting
 - name: StartFrame
   type: INT
   userInterface:
@@ -73,15 +82,13 @@ steps:
   script:
     actions:
       onRun:
-        command: aerender
-        args:
-        - "-project"
-        - "{{Param.ProjectFile}}"
-        - "-comp"
-        - "{{Param.CompName}}"
-        - "-output"
-        - "{{Param.OutputDirectory}}"
-        - "-s"
-        - "{{Param.StartFrame}}"
-        - "-e"
-        - "{{Param.EndFrame}}"
+        command: bash
+        args: ['{{Task.File.Run}}']
+    embeddedFiles:
+    - name: Run
+      type: TEXT
+      data: |
+        mkdir -p '{{Param.OutputDirectory}}'
+
+        aerender -project '{{Param.ProjectFile}}' -comp '{{Param.CompName}}' \
+        -output '{{Param.OutputDirectory}}\{{Param.OutputFile}}' -s {{Param.StartFrame}} -e {{Param.EndFrame}}


### PR DESCRIPTION
Fixes: *<insert link to GitHub issue here>*

### What was the problem/requirement? (What/Why)
After effects output param accepts the final output file path but current job passed in the output dir.

### What was the solution? (How)
1. Added output file name param.
2. Updated aerender cmd
3. Updated README

### What is the impact of this change?
Customers should be able to submit an AE job by this job template
### How was this change tested?
Submit this job to Windows Service Managed Fleet with a custom conda channel with AE conda package and get the right output.

### Was this change documented?
Updated the README.md

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*