### PR TITLE
feat: Email and slack integration integration cloud formation for bud…

### DIFF
--- a/cloudformation/notification_templates/README.md
+++ b/cloudformation/notification_templates/README.md
@@ -1,0 +1,14 @@
+# AWS Deadline Cloud Event Notification Templates
+
+## Introduction
+AWS Deadline Cloud sends events to customer's default event bus https://docs.aws.amazon.com/deadline-cloud/latest/userguide/monitoring-eventbridge.html
+This directory holds sample Cloud Formation Templates customers can use to setup notifications based on events received from Deadline Cloud
+through mechanisms like email or slack.
+
+## Setup Instructions
+Each Cloud Formation Template will have its own instructions on how to set up integrations, but in general they follow the below scheme:
+
+1. Download the specified YAML file
+2. On the AWS console, go to CloudFormation, Create Stack, and add the downloaded template.
+3. Follow the specific instructions for that file, as you may need to enter specific parameters.
+4. After this is set up, Deadline cloud events will reach through your setup mechanism.

--- a/cloudformation/notification_templates/budget_events_notification/README.md
+++ b/cloudformation/notification_templates/budget_events_notification/README.md
@@ -1,0 +1,89 @@
+# Deadline Budget Threshold Reached Event Integration with Email and Slack
+
+This CloudFormation template sets up an integration to receive notifications via email and Slack when a budget threshold is reached in the `aws.deadline` service. It creates an SNS topic, an EventBridge rule, and a Chatbot configuration to send the notifications.
+
+## Resources Created
+
+1. **SNS Topic**: An SNS topic named `DeadlineBudgetsSNSTopic` is created, and an email subscription is added to it using the provided email address.
+2. **SNS Topic Policy**: A policy `DeadlineBudgetsSNSTopicPolicy` is attached to the SNS topic to allow AWS services (like EventBridge) to publish messages to the topic.
+3. **IAM Role**: An IAM role `ChatbotRole` is created, which grants the necessary permissions for the Chatbot service to publish messages using Chatbot
+4. **Chatbot**: A Chatbot `DeadlineBudgetsChatbot` is configured to send notifications to the specified Slack channel. It is subscribed to the SNS topic created earlier.
+5. **EventBridge Rule**: An EventBridge rule `DeadlineBudgetsEventRule` is created to capture events of type `Budget Threshold Reached` from the `aws.deadline` service. When an event matches this rule, it triggers the SNS topic target, which publishes a notification to the topic.
+
+## Prerequisites
+
+Before deploying this CloudFormation template, check you have the following as per your chosen method of notifications:
+
+1. An email address to receive notifications (if setting up email integration).
+2. A Slack channel ID and workspace ID where you want to receive notifications (if setting up Slack integration).
+3. The AWS CLI installed and configured with your AWS credentials (if setting up using CLI option).
+
+##### Optional pre-requisite setup steps for Slack integration:
+If you are setting up notifications to Slack, you need to configure the Slack client with the following steps:
+
+1. Add AWS Chatbot to the Slack workspace:
+
+   a. In Slack, on the left navigation pane, choose Automations.
+   ###### Note: If you do not see Automations in the left navigation pane, choose More, then choose Automations.
+
+   b. If AWS Chatbot is not listed, choose the Browse Apps Directory button.
+   Browse the directory for the AWS Chatbot app and then choose Add to add AWS Chatbot to your workspace.
+
+   c. Next create a slack channel in your workspace.
+   d. Add AWS Chatbot to the channel by typing `/invite` in the channel and clicking on *Add apps to this channel*
+   e. Right click on the channel, click *View channel details*, copy and keep the *Channel ID* at the bottom
+
+2. Open the AWS Chatbot console at https://console.aws.amazon.com/chatbot/.
+
+3. Under Configure a chat client, choose Slack, then choose Configure. After choosing Configure, you'll be redirected to Slack's authorization page to request permission for AWS Chatbot to access your information. For more information, see Chat client application permissions.
+
+4. On the authorization page you can choose to change the Slack workspace that you want to use with AWS Chatbot from the dropdown list at the top right
+   There's no limit to the number of workspaces that you can set up for AWS Chatbot, but you can set up only one at a time.
+
+5. Choose Allow.
+6. Copy and keep the *Workspace ID* from the configured slack client.
+
+## Deployment
+
+You can use either of the below methods for deployment - AWS Console or AWS CLI.
+
+### AWS Console
+
+To deploy this CloudFormation template via the AWS Console, follow these steps:
+
+1. Save the CloudFormation template to a local file (e.g., `/Users/<your-username/Downloads/email_slack_integration_template.yaml`).
+2. Open the AWS CloudFormation console.
+3. Click on "Create Stack" and select "With new resources (standard)".
+4. Under "Specify template", choose "Upload a template file" and select the CloudFormation template file saved from location.
+5. Click "Next".
+6. On the "Specify stack details" page, provide values for the following parameters:
+   - `Email`: Enter the email address where you want to receive notifications (if setting up email integration).
+   - `SlackChannelId`: Enter the ID of the Slack channel where you want to receive notifications (if setting up slack integration).
+   - `SlackWorkspaceId`: Enter the ID of the Slack workspace containing the channel (if setting up slack integration).
+   - `EventRuleSource`: Keep it as is (`aws.deadline`) by default.
+7. Click "Next" through the remaining steps, and finally, click "Create Stack" to deploy the CloudFormation template.
+
+### AWS CLI
+
+To deploy this CloudFormation template using the AWS CLI, follow these steps:
+
+1. Save the CloudFormation template to a local file (e.g., `/Users/<your-username/Downloads/email_slack_integration_template.yaml`).
+2. Open a terminal or command prompt, and navigate to the directory containing the template file.
+3. Run the following AWS CLI command to create the CloudFormation stack:
+
+    ```
+    aws cloudformation create-stack \
+    --stack-name DeadlineNotificationIntegration \
+    --template-body file://email_slack_integration_template.yaml \
+    --parameters \
+    ParameterKey=Email,ParameterValue=your-email@example.com \
+    ParameterKey=SlackChannelId,ParameterValue=your-slack-channel-id \
+    ParameterKey=SlackWorkspaceId,ParameterValue=your-slack-workspace-id
+    ```
+
+   Replace `your-email@example.com`, `your-slack-channel-id`, and `your-slack-workspace-id` with your actual values.
+
+4. Wait for the stack creation to complete. You can monitor the progress using the `aws cloudformation describe-stacks` command.
+5. You might need to check your email inbox to confirm subscription to notifications. The subject would likely be of the form *AWS Notification - Subscription Confirmation*
+
+After successful deployment & confirmation, you should start receiving notifications in the specified email and Slack channel whenever a budget threshold is reached in the `aws.deadline` service.

--- a/cloudformation/notification_templates/budget_events_notification/email_slack_integration_template.yaml
+++ b/cloudformation/notification_templates/budget_events_notification/email_slack_integration_template.yaml
@@ -1,0 +1,171 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Deadline Notification Budget Events Integration with Email and Slack
+
+Parameters:
+  Email:
+    Type: String
+    Default: ''
+    Description: Email address to receive notifications (leave blank to skip email notifications)
+
+  SlackChannelId:
+    Type: String
+    Default: ''
+    Description: Slack channel ID to receive notifications (leave blank to skip Slack notifications)
+
+  SlackWorkspaceId:
+    Type: String
+    Default: ''
+    Description: Slack workspace ID for the channel (leave blank to skip Slack notifications)
+
+  EventRuleSource:
+    Type: String
+    Default: "aws.deadline"
+    Description: Source that events will be coming from
+
+Conditions:
+  SetupEmailNotifications: !Not [!Equals [!Ref Email, '']]
+  SetupSlackNotifications: !And
+    - !Not [!Equals [!Ref SlackChannelId, '']]
+    - !Not [!Equals [!Ref SlackWorkspaceId, '']]
+
+Resources:
+  # SNS Key
+  DeadlineBudgetsSNSKey:
+    Type: AWS::KMS::Key
+    Properties:
+      Description: Custom KMS key for encrypting the Deadline Budgets SNS topic
+      KeyPolicy:
+        Version: '2012-10-17'
+        Id: key-default-policy
+        Statement:
+          - Sid: Enable IAM User Permissions
+            Effect: Allow
+            Principal:
+              AWS: !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:root'
+            Action: 'kms:*'
+            Resource: '*'
+          - Sid: Allow EventBridge to use the key
+            Effect: Allow
+            Principal:
+              Service: events.amazonaws.com
+            Action:
+              - "kms:Decrypt"
+              - "kms:GenerateDataKey"
+            Resource: '*'
+    UpdateReplacePolicy: Retain
+    DeletionPolicy: Retain
+
+
+
+  # SNS Topic
+  DeadlineBudgetsSNSTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: DeadlineBudgetsSNSTopic
+      KmsMasterKeyId: !Ref DeadlineBudgetsSNSKey
+      Subscription:
+        - !If
+          - SetupEmailNotifications
+          - Endpoint: !Ref Email
+            Protocol: email
+          - !Ref AWS::NoValue
+
+  # SNS Topic Policy
+  DeadlineBudgetsSNSTopicPolicy:
+    Type: AWS::SNS::TopicPolicy
+    Properties:
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: "__default_statement_ID"
+            Effect: Allow
+            Principal:
+              AWS: "*"
+            Action:
+              - "SNS:Publish"
+              - "SNS:RemovePermission"
+              - "SNS:SetTopicAttributes"
+              - "SNS:DeleteTopic"
+              - "SNS:ListSubscriptionsByTopic"
+              - "SNS:GetTopicAttributes"
+              - "SNS:AddPermission"
+              - "SNS:Subscribe"
+            Resource: !Ref DeadlineBudgetsSNSTopic
+            Condition:
+              StringEquals:
+                AWS:SourceOwner: !Ref AWS::AccountId
+          - Sid: "__default_statement_ID_2"
+            Effect: Allow
+            Principal:
+              Service: events.amazonaws.com
+            Action: sns:Publish
+            Resource: !Ref DeadlineBudgetsSNSTopic
+      Topics:
+        - !Ref DeadlineBudgetsSNSTopic
+
+  # IAM Role for Chatbot
+  ChatbotRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - chatbot.amazonaws.com
+            Action:
+              - 'sts:AssumeRole'
+
+  # Chatbot
+  ChatbotSlack:
+    Type: AWS::Chatbot::SlackChannelConfiguration
+    Condition: SetupSlackNotifications
+    Properties:
+      ConfigurationName: DeadlineBudgetsChatbot
+      SlackChannelId: !Ref SlackChannelId
+      SlackWorkspaceId: !Ref SlackWorkspaceId
+      IamRoleArn: !GetAtt ChatbotRole.Arn
+      SnsTopicArns:
+        - !Sub 'arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:DeadlineBudgetsSNSTopic'
+
+  # EventBridge Rule
+  DeadlineBudgetsEventRule:
+    Type: AWS::Events::Rule
+    Properties:
+      Description: Rule to capture aws.deadline budget events
+      EventPattern:
+        detail-type:
+          - "Budget Threshold Reached"
+        source:
+          - !Ref EventRuleSource
+        account:
+          - !Ref AWS::AccountId
+      State: ENABLED
+      Targets:
+        - Arn: !Sub 'arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:DeadlineBudgetsSNSTopic'
+          Id: DeadlineBudgetsTopicSNSTarget
+          InputTransformer:
+            InputPathsMap:
+              account: "$.account"
+              budget-id: "$.detail.budgetId"
+              farm-id: "$.detail.farmId"
+              threshold: "$.detail.thresholdInPercent"
+              type: "$.detail-type"
+            InputTemplate: |
+              {
+                "version": "1.0",
+                "source": "custom",
+                "id": "1",
+                "content": {
+                  "title": "Deadline Event: <type>. Budget: <budget-id> reached <threshold>%",
+                  "description": "account: <account>. farm: <farm-id>"
+                }
+              }
+
+Outputs:
+  SNSTopicArn:
+    Description: ARN of the SNS Topic
+    Value: !Ref DeadlineBudgetsSNSTopic
+    Export:
+      Name: DeadlineBudgetsSNSTopicArn


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We've launched Event bridge events for budget thresholds for customers https://docs.aws.amazon.com/deadline-cloud/latest/userguide/budget-threshold-events.html. We need to create a cloudformation template for customers to run on their account to setup consuming these events & sending them as notifications.

### What was the solution? (How)
Publishing a CloudFormation Template sample for sending notifications over email and on slack for [BudgetThresholdReached](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/events-detail-reference.html#event-detail-budget-threshold-reached) events.

### What is the impact of this change?
Customers can use this template directly to setup their accounts for getting events as notifications over email and/or slack.

### How was this change tested?

Tested this on own account as a customer would. Created the stacks using the CloudFormation Template and was able to get the slack and email notifications over configured channels.

```
{
  "version": "1.0",
  "source": "custom",
  "id": "1",
  "content": {
    "title": "Deadline Event: Budget Threshold Reached. Budget: budget-xxxxxxxx reached 100%",
    "description": "account: xxxxxxxx. farm: farm-xxxxxxxxxxx"
  }
}
```

### Was this change documented?
Yes Readme files have been updated as necessary

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*