### PR TITLE
feat: Add Cinema4D OpenJD adaptor recipe.

### DIFF
--- a/conda_recipes/cinema4d-openjd/deadline-cloud.yaml
+++ b/conda_recipes/cinema4d-openjd/deadline-cloud.yaml
@@ -1,0 +1,32 @@
+condaPlatforms:
+  - platform: linux-64
+    variant: py311
+    defaultSubmit: true
+    variantConfig:
+      python:
+      - 3.11
+    buildTool: rattler-build
+  - platform: linux-64
+    variant: py312
+    defaultSubmit: true
+    variantConfig:
+      python:
+      - 3.12
+    buildTool: rattler-build
+  - platform: win-64
+    variant: py311
+    defaultSubmit: true
+    variantConfig:
+      python:
+      - 3.11
+    buildTool: conda-build
+  - platform: win-64
+    variant: py312
+    defaultSubmit: true
+    variantConfig:
+      python:
+      - 3.12
+    buildTool: conda-build
+jobParameters:
+- name: CondaChannels
+  value: conda-forge

--- a/conda_recipes/cinema4d-openjd/recipe/0001-Remove-version-hook.patch
+++ b/conda_recipes/cinema4d-openjd/recipe/0001-Remove-version-hook.patch
@@ -1,0 +1,42 @@
+From 5e9dc19635af507c60aad76834af68fde0f483b5 Mon Sep 17 00:00:00 2001
+From: Karthik Bekal Pattathana
+ <133984042+karthikbekalp@users.noreply.github.com>
+Date: Wed, 6 Nov 2024 10:52:46 -0600
+Subject: [PATCH] patched
+
+---
+ pyproject.toml | 18 ------------------
+ 1 file changed, 18 deletions(-)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index babdae5..1ea9453 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -46,24 +46,6 @@ artifacts = [
+   "*_version.py",
+ ]
+ 
+-[tool.hatch.version]
+-source = "vcs"
+-
+-[tool.hatch.version.raw-options]
+-version_scheme = "post-release"
+-
+-[tool.hatch.build.hooks.vcs]
+-version-file = "_version.py"
+-
+-[tool.hatch.build.hooks.custom]
+-path = "hatch_custom_hook.py"
+-
+-[tool.hatch.build.hooks.custom.copy_version_py]
+-destinations = [
+-  "src/deadline/cinema4d_adaptor",
+-  "src/deadline/cinema4d_submitter",
+-]
+-
+ [tool.hatch.build.targets.sdist]
+ include = [
+     "src/*",
+-- 
+2.47.0.windows.2
+

--- a/conda_recipes/cinema4d-openjd/recipe/meta.yaml
+++ b/conda_recipes/cinema4d-openjd/recipe/meta.yaml
@@ -1,0 +1,61 @@
+# Before building this recipe, build the conda 
+# packages for "deadline" and "openjd-adaptor-runtime" dependencies. 
+# Find these recipes for building the packages at : 
+# https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/conda_recipes
+
+{% set name = "cinema4d-openjd" %}
+{% set version = "0.4.1" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/d/deadline-cloud-for-cinema-4d/deadline_cloud_for_cinema_4d-{{ version }}.tar.gz
+  sha256: 0404af9f6740a9778ced6f698c096ef52f6e8a0a73f975c4520727578a3dfabb
+  patches:
+    - 0001-Remove-version-hook.patch
+
+# Here's an alternative source definition to build a package from a development branch on github. Replace
+# the username and git branch as appropriate for your case.
+# source:
+#   git_url: https://github.com/aws-deadline/deadline-cloud-for-cinema-4d.git
+#   git_rev: region-render
+
+build:
+  entry_points:
+    - cinema4d-openjd = deadline.cinema4d_adaptor.Cinema4DAdaptor:main
+    - Cinema4DAdaptor = deadline.cinema4d_adaptor.Cinema4DAdaptor:main
+  noarch: python
+  script: python -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  build:
+    # For the variant config file in deadline-cloud.yaml to work, python must not specify a version here.
+    - python
+    - hatchling
+    - hatch-vcs
+    - pip
+  run:
+    # For the variant config file in deadline-cloud.yaml to work, python must not specify a version here.
+    - python
+    - deadline ==0.48.*
+    - openjd-adaptor-runtime ==0.8.*
+
+test:
+  imports:
+    - deadline.cinema4d_adaptor
+  commands:
+    - pip check
+    - cinema4d-openjd --help
+  requires:
+    - pip
+
+about:
+  summary: AWS Deadline Cloud for Cinema 4D
+  dev_url: https://github.com/aws-deadline/deadline-cloud-for-cinema-4d
+  license: Apache-2.0
+  license_file:
+    - LICENSE
+    - NOTICE

--- a/conda_recipes/cinema4d-openjd/recipe/recipe.yaml
+++ b/conda_recipes/cinema4d-openjd/recipe/recipe.yaml
@@ -1,0 +1,55 @@
+# Recipe in rattler-build format.
+# See https://prefix-dev.github.io/rattler-build/latest/
+# Before building this recipe, build the conda 
+# packages for "deadline" and "openjd-adaptor-runtime" dependencies. 
+# Find these recipes for building the packages at : 
+# https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/conda_recipes
+
+context:
+  version: "0.4.1"
+
+package:
+  name: cinema4d-openjd
+  version: ${{ version }}
+
+# This source reference uses the source archive published to PyPI
+source:
+  url: https://pypi.io/packages/source/d/deadline-cloud-for-cinema-4d/deadline_cloud_for_cinema_4d-${{ version }}.tar.gz
+  sha256: 0404af9f6740a9778ced6f698c096ef52f6e8a0a73f975c4520727578a3dfabb
+  patches:
+    - 0001-Remove-version-hook.patch
+
+build:
+  number: 0
+  script:
+    - python -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python
+    - hatchling
+    - hatch-vcs
+    - pip
+  run:
+    - python
+    - deadline 0.48.*
+    - openjd-adaptor-runtime 0.8.*
+
+tests:
+- python:
+    imports:
+      - deadline.cinema4d_adaptor
+- requirements:
+    run:
+      - pip
+  script:
+    - pip check
+    - cinema4d-openjd --help
+
+about:
+  summary: AWS Deadline Cloud for Cinema 4D
+  homepage: https://github.com/aws-deadline/deadline-cloud-for-cinema-4d
+  license: Apache-2.0
+  license_file:
+    - LICENSE
+    - NOTICE


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

This PR aims to help customers build their own Cinema 4D OpenJD Conda packages. 

### What was the solution? (How)

Followed the examples of an existing recipe for Maya for Cinema4D. https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/conda_recipes/maya-openjd

### What is the impact of this change?

Currently Deadline Cloud does not provide customers with Conda packages for Cinema 4D. By providing the Conda recipes, customers can build their own packages and use it. This can simplify the setup for our customers. 

### How was this change tested?

To test this, I submitted the Conda recipe and built it in Deadline Cloud following a similar approach as described in https://aws.amazon.com/blogs/media/create-a-conda-package-and-channel-for-aws-deadline-cloud/ and I was able to get the renders for Cinema4D. 

I tested this locally using a Windows service managed fleet setup on DeadlineCloud and I was able to get the renders from Cinema4D. 
![Screenshot 2024-10-28 at 10 15 47 AM](https://github.com/user-attachments/assets/5df67bee-90a2-4707-aa2c-ece07c51e558)
![Screenshot 2024-10-28 at 10 14 22 AM](https://github.com/user-attachments/assets/fd59ae00-bae3-4413-8359-0b9b28536028)




### Was this change documented?

No, there is an upcoming PR for adding Conda recipes for Cinema 4D installer. I'll update the documentation for all of it then. 

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*