### PR TITLE
fix: ripgrep changed executable location

### DIFF
--- a/conda_recipes/conda_build_linux_package/scripts/enter-conda-build-env.sh
+++ b/conda_recipes/conda_build_linux_package/scripts/enter-conda-build-env.sh
@@ -94,6 +94,7 @@ if [[ "$(uname -s)" == MINGW* ]]; then
     # See https://github.com/conda/conda-build/issues/4357
     #   FileNotFoundError: [WinError 206] The filename or extension is too long
     rm -f $CONDA_PREFIX/bin/rg.exe || true
+    rm -f $CONDA_PREFIX/Library/bin/rg.exe || true
 fi
 
 # Create a .condarc to control the package build settings


### PR DESCRIPTION
Fixes: ripgrep > v.11 moves .exe location, reintroduces WinError 206 (The filename or extension is too long)

### What was the problem/requirement? (What/Why)
My dependency tree now pulls in ripgrep 14 which has the rg.exe in a different location, breaking existing build

### What was the solution? (How)
This just adds another location for removing rg.exe

### What is the impact of this change?
Original location was left in, in case of existing builds

### How was this change tested?
1. Previously successful recipe now gives FileNotFoundError: [WinError 206] The filename or extension is too long
2. Add this new location in the removal of rg.exe
3. Conda builds package successfully

- If this is a sample, then please describe the steps that you took to test it.
- Include output from your testing to demonstrate it working as expected if possible.

### Was this change documented?
Not applicable

- For instance, if applicable, has the sample's description been updated?

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*