### PR TITLE
feat: Add V-Ray conda recipe

### DIFF
--- a/conda_recipes/vray/deadline-cloud.yaml
+++ b/conda_recipes/vray/deadline-cloud.yaml
@@ -1,0 +1,12 @@
+condaPlatforms:
+  - platform: linux-64
+    defaultSubmit: true
+    sourceArchiveFilename: vraystd_adv_62022_rhel8_clang-gcc-11.2
+    sourceDownloadInstructions: 'Download the vraystd_adv_62022_rhel8_clang-gcc-11.2 full download file from Chaos.'
+  - platform: linux-aarch64
+    defaultSubmit: false
+    sourceArchiveFilename: vraystd_adv_62022_rhel8_arm64_clang-gcc-11.2
+    sourceDownloadInstructions: 'Download the vraystd_adv_62022_rhel8_arm64_clang-gcc-11.2 full download file from Chaos.'
+jobParameters:
+  - name: CondaChannels
+    value: conda-forge

--- a/conda_recipes/vray/recipe/build.sh
+++ b/conda_recipes/vray/recipe/build.sh
@@ -1,0 +1,77 @@
+#!/bin/sh
+set -xeuo pipefail
+
+# Run the installer extracting to a temporary directory
+ls -l $SRC_DIR
+chmod u+x $SRC_DIR/vray*
+mkdir "$SRC_DIR/extracted"
+$SRC_DIR/vray* -unpackInstall $SRC_DIR/extracted
+
+cd $PREFIX
+
+# Copy the vray relocatable (aka portable) installation from the temporary directory to the prefix
+mkdir -p "$PREFIX/usr"
+VRAY_ROOT="usr/vray-$PKG_VERSION"
+cp -r "$SRC_DIR/extracted/" "$PREFIX/$VRAY_ROOT"
+
+# Remove the samples, they're not needed on the farm
+rm -rf $PREFIX/$VRAY_ROOT/samples
+# Remove the docs, they're not needed on the farm
+rm -rf $PREFIX/$VRAY_ROOT/docs
+
+mkdir -p $PREFIX/bin
+
+# Add relative RPATHs for the vray executable and the plugins using patchelf, which is part of
+# the conda-build virtual environment. This is so we can follow the recommendation
+# of https://docs.conda.io/projects/conda-build/en/latest/resources/use-shared-libraries.html
+# to never use LD_LIBRARY_PATH in Conda environments.
+VRAY_BIN="$CONDA_PREFIX/$VRAY_ROOT/bin"
+PATCHELF=$(dirname $CONDA_EXE)/patchelf
+$PATCHELF --add-rpath '$ORIGIN/../lib' "$VRAY_BIN/vray.bin"
+$PATCHELF --add-rpath '$ORIGIN/../' "$VRAY_BIN/plugins/libvray_ChaosScatter.so"
+$PATCHELF --add-rpath '$ORIGIN/../../lib' "$VRAY_BIN/plugins/libvray_MtlOSL.so"
+$PATCHELF --add-rpath '$ORIGIN/../../lib' "$VRAY_BIN/plugins/libvray_mtlx_private.so"
+
+# Create symlinks
+# For vray.bin, we symlink it to vray
+for BINARY in "$VRAY_BIN"/*.bin; do
+    # Skip creating a symlink for vray.bin
+    if [[ "$(basename "$BINARY")" == "vray.bin" ]]; then
+        ln -s "$BINARY" "$PREFIX/bin/vray"
+    else
+        ln -r -s "$BINARY" "$PREFIX/bin/$(basename "$BINARY")"
+    fi
+done
+
+# Install dependencies not available on Deadline Cloud service-managed fleets
+mkdir -p $SRC_DIR/download
+cd $SRC_DIR/download
+dnf download --resolve -y --arch $(uname -m) \
+    libglvnd-glx mesa-libGLU pango libXft fontconfig libX11 libXext \
+    libXinerama libXxf86vm libSM cairo libxkbcommon libICE libxcb \
+    xcb-util-renderutil xcb-util-keysyms xcb-util xcb-util-image xcb-util-wm
+
+for rpm_file in $(realpath $SRC_DIR/download/*.rpm); do
+    rpm2cpio "$rpm_file" | cpio -idm
+done
+
+# Remove a broken symlink from mesa-libGLU
+rm -f ./usr/lib64/libGLX_system.so.0
+
+# Copy .so's to the V-Ray installation
+find . -iname "*.so.*" -exec cp -P -r {} "$PREFIX/$VRAY_ROOT/lib/." \;
+
+# Script to set environment variables during activation
+mkdir -p $PREFIX/etc/conda/activate.d
+cat <<EOF > $PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.sh
+export "VRAY=\$CONDA_PREFIX/$VRAY_ROOT"
+export "VRAY_EULA=https://docs.chaos.com/display/VNS/End+User+License+Agreement"
+EOF
+
+mkdir -p $PREFIX/etc/conda/deactivate.d
+cat <<EOF > $PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.sh
+if ! [ -z \$VRAY ]; then 
+    unset VRAY
+    unset VRAY_EULA
+fi
+EOF

--- a/conda_recipes/vray/recipe/meta.yaml
+++ b/conda_recipes/vray/recipe/meta.yaml
@@ -1,0 +1,36 @@
+{% set version = "62022" %}
+
+package:
+  name: vray
+  version: {{ version }}
+
+source:
+  - if: linux-64
+    then:
+      url: archive_files/vraystd_adv_{{ version }}_rhel8_clang-gcc-11.2 # [linux64 and x86_64]
+      sha256: 404157ac038bcc0b8d2edeac78e093b4f8e984b5da46cc55bf0edb61c9a81445
+  - if: linux-aarch64
+    then:
+      url: archive_files/vraystd_adv_{{ version }}_rhel8_arm64_clang-gcc-11.2 # [aarch64]
+      sha256: cbcd9c1d5c955f67a3ae34ee4bd498f67675759098bfdb18f6bdf341e471414e
+
+build:
+  number: 0
+  binary_relocation: False
+  detect_binary_files_with_prefix: False
+  # V-Ray is built to be relocatable, so can ignore the warnings about DSOs.
+  missing_dso_whitelist:
+  - "*"
+
+test:
+  commands:
+    - vray --help
+    - vray --version
+
+about:
+  home: https://www.chaos.com/vray
+  doc_url: https://docs.chaos.com/display/VNS/V-Ray+Standalone+Home
+  license: Commercial
+  summary: |
+    V-Ray is a 3D photorealistic ray-traced rendering plug-in.
+    V-Ray Standalone is the full-featured and command-line renderer that supports V-Ray's native .vrscene file format.


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We want to expand our's conda recipe library to support more DCC to better support our customers and V-Ray is one of them
### What was the solution? (How)
Develop a conda recipe so customer could follow the readme and setup a V-Ray conda package to be use with Deadline Cloud
### What is the impact of this change?
V-Ray can now be use on Deadline Cloud 
### How was this change tested?
- Setup BYOL
- Setup V-Ray conda package on a conda channel using the conda recipe here and the public blog on how to setup a non default conda channel and conda package
- Start render job using V-Ray
### Was this change documented?
Yes


---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*