### PR TITLE
fix: Improve robustness of conda queue envs and package build

### DIFF
--- a/conda_recipes/submit-package-job-script.py
+++ b/conda_recipes/submit-package-job-script.py
@@ -30,8 +30,9 @@ def validate_recipe(recipe_dir):
         raise RuntimeError(f"The recipe directory does not exist: {recipe_dir}.")
 
     meta_yaml_file = recipe_dir / "recipe" / "meta.yaml"
-    if not meta_yaml_file.is_file():
-        raise RuntimeError(f"The recipe metadata file does not exist: {meta_yaml_file}.")
+    recipe_yaml_file = recipe_dir / "recipe" / "recipe.yaml"
+    if not meta_yaml_file.is_file() and not recipe_yaml_file.is_file():
+        raise RuntimeError(f"No meta.yaml or recipe.yaml exists in {recipe_dir}.")
 
     submit_yaml_file = recipe_dir / "deadline-cloud.yaml"
     if not submit_yaml_file.is_file():

--- a/queue_environments/conda_queue_env_console_equivalent.yaml
+++ b/queue_environments/conda_queue_env_console_equivalent.yaml
@@ -69,7 +69,9 @@ environment:
 
         # Activate the Conda environment, capturing the environment variables for the session to use
         python '{{Env.File.OpenJDVarsStart}}' .vars
+        set +u
         conda activate '{{Session.WorkingDirectory}}/.env'
+        set -u
         python '{{Env.File.OpenJDVarsCapture}}' .vars
 
         # Print information about the activated Conda environment

--- a/queue_environments/conda_queue_env_improved_caching.yaml
+++ b/queue_environments/conda_queue_env_improved_caching.yaml
@@ -132,7 +132,16 @@ environment:
         # If we're not reusing the Conda env, clean up any prior ones
         if [ '{{Param.NamedCondaEnvAction}}' = 'REMOVE_AND_CREATE' ] && [ -n "$NAMED_CONDA_ENV" ]; then
             echo "NamedCondaEnvAction parameter is set to REMOVE_AND_CREATE, removing the virtual environment..."
-            conda remove --yes --name "$NAMED_CONDA_ENV" --all
+            for ENVS_DIR in $(conda info --json | python -c "import json, sys; v = json.load(sys.stdin); print('\n'.join(v['envs_dirs']))"); do
+                if [ -d $ENVS_DIR/$NAMED_CONDA_ENV ]; then
+                    echo "Removing directory $ENVS_DIR/$NAMED_CONDA_ENV for the environment"
+                    rm -rf $ENVS_DIR/$NAMED_CONDA_ENV
+                    if [ -d $ENVS_DIR/$NAMED_CONDA_ENV ]; then
+                        echo "ERROR: Could not remove the directory. Possibly a permissions error or a process holding a lock."
+                        exit 1
+                    fi
+                fi
+            done
         fi
 
         # If requested, clean the Conda package cache
@@ -150,14 +159,22 @@ environment:
         if [ -n "$NAMED_CONDA_ENV" ] && conda env list | grep -q "^$NAMED_CONDA_ENV "; then
             echo "Reusing the existing named Conda environment $NAMED_CONDA_ENV."
 
-            # Activate the Conda environment, capturing the environment variables for the session to use
+            # Activate the Conda environment
             python '{{Env.File.OpenJDVarsStart}}' .vars
+            set +u
             conda activate "$NAMED_CONDA_ENV"
+            set -u
             python '{{Env.File.OpenJDVarsCapture}}' .vars
 
             CURRENT_TIMESTAMP="$(date +%s)"
-            PREVIOUS_UPDATE_TIMESTAMP="$(cat "$CONDA_PREFIX/var/log/conda_queue_env_update_timestamp")"
-            MINUTES_SINCE_UPDATE="$(( ( $CURRENT_TIMESTAMP - $PREVIOUS_UPDATE_TIMESTAMP ) / 60 ))"
+            TIMESTAMP_FILE="$CONDA_PREFIX/var/log/conda_queue_env_update_timestamp"
+            if [ -f "$TIMESTAMP_FILE" ]; then
+                PREVIOUS_UPDATE_TIMESTAMP="$(cat "$TIMESTAMP_FILE")"
+                MINUTES_SINCE_UPDATE="$(( ( $CURRENT_TIMESTAMP - $PREVIOUS_UPDATE_TIMESTAMP ) / 60 ))"
+            else
+                echo "The file recording the previous timestamp was not found"
+                MINUTES_SINCE_UPDATE=0
+            fi
             echo "Minutes elapsed since last update of this named Conda environment: $MINUTES_SINCE_UPDATE"
 
             if [ $MINUTES_SINCE_UPDATE -ge {{Param.NamedCondaEnvUpdateAfterMinutes}} ]; then
@@ -183,7 +200,14 @@ environment:
 
             # Make sure there's no incomplete environment hanging around
             for ENVS_DIR in $(conda info --json | python -c "import json, sys; v = json.load(sys.stdin); print('\n'.join(v['envs_dirs']))"); do
-                rm -rf $ENVS_DIR/$NAMED_CONDA_ENV
+                if [ -d $ENVS_DIR/$NAMED_CONDA_ENV ]; then
+                    echo "Removing directory $ENVS_DIR/$NAMED_CONDA_ENV for the environment"
+                    rm -rf $ENVS_DIR/$NAMED_CONDA_ENV
+                    if [ -d $ENVS_DIR/$NAMED_CONDA_ENV ]; then
+                        echo "ERROR: Could not remove the directory. Possibly a permissions error or a process holding a lock."
+                        exit 1
+                    fi
+                fi
             done
 
             # Create the virtual environment
@@ -192,9 +216,11 @@ environment:
                 $CONDA_PACKAGES \
                 $CHANNEL_OPTS
 
-            # Activate the Conda environment, capturing the environment variables for the session to use
+            # Activate the Conda environment
             python '{{Env.File.OpenJDVarsStart}}' .vars
+            set +u
             conda activate "$NAMED_CONDA_ENV"
+            set -u
             python '{{Env.File.OpenJDVarsCapture}}' .vars
 
             # Save the channels and packages used in the environment, to help out debugging
@@ -215,9 +241,11 @@ environment:
                 $CONDA_PACKAGES \
                 $CHANNEL_OPTS
 
-            # Activate the Conda environment, capturing the environment variables for the session to use
+            # Activate the Conda environment
             python '{{Env.File.OpenJDVarsStart}}' .vars
+            set +u
             conda activate '{{Session.WorkingDirectory}}/.env'
+            set -u
             python '{{Env.File.OpenJDVarsCapture}}' .vars
         fi
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

In exploratory testing, we've encountered some corner cases that were not handled in the package build scripts and queue environments.

### What was the solution? (How)

* When removing an environment directory, confirm that it was removed before proceeding, as permissions or a process lock could prevent that from succeeding.
* During environment activation, turn off bash strict variable checking, as some activation scripts expect `$VAR` to resolve to "" when it is undefined.
* When checking the time since last env update, check for the timestamp file first and assume 0 minutes if it is missing.

### What is the impact of this change?

Anyone using these samples will have fewer errors, and better messages when errors do occur.

### How was this change tested?

Updated a test farm's queue environment, then submitted all the sample package build recipes to it.

### Was this change documented?

No, it has no change to functionality.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*