### PR TITLE
feat: Add support for rattler-build in the sample conda tools

### DIFF
--- a/conda_recipes/blender-4.1/deadline-cloud.yaml
+++ b/conda_recipes/blender-4.1/deadline-cloud.yaml
@@ -3,7 +3,9 @@ condaPlatforms:
     defaultSubmit: true
     sourceArchiveFilename: blender-4.1.1-linux-x64.tar.xz
     sourceDownloadInstructions: 'Run "curl -LO https://download.blender.org/release/Blender4.1/blender-4.1.1-linux-x64.tar.xz"'
+    buildTool: rattler-build
   - platform: win-64
     defaultSubmit: false
     sourceArchiveFilename: blender-4.1.1-windows-x64.zip
     sourceDownloadInstructions: 'Run "curl -LO https://download.blender.org/release/Blender4.1/blender-4.1.1-windows-x64.zip"'
+    buildTool: conda-build

--- a/conda_recipes/blender-4.1/recipe/meta.yaml
+++ b/conda_recipes/blender-4.1/recipe/meta.yaml
@@ -1,3 +1,6 @@
+# Recipe in conda-build format.
+# This recipe is only for Windows, see recipe.yaml for the Linux recipe in rattler-build format.
+
 {% set version = "4.1.1" %}
 {% set major_minor_version = ".".join(version.split(".")[:2]) %}
 
@@ -6,13 +9,12 @@ package:
   version: {{ version }}
 
 source:
-  url: https://download.blender.org/release/Blender{{major_minor_version}}/blender-{{version}}-linux-x64.tar.gz # [linux64]
   url: https://download.blender.org/release/Blender{{major_minor_version}}/blender-{{version}}-windows-x64.zip # [win64]
-  sha256: ab2ea3fe991601a5e6bd2cda786ecaa919c0b39e0550e59978b5d40270c260d3 # [linux64]
   sha256: 40b4829888770b93aafe96875e00a12e781720010dbbad3aa898362ea3cad62c # [win64]
   folder: blender
 
 build:
+  skip: true  # [not win64]
   number: 0
   # These build options for repackaging an application
   # https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html

--- a/conda_recipes/blender-4.1/recipe/recipe.yaml
+++ b/conda_recipes/blender-4.1/recipe/recipe.yaml
@@ -1,0 +1,45 @@
+# Recipe in rattler-build format.
+# See https://prefix-dev.github.io/rattler-build/latest/
+
+context:
+  version: "4.1.1"
+  major_minor_version: "4.1"
+
+package:
+  name: blender
+  version: ${{ version }}
+
+source:
+  - if: linux
+    then:
+      url: https://download.blender.org/release/Blender${{ major_minor_version }}/blender-${{ version }}-linux-x64.tar.xz
+      sha256: ab2ea3fe991601a5e6bd2cda786ecaa919c0b39e0550e59978b5d40270c260d3
+      target_directory: blender
+  - if: win
+    then:
+      url: https://download.blender.org/release/Blender${{ major_minor_version }}/blender-${{ version }}-windows-x64.zip
+      sha256: 40b4829888770b93aafe96875e00a12e781720010dbbad3aa898362ea3cad62c
+      target_directory: blender
+
+build:
+  number: 0
+  # These build options for repackaging an application
+  # https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html
+  prefix_detection:
+    ignore_binary_files: True
+  dynamic_linking:
+    binary_relocation: False
+    missing_dso_allowlist:
+    - "**"
+
+tests:
+  - script:
+    - blender -h
+
+about:
+  homepage: https://www.blender.org/
+  license: GPL-3.0
+  summary: >
+    Blender is the free and open source 3D creation suite. It supports the entirety of
+    the 3D pipeline—modeling, rigging, animation, simulation, rendering, compositing
+    and motion tracking, even video editing and game creation.

--- a/conda_recipes/blender-4.2/deadline-cloud.yaml
+++ b/conda_recipes/blender-4.2/deadline-cloud.yaml
@@ -1,9 +1,11 @@
 condaPlatforms:
   - platform: linux-64
     defaultSubmit: true
-    sourceArchiveFilename: blender-4.2.1-linux-x64.tar.xz
-    sourceDownloadInstructions: 'Run "curl -LO https://download.blender.org/release/Blender4.2/blender-4.2.1-linux-x64.tar.xz"'
+    sourceArchiveFilename: blender-4.2.3-linux-x64.tar.xz
+    sourceDownloadInstructions: 'Run "curl -LO https://download.blender.org/release/Blender4.2/blender-4.2.3-linux-x64.tar.xz"'
+    buildTool: rattler-build
   - platform: win-64
     defaultSubmit: false
-    sourceArchiveFilename: blender-4.2.1-windows-x64.zip
-    sourceDownloadInstructions: 'Run "curl -LO https://download.blender.org/release/Blender4.2/blender-4.2.1-windows-x64.zip"'
+    sourceArchiveFilename: blender-4.2.3-windows-x64.zip
+    sourceDownloadInstructions: 'Run "curl -LO https://download.blender.org/release/Blender4.2/blender-4.2.3-windows-x64.zip"'
+    buildTool: conda-build

--- a/conda_recipes/blender-4.2/recipe/meta.yaml
+++ b/conda_recipes/blender-4.2/recipe/meta.yaml
@@ -1,4 +1,7 @@
-{% set version = "4.2.1" %}
+# Recipe in conda-build format.
+# This recipe is only for Windows, see recipe.yaml for the Linux recipe in rattler-build format.
+
+{% set version = "4.2.3" %}
 {% set major_minor_version = ".".join(version.split(".")[:2]) %}
 
 package:
@@ -6,13 +9,12 @@ package:
   version: {{ version }}
 
 source:
-  url: https://download.blender.org/release/Blender{{major_minor_version}}/blender-{{version}}-linux-x64.tar.gz # [linux64]
   url: https://download.blender.org/release/Blender{{major_minor_version}}/blender-{{version}}-windows-x64.zip # [win64]
-  sha256: be0fbaa0c1e52d4552023220b4c67351efbb707cac49bb381fcbee2182447005 # [linux64]
-  sha256: 46b9d27c2406454c68842d1790515732be385719e844f6b283e3c78186f9ffce # [win64]
+  sha256: 7f8be9b1dc904e7689b3112659791c29cc9ed9d46ce57c4ea5b31a0621489b3a # [win64]
   folder: blender
 
 build:
+  skip: true  # [not win64]
   number: 0
   # These build options for repackaging an application
   # https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html

--- a/conda_recipes/blender-4.2/recipe/recipe.yaml
+++ b/conda_recipes/blender-4.2/recipe/recipe.yaml
@@ -1,0 +1,45 @@
+# Recipe in rattler-build format.
+# See https://prefix-dev.github.io/rattler-build/latest/
+
+context:
+  version: "4.2.3"
+  major_minor_version: "4.2"
+
+package:
+  name: blender
+  version: ${{ version }}
+
+source:
+  - if: linux
+    then:
+      url: https://download.blender.org/release/Blender${{ major_minor_version }}/blender-${{ version }}-linux-x64.tar.xz
+      sha256: 3a64efd1982465395abab4259b4091d5c8c56054c7267e9633e4f702a71ea3f4
+      target_directory: blender
+  - if: win
+    then:
+      url: https://download.blender.org/release/Blender${{ major_minor_version }}/blender-${{ version }}-windows-x64.zip
+      sha256: 7f8be9b1dc904e7689b3112659791c29cc9ed9d46ce57c4ea5b31a0621489b3a
+      target_directory: blender
+
+build:
+  number: 0
+  # These build options for repackaging an application
+  # https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html
+  prefix_detection:
+    ignore_binary_files: True
+  dynamic_linking:
+    binary_relocation: False
+    missing_dso_allowlist:
+    - "**"
+
+tests:
+  - script:
+    - blender -h
+
+about:
+  homepage: https://www.blender.org/
+  license: GPL-3.0
+  summary: >
+    Blender is the free and open source 3D creation suite. It supports the entirety of
+    the 3D pipeline—modeling, rigging, animation, simulation, rendering, compositing
+    and motion tracking, even video editing and game creation.

--- a/conda_recipes/conda_build_linux_package/scripts/enter-package-build-env.sh
+++ b/conda_recipes/conda_build_linux_package/scripts/enter-package-build-env.sh
@@ -8,8 +8,7 @@ REUSE_ENV=1
 # Parse the CLI arguments
 while [ $# -gt 0 ]; do
     case "${1}" in
-    --reuse-env) REUSE_ENV=1 ; shift 1 ;;
-    --no-reuse-env) REUSE_ENV=0 ; shift 1 ;;
+    --reuse-env) REUSE_ENV="$2" ; shift 2 ;;
     --env-name) ENV_NAME="$2" ; shift 2 ;;
     --conda-bld-dir) CONDA_BLD_DIR="$2" ; shift 2 ;;
     *) echo "Unexpected option: $1" ; exit 1 ;;
@@ -29,13 +28,16 @@ fi
 function conda_clean_on_error {
     if [ ! "$1" = "0" ]; then
         echo "Error detected, removing the $ENV_NAME environment and cleaning the Conda cache."
-        conda remove --yes --name "$ENV_NAME" --all || true
+        for ENVS_DIR in $(conda info --json | python -c "import json, sys; v = json.load(sys.stdin); print('\n'.join(v['envs_dirs']))"); do
+            rm -rf $ENVS_DIR/$ENV_NAME
+        done
         conda clean --yes --all || true
     fi
 }
 trap 'conda_clean_on_error $?' EXIT
 
-if [ "$REUSE_ENV" = "0" ]; then
+if [ "$REUSE_ENV" == "0" ]; then
+    echo "Removing any existing environment called $ENV_NAME"
     conda env remove --yes -q -n $ENV_NAME
 fi
 
@@ -51,7 +53,7 @@ else
 
     conda create --yes -n "$ENV_NAME" \
         -c conda-forge \
-        python=3.11 conda conda-build conda-index boto3 pyyaml
+        python=3.12 conda conda-build rattler-build conda-index boto3 pyyaml
 
     # Activate the Conda environment, capturing the environment variables for the session to use
     python "$(dirname "$0")/openjd-vars-start.py" .vars
@@ -62,7 +64,7 @@ else
     # We patch the file conda_package_handling/conda_fmt.py to change its constructor
     # from `conda_file.open(component, "w")` to
     # `conda_file.open(component, "w", force_zip64=True)`.
-    for CFP in "lib/python3.11/site-packages/conda_package_handling/conda_fmt.py" "lib/site-packages/conda_package_handling/conda_fmt.py"; do
+    for CFP in "lib/python3.12/site-packages/conda_package_handling/conda_fmt.py" "lib/site-packages/conda_package_handling/conda_fmt.py"; do
         if [ -f "$CONDA_PREFIX/$CFP" ]; then
             CONDA_FMT_PATH=$CFP
         fi
@@ -89,7 +91,7 @@ else
 
 fi
 
-if [[ "$(uname -s)" == MINGW* ]]; then
+if [[ "$(uname -s)" == MINGW* || "$(uname -s)" == MSYS_NT* ]]; then
     # Remove ripgrep because conda-build gives it an arguments list that is too long when building some package recipes.
     # See https://github.com/conda/conda-build/issues/4357
     #   FileNotFoundError: [WinError 206] The filename or extension is too long
@@ -99,9 +101,13 @@ fi
 
 # Create a .condarc to control the package build settings
 cat <<EOF > "$CONDA_PREFIX/.condarc"
+# Default to no channels. Specify channels in the conda build recipe's deadline-cloud.yaml file.
+channels: []
 conda_build:
     # Build in the .conda package format
     pkg_format: '2'
     root-dir: '$CONDA_BLD_DIR'
     debug: false
 EOF
+
+conda info

--- a/conda_recipes/conda_build_linux_package/scripts/enter-proxy-s3-conda-channels.sh
+++ b/conda_recipes/conda_build_linux_package/scripts/enter-proxy-s3-conda-channels.sh
@@ -1,0 +1,100 @@
+#!/bin/env bash
+set -euo pipefail
+
+# The rattler-build tool does not support S3 conda channels. Therefore,
+# this job uses s3-mountpoint to mount any conda channels that start with s3://.
+#
+# Publishes the environment variables CONDA_CHANNELS and S3_CONDA_CHANNEL
+# with the s3:// channels rewritten to file://. Also publishes S3_PROXY_ROOT
+# for the exit-proxy-s3-conda-channels.sh script to use for clean-up.
+
+CONDA_CHANNELS=
+S3_CONDA_CHANNEL=
+BUILD_TOOL=
+
+# Parse the CLI arguments
+while [ $# -gt 0 ]; do
+    case "${1}" in
+    --conda-channels) CONDA_CHANNELS="$2" ; shift 2 ;;
+    --s3-conda-channel) S3_CONDA_CHANNEL="$2" ; shift 2 ;;
+    --build-tool) BUILD_TOOL="$2" ; shift 2 ;;
+    *) echo "Unexpected option: $1" ; exit 1 ;;
+  esac
+done
+
+if [ -z "$S3_CONDA_CHANNEL" ]; then
+    echo "ERROR: Option --s3-conda-channel is required."
+    exit 1
+fi
+
+if [ -z "$BUILD_TOOL" ]; then
+    echo "ERROR: Option --build-tool is required."
+    exit 1
+fi
+
+if [ "$BUILD_TOOL" != "conda-build" ] && [ "$BUILD_TOOL" != "rattler-build" ]; then
+    echo "ERROR: Option --build-tool must be either conda-build or rattler-build."
+    exit 1
+fi
+
+if [ "$BUILD_TOOL" == "conda-build" ]; then
+    echo "The conda-build tool support s3:// channels, no proxy is required."
+    echo "openjd_env: CONDA_CHANNELS=$CONDA_CHANNELS"
+    echo "openjd_env: S3_CONDA_CHANNEL=$S3_CONDA_CHANNEL"
+    exit 0
+fi
+
+# Choose a root directory for mounting the S3 channels
+if [[ "$(uname)" == Linux ]]; then
+    mkdir -p proxy-s3
+    S3_PROXY_ROOT=$(pwd)/proxy-s3
+else
+    echo "ERROR: The S3 conda channel proxy is based on s3-mountpoint, only available on Linux."
+    exit 1
+fi
+echo "openjd_env: S3_PROXY_ROOT=$S3_PROXY_ROOT"
+mkdir -p "$S3_PROXY_ROOT"
+
+# Install an error handler to unmount any mounted drives
+function unmount_s3_proxy_on_error {
+    if [ ! "$1" = "0" ]; then
+        set +e
+        for MOUNTPOINT in "$S3_PROXY_ROOT"/*; do
+            fusermount -u $MOUNTPOINT
+            rmdir $MOUNTPOINT
+        done
+        set -e
+    fi
+}
+trap 'unmount_s3_proxy_on_error $?' EXIT
+
+function mount_s3_proxy {
+    # Checks if the channel is s3:// and mounts it with s3-mountpoint if so.
+    # Outputs new channel name to UPDATED_CHANNEL.
+    local CHANNEL=$1
+
+    if [[ "$CHANNEL" =~ ^s3://([^/]+)/(.*)/?$ ]]; then
+        local S3_CHANNEL_BUCKET=${BASH_REMATCH[1]}
+        local S3_CHANNEL_PREFIX=${BASH_REMATCH[2]}
+        local CHANNEL_DIR="${S3_CHANNEL_BUCKET}_${S3_CHANNEL_PREFIX//\//_}"
+        mkdir -p "$S3_PROXY_ROOT/$CHANNEL_DIR"
+        mount-s3 --prefix $S3_CHANNEL_PREFIX/ \
+            --read-only \
+            $S3_CHANNEL_BUCKET "$S3_PROXY_ROOT/$CHANNEL_DIR"
+        UPDATED_CHANNEL="file://$S3_PROXY_ROOT/$CHANNEL_DIR"
+    else
+        UPDATED_CHANNEL="$CHANNEL"
+    fi
+}
+
+# Mount all the S3 conda channels, and rewrite the channel names
+RESULT_CONDA_CHANNELS=
+for CHANNEL in $CONDA_CHANNELS; do
+    mount_s3_proxy "$CHANNEL"
+    RESULT_CONDA_CHANNELS="$RESULT_CONDA_CHANNELS $UPDATED_CHANNEL"
+done
+echo "openjd_env: CONDA_CHANNELS=$RESULT_CONDA_CHANNELS"
+
+# Mount the S3 conda channel and rewrite its name
+mount_s3_proxy $S3_CONDA_CHANNEL
+echo "openjd_env: S3_CONDA_CHANNEL=$UPDATED_CHANNEL"

--- a/conda_recipes/conda_build_linux_package/scripts/exit-proxy-s3-conda-channels.sh
+++ b/conda_recipes/conda_build_linux_package/scripts/exit-proxy-s3-conda-channels.sh
@@ -1,0 +1,15 @@
+#!/bin/env bash
+set -euo pipefail
+
+if [ -z "${S3_PROXY_ROOT:-}" ]; then
+    echo "No S3 proxy was performed."
+    exit 0
+fi
+
+set +e
+for MOUNTPOINT in "$S3_PROXY_ROOT"/*; do
+    echo "Unmounting $MOUNTPOINT"
+    fusermount -u $MOUNTPOINT
+    rmdir $MOUNTPOINT
+done
+set -e

--- a/conda_recipes/conda_build_linux_package/scripts/s3-object-mutex.py
+++ b/conda_recipes/conda_build_linux_package/scripts/s3-object-mutex.py
@@ -85,9 +85,7 @@ def _mutex_get_lock_data(mutex_timeout_seconds=MUTEX_TIMEOUT_SECONDS):
         return (None, None)
 
     time_until_expiry = (
-        response["LastModified"]
-        + datetime.timedelta(seconds=mutex_timeout_seconds)
-        - datetime.datetime.now(tz=datetime.timezone.utc)
+        response["LastModified"] + datetime.timedelta(seconds=mutex_timeout_seconds) - datetime.datetime.now(tz=datetime.timezone.utc)
     )
     if time_until_expiry <= datetime.timedelta(seconds=0):
         # If the object hasn't been refreshed within the timeout, it's not locked. This
@@ -107,9 +105,7 @@ def _mutex_wait_while_locked():
     """
     lock_data, time_until_expiry = _mutex_get_lock_data()
     while lock_data is not None:
-        print(
-            f"Waiting, the lock for mutex s3://{s3_bucket_name}/{s3_lock_object} expires in {time_until_expiry}, info:"
-        )
+        print(f"Waiting, the lock for mutex s3://{s3_bucket_name}/{s3_lock_object} expires in {time_until_expiry}, info:")
         pprint(lock_data)
         time.sleep(MUTEX_WAIT_POLLING_SECONDS)
         lock_data, time_until_expiry = _mutex_get_lock_data()
@@ -151,9 +147,7 @@ def enter():
             continue
 
         # Filter out expired objects
-        expiry = datetime.datetime.now(tz=datetime.timezone.utc) - datetime.timedelta(
-            seconds=MUTEX_ACQUISITION_TIMEOUT_SECONDS
-        )
+        expiry = datetime.datetime.now(tz=datetime.timezone.utc) - datetime.timedelta(seconds=MUTEX_ACQUISITION_TIMEOUT_SECONDS)
         s3_objects = [obj for obj in all_s3_objects if obj["LastModified"] > expiry]
 
         # Sort the objects oldest first, then by key
@@ -176,9 +170,7 @@ def enter():
     s3_client.put_object(Bucket=s3_bucket_name, Key=s3_lock_object, Body=body)
 
     # Delete our lock acquisition object and any expired ones
-    delete_s3_objects = [
-        obj for obj in all_s3_objects if obj["LastModified"] <= expiry or obj["Key"] == s3_lock_acquisition_object
-    ]
+    delete_s3_objects = [obj for obj in all_s3_objects if obj["LastModified"] <= expiry or obj["Key"] == s3_lock_acquisition_object]
     for obj in delete_s3_objects:
         print(f"Deleting object s3://{s3_bucket_name}/{obj['Key']}")
         s3_client.delete_object(Bucket=s3_bucket_name, Key=obj["Key"])

--- a/conda_recipes/conda_build_linux_package/template.yaml
+++ b/conda_recipes/conda_build_linux_package/template.yaml
@@ -12,6 +12,15 @@ description: |
 
 parameterDefinitions:
 # Group: Conda Package Recipe
+- name: BuildTool
+  type: STRING
+  userInterface:
+    control: DROPDOWN_LIST
+    label: Package Build Tool
+    groupLabel: Conda Package Recipe
+  description: Choose the build tool to use for the recipe (conda-build or rattler-build).
+  default: conda-build
+  allowedValues: ["conda-build", "rattler-build"]
 - name: RecipeName
   description: The name of the recipe being built.
   userInterface:
@@ -77,16 +86,16 @@ parameterDefinitions:
     control: SPIN_BOX
     label: Override Prefix Length
     groupLabel: Conda Package Recipe
-- name: CondaBuildConfigFile
+- name: VariantConfigFile
   description: |
-    If provided, this is saved as the conda_build_config.yaml file for the conda package build.
+    If provided, this is used as the variant config for the conda package build.
   type: PATH
   objectType: FILE
   dataFlow: IN
   default: ""
   userInterface:
     control: CHOOSE_INPUT_FILE
-    label: Conda-build config YAML file
+    label: Variant config YAML file
     groupLabel: Conda Package Recipe
 
 # Group: Conda Channel
@@ -124,21 +133,21 @@ parameterDefinitions:
   type: STRING
   default: ""
 
-# Group: Conda-build Env
-- name: CondaBuildEnvName
-  description: The name of the Conda virtual environment with conda-build installed.
+# Group: Package Build Env
+- name: PackageBuildEnvName
+  description: The name of the Conda virtual environment with conda-build and rattler-build installed.
   userInterface:
     control: LINE_EDIT
-    label: Conda-build Env Name
-    groupLabel: Conda-build Env
+    label: Package Build Env Name
+    groupLabel: Package Build Env
   type: STRING
-  default: "CondaBuildEnv"
-- name: ReuseCondaBuildEnv
+  default: "PackageBuildEnv"
+- name: ReusePackageBuildEnv
   description: Whether to reuse the Conda virtual environment for conda-build or not.
   userInterface:
     control: CHECK_BOX
     label: Reuse the named Conda Build environment.
-    groupLabel: Conda-build Env
+    groupLabel: Package Build Env
   type: STRING
   default: "1"
   allowedValues: ["1", "0"]
@@ -155,7 +164,7 @@ parameterDefinitions:
 
 jobEnvironments:
 
-- name: CondaBuild Env
+- name: Package Build Env
   variables:
     # Tell Qt applications to run off-screen.
     QT_QPA_PLATFORM: offscreen
@@ -166,11 +175,13 @@ jobEnvironments:
       onEnter:
         command: "bash"
         args:
-        - '{{Param.JobScriptDir}}/enter-conda-build-env.sh'
+        - '{{Param.JobScriptDir}}/enter-package-build-env.sh'
         - '--env-name'
-        - '{{Param.CondaBuildEnvName}}'
+        - '{{Param.PackageBuildEnvName}}'
         - '--conda-bld-dir'
         - '{{Session.WorkingDirectory}}/conda-bld'
+        - '--reuse-env'
+        - '{{Param.ReusePackageBuildEnv}}'
 
 steps:
 
@@ -183,37 +194,56 @@ steps:
 
     meta:
       perStepParameters:
+      - BuildTool
       - OverrideSourceArchive1
       - OverrideSourceArchive2
       - CondaPlatform
-      - CondaBuildConfigFile
+      - VariantConfigFile
+
+  stepEnvironments:
+  - name: S3 Conda Channels
+    script:
+      actions:
+        onEnter:
+          command: "bash"
+          args:
+          - '{{Param.JobScriptDir}}/enter-proxy-s3-conda-channels.sh'
+          - '--build-tool'
+          - '{{Param.BuildTool}}'
+          - '--conda-channels'
+          - '{{Param.CondaChannels}}'
+          - '--s3-conda-channel'
+          - '{{Param.S3CondaChannel}}'
+        onExit:
+          command: "bash"
+          args:
+          - '{{Param.JobScriptDir}}/exit-proxy-s3-conda-channels.sh'
 
   script:
     actions:
       onRun:
-        command: python
-        args:
-        - '{{Param.JobScriptDir}}/build-package.py'
-        - '--conda-bld-dir'
-        - '{{Session.WorkingDirectory}}/conda-bld'
-        - '--conda-platform'
-        - '{{Param.CondaPlatform}}'
-        - '--conda-channels'
-        - '{{Param.CondaChannels}}'
-        - '--s3-conda-channel'
-        - '{{Param.S3CondaChannel}}'
-        - '--override-prefix-length'
-        - '{{Param.OverridePrefixLength}}'
-        - '--recipe-dir'
-        - '{{Param.RecipeDir}}'
-        - '--override-package-name'
-        - '{{Param.OverridePackageName}}'
-        - '--override-source-archive1'
-        - '{{Param.OverrideSourceArchive1}}'
-        - '--override-source-archive2'
-        - '{{Param.OverrideSourceArchive2}}'
-        - '--conda-build-config-file'
-        - '{{Param.CondaBuildConfigFile}}'
+        command: "bash"
+        args: ["{{Task.File.Run}}"]
+    embeddedFiles:
+    - name: Run
+      type: TEXT
+      data: |
+        #!/bin/env bash
+        set -xeuo pipefail
+
+        python '{{Param.JobScriptDir}}/build-package.py' \
+            --build-tool '{{Param.BuildTool}}' \
+            --conda-bld-dir '{{Session.WorkingDirectory}}/conda-bld' \
+            --conda-platform '{{Param.CondaPlatform}}' \
+            --conda-channels "$CONDA_CHANNELS" \
+            --s3-conda-channel '{{Param.S3CondaChannel}}' \
+            --proxy-s3-conda-channel "$S3_CONDA_CHANNEL" \
+            --override-prefix-length '{{Param.OverridePrefixLength}}' \
+            --recipe-dir '{{Param.RecipeDir}}' \
+            --override-package-name '{{Param.OverridePackageName}}' \
+            --override-source-archive1 '{{Param.OverrideSourceArchive1}}' \
+            --override-source-archive2 '{{Param.OverrideSourceArchive2}}' \
+            --variant-config-file '{{Param.VariantConfigFile}}'
 
   hostRequirements:
     # Host requirements for the linux-64 conda platform

--- a/conda_recipes/deadline/deadline-cloud.yaml
+++ b/conda_recipes/deadline/deadline-cloud.yaml
@@ -1,12 +1,46 @@
 condaPlatforms:
   - platform: linux-64
+    variant: py311
     defaultSubmit: true
-  - platform: linux-aarch64
-    defaultSubmit: false
+    buildTool: rattler-build
+    variantConfig:
+      python:
+      - 3.11
+  - platform: linux-64
+    variant: py312
+    defaultSubmit: true
+    buildTool: rattler-build
+    variantConfig:
+      python:
+      - 3.12
   - platform: win-64
+    variant: py311
     defaultSubmit: true
-  - platform: osx-64
+    buildTool: conda-build
+    variantConfig:
+      python:
+      - 3.11
+  - platform: win-64
+    variant: py312
+    defaultSubmit: true
+    buildTool: conda-build
+    variantConfig:
+      python:
+      - 3.12
+  - platform: linux-aarch64
+    variant: py312
     defaultSubmit: false
+    buildTool: rattler-build
+    variantConfig:
+      python:
+      - 3.12
+  - platform: osx-64
+    variant: py312
+    defaultSubmit: false
+    buildTool: conda-build
+    variantConfig:
+      python:
+      - 3.12
 jobParameters:
 - name: CondaChannels
   value: conda-forge

--- a/conda_recipes/deadline/recipe/meta.yaml
+++ b/conda_recipes/deadline/recipe/meta.yaml
@@ -1,5 +1,8 @@
+# Recipe in conda-build format.
+# See recipe.yaml for the recipe in rattler-build format.
+
 {% set name = "deadline" %}
-{% set version = "0.48.8" %}
+{% set version = "0.48.9" %}
 
 package:
   name: {{ name }}
@@ -7,7 +10,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/deadline-{{ version }}.tar.gz
-  sha256: 998962a50d254d0b969f767f55282468949fdb668ddd33e1a30815e5ca9bb74e
+  sha256: ad4256b6b80325598e3ae3660f43ea0b037958c9bb7081c96ce737395ebf5a00
   patches:
     - 0001-Remove-version-build-hook.patch
 
@@ -21,17 +24,17 @@ build:
 
 requirements:
   host:
-    - python >=3.8
+    - python
     - hatchling
     - hatch-vcs
     - pip
   run:
-    - python >=3.8
+    - python
     - boto3 >=1.34.75
     - click >=8.1.7
     - pyyaml >=6.0
     - typing-extensions >=4.8
-    - python-xxhash ==3.4.*
+    - python-xxhash >=3.4,<3.6
     - jsonschema ==4.17.*
     - pywin32 ==306  # [win]
     - qtpy ==2.4.*
@@ -42,6 +45,7 @@ test:
   commands:
     - pip check
     - deadline --help
+    - python -m deadline --help
   requires:
     - pip
 

--- a/conda_recipes/deadline/recipe/recipe.yaml
+++ b/conda_recipes/deadline/recipe/recipe.yaml
@@ -1,0 +1,59 @@
+# Recipe in rattler-build format.
+# See https://prefix-dev.github.io/rattler-build/latest/
+
+context:
+  version: "0.48.9"
+
+package:
+  name: deadline
+  version: ${{ version }}
+
+source:
+  url: https://pypi.io/packages/source/d/deadline/deadline-${{ version }}.tar.gz
+  sha256: ad4256b6b80325598e3ae3660f43ea0b037958c9bb7081c96ce737395ebf5a00
+  patches:
+    - 0001-Remove-version-build-hook.patch
+
+build:
+  number: 0
+  script:
+    - python -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python
+    - hatchling
+    - hatch-vcs
+    - pip
+  run:
+    - python
+    - boto3 >=1.34.75
+    - click >=8.1.7
+    - pyyaml >=6.0
+    - typing-extensions >=4.8
+    - python-xxhash >=3.4,<3.6
+    - jsonschema 4.17
+    - qtpy 2.4
+    - ${{ "pywin32 ==306" if win }}
+
+tests:
+- python:
+    imports:
+      - deadline
+      - deadline.client
+      - deadline.job_attachments
+- requirements:
+    run:
+      - pip
+  script:
+  - pip check
+  - deadline --help
+  - python -m deadline --help
+
+about:
+  summary: Multi-purpose library and command line tool that implements functionality to support applications using AWS Deadline Cloud.
+  homepage: https://github.com/aws-deadline/deadline-cloud
+  license: Apache-2.0
+  license_file:
+    - LICENSE
+    - NOTICE

--- a/conda_recipes/maya-openjd/deadline-cloud.yaml
+++ b/conda_recipes/maya-openjd/deadline-cloud.yaml
@@ -1,8 +1,32 @@
 condaPlatforms:
   - platform: linux-64
+    variant: py311
     defaultSubmit: true
+    variantConfig:
+      python:
+      - 3.11
+    buildTool: rattler-build
+  - platform: linux-64
+    variant: py312
+    defaultSubmit: true
+    variantConfig:
+      python:
+      - 3.12
+    buildTool: rattler-build
   - platform: win-64
+    variant: py311
     defaultSubmit: true
+    variantConfig:
+      python:
+      - 3.11
+    buildTool: conda-build
+  - platform: win-64
+    variant: py312
+    defaultSubmit: true
+    variantConfig:
+      python:
+      - 3.12
+    buildTool: conda-build
 jobParameters:
 - name: CondaChannels
   value: conda-forge

--- a/conda_recipes/maya-openjd/recipe/0001-Remove-version-hook.patch
+++ b/conda_recipes/maya-openjd/recipe/0001-Remove-version-hook.patch
@@ -1,20 +1,29 @@
-From 9e98b5cc9d014bc0fa022b8adb7ffc32c2949bef Mon Sep 17 00:00:00 2001
+From 88f9bd0136c786b499a171e196275fc2ba853f3b Mon Sep 17 00:00:00 2001
 From: Mark Wiebe <399551+mwiebe@users.noreply.github.com>
-Date: Wed, 24 Apr 2024 16:00:09 -0700
-Subject: [PATCH] Remove version hook
+Date: Mon, 4 Nov 2024 16:26:56 -0800
+Subject: [PATCH] patched
 
 ---
- pyproject.toml | 13 -------------
- 1 file changed, 13 deletions(-)
+ pyproject.toml | 21 ---------------------
+ 1 file changed, 21 deletions(-)
 
 diff --git a/pyproject.toml b/pyproject.toml
-index 072e03d..a02178d 100644
+index dc22099..bb3f888 100644
 --- a/pyproject.toml
 +++ b/pyproject.toml
-@@ -58,19 +58,6 @@ source = "vcs"
- [tool.hatch.version.raw-options]
- version_scheme = "post-release"
-
+@@ -49,27 +49,6 @@ artifacts = [
+   "*_version.py",
+ ]
+ 
+-[tool.hatch.build.targets.wheel.force-include]
+-"./maya_submitter_plugin" = "deadline/maya_submitter/maya_submitter_plugin"
+-
+-[tool.hatch.version]
+-source = "vcs"
+-
+-[tool.hatch.version.raw-options]
+-version_scheme = "post-release"
+-
 -[tool.hatch.build.hooks.vcs]
 -version-file = "_version.py"
 -
@@ -30,6 +39,6 @@ index 072e03d..a02178d 100644
  [tool.hatch.build.targets.sdist]
  include = [
      "src/*",
---
-2.39.2.windows.1
+-- 
+2.46.2.windows.1
 

--- a/conda_recipes/maya-openjd/recipe/meta.yaml
+++ b/conda_recipes/maya-openjd/recipe/meta.yaml
@@ -1,38 +1,43 @@
+# Recipe in conda-build format.
+# See recipe.yaml for the recipe in rattler-build format.
+
 {% set name = "maya-openjd" %}
-{% set version = "0.14.2" %}
+{% set version = "0.14.3" %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
+# This source reference uses the source archive published to PyPI
 source:
-  url: https://pypi.io/packages/source/d/deadline-cloud-for-maya/deadline_cloud_for_maya-{{ version }}.tar.gz
-  sha256: 85f3170876c002686e4a73a0a25f22ba3d13d3d0f990e76014893c1e0b2a111e
-  patches:
-    - 0001-Remove-version-hook.patch
+ url: https://pypi.io/packages/source/d/deadline-cloud-for-maya/deadline_cloud_for_maya-{{ version }}.tar.gz
+ sha256: d3789e4a14144b43224bc0657eacdb3e39e333aedc22ad29b8591530a185f845
+ patches:
+   - 0001-Remove-version-hook.patch
 
-## Here's an alternative source definition to build a package from a development branch on github. Replace
-## the username and git branch as appropriate for your case.
+# # This source reference uses git to retrieve the tag for the specified version. You can modify
+# # the git_url and git_rev to point to a branch in your own fork of the project.
 # source:
-  # git_url: https://github.com/mwiebe/deadline-cloud-for-maya.git
-  # git_rev: region-render
+#   git_url: https://github.com/aws-deadline/deadline-cloud-for-maya.git
+#   git_rev: {{ version }}
 
 build:
   entry_points:
     - maya-openjd = deadline.maya_adaptor.MayaAdaptor:main
     - MayaAdaptor = deadline.maya_adaptor.MayaAdaptor:main
-  noarch: python
   script: python -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 
 requirements:
-  host:
-    - python >=3.9
+  build:
+    # For the variant config file in deadline-cloud.yaml to work, python must not specify a version here.
+    - python
     - hatchling
     - hatch-vcs
     - pip
   run:
-    - python >=3.9
+    # For the variant config file in deadline-cloud.yaml to work, python must not specify a version here.
+    - python
     - deadline ==0.48.*
     - openjd-adaptor-runtime ==0.8.*
 

--- a/conda_recipes/maya-openjd/recipe/recipe.yaml
+++ b/conda_recipes/maya-openjd/recipe/recipe.yaml
@@ -1,0 +1,51 @@
+# Recipe in rattler-build format.
+# See https://prefix-dev.github.io/rattler-build/latest/
+
+context:
+  version: "0.14.3"
+
+package:
+  name: maya-openjd
+  version: ${{ version }}
+
+# This source reference uses the source archive published to PyPI
+source:
+  url: https://pypi.io/packages/source/d/deadline-cloud-for-maya/deadline_cloud_for_maya-${{ version }}.tar.gz
+  sha256: d3789e4a14144b43224bc0657eacdb3e39e333aedc22ad29b8591530a185f845
+  patches:
+    - 0001-Remove-version-hook.patch
+
+build:
+  number: 0
+  script:
+    - python -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python
+    - hatchling
+    - hatch-vcs
+    - pip
+  run:
+    - python
+    - deadline 0.48.*
+    - openjd-adaptor-runtime 0.8.*
+
+tests:
+- python:
+    imports:
+      - deadline.maya_adaptor
+- requirements:
+    run:
+      - pip
+  script:
+    - pip check
+    - maya-openjd --help
+
+about:
+  summary: AWS Deadline Cloud for Maya
+  homepage: https://github.com/aws-deadline/deadline-cloud-for-maya
+  license: Apache-2.0
+  license_file:
+    - LICENSE
+    - NOTICE

--- a/conda_recipes/openjd-adaptor-runtime/deadline-cloud.yaml
+++ b/conda_recipes/openjd-adaptor-runtime/deadline-cloud.yaml
@@ -1,8 +1,32 @@
 condaPlatforms:
   - platform: linux-64
+    variant: py311
     defaultSubmit: true
+    variantConfig:
+      python:
+      - 3.11
+    buildTool: rattler-build
+  - platform: linux-64
+    variant: py312
+    defaultSubmit: true
+    variantConfig:
+      python:
+      - 3.12
+    buildTool: rattler-build
   - platform: win-64
+    variant: py311
     defaultSubmit: true
+    variantConfig:
+      python:
+      - 3.11
+    buildTool: conda-build
+  - platform: win-64
+    variant: py312
+    defaultSubmit: true
+    variantConfig:
+      python:
+      - 3.12
+    buildTool: conda-build
 jobParameters:
 - name: CondaChannels
   value: conda-forge

--- a/conda_recipes/openjd-adaptor-runtime/recipe/meta.yaml
+++ b/conda_recipes/openjd-adaptor-runtime/recipe/meta.yaml
@@ -1,3 +1,6 @@
+# Recipe in conda-build format.
+# See recipe.yaml for the recipe in rattler-build format.
+
 {% set name = "openjd-adaptor-runtime" %}
 {% set version = "0.8.0" %}
 
@@ -5,11 +8,18 @@ package:
   name: {{ name }}
   version: {{ version }}
 
+# # This source reference uses the source archive published to PyPI
+# source:
+#   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/openjd_adaptor_runtime-{{ version }}.tar.gz
+#   sha256: 58e00c4a08686821df01c736e0781a3736450865cc2cf4e3799e354d324112d8
+#   patches:
+#     - 0001-Remove-version-hook.patch
+
+# This source reference uses git to retrieve the tag for the specified version. You can modify
+# the git_url and git_rev to point to a branch in your own fork of the project.
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/openjd_adaptor_runtime-{{ version }}.tar.gz
-  sha256: 58e00c4a08686821df01c736e0781a3736450865cc2cf4e3799e354d324112d8
-  patches:
-    - 0001-Remove-version-hook.patch
+  git_url: https://github.com/OpenJobDescription/openjd-adaptor-runtime-for-python.git
+  git_rev: "{{ version }}"
 
 build:
   skip: true  # [py<39]
@@ -17,13 +27,15 @@ build:
   number: 0
 
 requirements:
-  host:
-    - python >=3.9
+  build:
+    # For the variant config file in deadline-cloud.yaml to work, python must not specify a version here.
+    - python
     - hatchling
     - hatch-vcs
     - pip
   run:
-    - python >=3.9
+    # For the variant config file in deadline-cloud.yaml to work, python must not specify a version here.
+    - python
     - pyyaml >=6.0,<7.dev0
     - jsonschema >=4.17.0,<5.0
     - pywin32 ==306  # [win]

--- a/conda_recipes/openjd-adaptor-runtime/recipe/recipe.yaml
+++ b/conda_recipes/openjd-adaptor-runtime/recipe/recipe.yaml
@@ -1,0 +1,50 @@
+# Recipe in rattler-build format.
+# See https://prefix-dev.github.io/rattler-build/latest/
+
+context:
+  version: "0.8.0"
+
+package:
+  name: openjd-adaptor-runtime
+  version: ${{ version }}
+
+source:
+  url: https://pypi.io/packages/source/o/openjd-adaptor-runtime/openjd_adaptor_runtime-${{ version }}.tar.gz
+  sha256: 58e00c4a08686821df01c736e0781a3736450865cc2cf4e3799e354d324112d8
+  patches:
+    - 0001-Remove-version-hook.patch
+
+build:
+  number: 0
+  script:
+    - python -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python
+    - hatchling
+    - hatch-vcs
+    - pip
+  run:
+    - python
+    - pyyaml >=6.0,<7.dev0
+    - jsonschema >=4.17.0,<5.0
+    - ${{ "pywin32 ==306" if win }}
+
+tests:
+- python:
+    imports:
+    - openjd.adaptor_runtime
+    - openjd.adaptor_runtime_client
+- requirements:
+    run:
+      - pip
+  script:
+  - pip check
+
+about:
+  summary: A python library for building adaptors that integrate applications with Open Job Description jobs.
+  license: Apache-2.0
+  license_file:
+    - LICENSE
+    - NOTICE


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The rattler-build tool is much faster at building conda packages than conda-build. See https://prefix.dev/blog/rattler_build_on_conda_forge to read about how this is available on conda-forge now.

### What was the solution? (How)

* Currently Linux-only, add the ability to use rattler-build to build conda packages submitted with the submit-conda-build script. Because rattler-build doesn't support S3 conda channels directly, it creates proxy channels using mountpoint-s3.
* Define a way to specify the build tool as either conda-build or rattler-build, and update the README.md documentation to describe that.
* Add glob platform matching to the submit-package-build script to make it easier to submit variants based on patterns.
* Update the sample conda package recipes to include a recipe.yaml for rattler-build. The deadline-cloud.yaml metadata specifies rattler-build for Linux and conda-build for Windows.
* Update the Blender 4.2 sample to 4.2.3.
* Fix a STDOUT vs STDERR bug in the package build script, and refactor its logging to speed up debugging issues like this in the future.

### What is the impact of this change?

Experimentation shows roughly 4 or 5 times faster package builds on some of the samples, so switching will save a lot of time.

### How was this change tested?

Submitted all the sample package recipes to a build farm with various options, and confirmed successful builds.

### Was this change documented?

Updated the README.md documentation about how to submit package builds.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*