### PR TITLE
feat: Add a sample conda package recipe for Maya and MtoA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 **/output/
 **/workspace/
 
+# The V-Ray source files do not have an extension to distinguish them
+conda_recipes/archive_files/vraystd_*
+
 **/*.tar.xz
 **/*.tar.gz
 **/*.tgz

--- a/conda_recipes/maya-2025/README.md
+++ b/conda_recipes/maya-2025/README.md
@@ -1,0 +1,76 @@
+# Maya 2025 conda build recipe
+
+## Instructions for Maya plugin packages
+
+This Maya conda build recipe configures the `MAYA_MODULE_PATH` environment variable
+to include several paths to search for plugin `.mod` files. When creating a plugin
+package, place its `.mod` file in one of these so that Maya loads the plugin at startup.
+
+* `$PREFIX/usr/autodesk/maya$MAYA_VERSION/modules`
+* `$PREFIX/usr/autodesk/modules/maya/$MAYA_VERSION`
+* `$PREFIX/usr/autodesk/modules/maya`
+
+## Download the archive file for Linux
+
+Download the Autodesk_Maya_2025_Linux_64bit.tgz full download file from Autodesk, and
+place it in the `conda_recipes/archive_files` directory in your git clone of the
+[https://github.com/aws-deadline/deadline-cloud-samples](deadline-cloud-samples) repository for
+submitting package build jobs,
+
+## Creating an archive file for Windows
+
+The Windows installer requires Administrator permissions that are not available in most conda package
+build environments, such as on a Deadline Cloud service-managed fleets. Follow these instructions to
+install Maya 2025 on a freshly created EC2 instance as Administrator, and create an archive file
+for use by the conda build recipe.
+
+1. Launch a fresh Windows Server 2022 instance.
+    1. From the AWS EC2 management console, select the option to Launch instance.
+    2. Enter instance name "Create Windows Maya archive".
+    3. Select "Microsoft Windows Server 2022 Base" for the AMI. (As of writing, Windows Server 2025 did not work with these instructions.)
+    4. Select an instance type with enough vCPUs and RAM, for example c5.4xlarge has 8 vCPUs and 16 GiB RAM.
+    5. Select "Proceed without a key pair" for the "Key pair (login)" option.
+    6. We will use SSM port forwarding to avoid sending RDP protocol traffic directly over the internet.
+        1. Make sure that "Allow RDP traffic" is unchecked.
+        2. Make sure the security group does not allow any inbound traffic.
+        3. Make sure to remove any public IP addresses from the instance.
+    7. Set the storage to at least 64 GiB. Adjust other settings as you like, e.g. if you want an encrypted volume of type gp3.
+    8. Select "Launch instance."
+    9. If it asks, select "Proceed without key pair" and proceed with the launch.
+    10. Once it launched, navigate to the instance detail page. Select "Connect," and with "Session manager" selected, again select "Connect."
+        If it says "SSM Agent is not online," you may have to wait a few minutes for it to initialize.
+    11. Create a secure password for the Administrator account. From the Administrator powershell window that session manager,
+        enter the following command with your secure password substituted to change the password.
+        1. `net user Administrator MY_SECURE_PASSWORD`
+2. Connect to the instance with SSM port forwarding and RDP.
+    1. Install or update the AWS CLI v2 from https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html.
+    2. Install or update the Session Manager plugin from https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html.
+    3. Run the following command, using AWS credentials that have suitable permissions, to start the SSM port forwarding. Replace INSTANCE_ID with the one you launched.
+        1. `aws ssm start-session --document-name AWS-StartPortForwardingSession --parameters "localPortNumber=33389,portNumber=3389" --target INSTANCE_ID`
+    4. Open RDP, and enter the following connection details:
+        1. Computer: `localhost:33389`
+        2. User name: `Administrator`
+    5. Enter the password you set for Administrator after you created the instance. You should now have a remote desktop session to your instance.
+3. Install Maya 2025 on the instance.
+    1. Download the Maya 2025 Direct Downloads self-extracting files you got from Autodesk. For example, the files
+       `Autodesk_Maya_2025_Windows_64bit_dlm_001_002.sfx.exe` and `Autodesk_Maya_2025_Windows_64bit_dlm_002_002.sfx.exe`.
+       If you have placed them on S3, you can use a PowerShell command like `Read-S3Object -BucketName MY_BUCKET_NAME -Key MY_UPLOADED_KEY_NAME -File MY_FILE_NAME`.
+    2. Run the self-extracting file. Accept the prompts to continue.
+    3. The Maya installer will launch. Proceed to install as normal with the components you want included.
+    4. Restart the instance to ensure that changes from the installation took effect.
+    5. Log in with a powershell window again, either from the EC2 management console session manager or reconnecting to RDP.
+    5. Run the following commands to create the archive. Note specifically that we are making a copy of the ProductInformation.pit file, so that we
+       can use it to tell the applications about available licenses via the thin client features.
+        1. `cd 'C:\Program Files\Autodesk\'`
+        2. `$MAYA_VERSION = '2025'`
+        3. `$MAYA_UPDATE = '0'`
+        2. `Copy-Item "C:\ProgramData\Autodesk\Adlm\ProductInformation.pit" -Destination "C:\Program Files\Autodesk\"`
+        2. `Compress-Archive -Path Arnold, Bifrost, LookdevX, Maya${MAYA_VERSION}, MayaUSD, ProductInformation.pit -DestinationPath Autodesk_Maya_${MAYA_VERSION}_${MAYA_UPDATE}_Windows_installation.zip`
+        3. `(Get-FileHash -Path Autodesk_Maya_${MAYA_VERSION}_${MAYA_UPDATE}_Windows_installation.zip -Algorithm SHA256).Hash.ToLower()`
+    6. Record the file sha256 hash, and upload the archive to your private S3 bucket. You can use a PowerShell command like
+       `Write-S3Object -BucketName MY_BUCKET_NAME -Key Autodesk_Maya_${MAYA_VERSION}_${MAYA_UPDATE}_Windows_installation.zip -File Autodesk_Maya_${MAYA_VERSION}_${MAYA_UPDATE}_Windows_installation.zip`.
+4. From the AWS EC2 management console, select the instance you used and terminate it.
+5. Download the zip file to the `conda_recipes/archive_files` directory in your git clone of the
+   [deadline-cloud-samples](https://github.com/aws-deadline/deadline-cloud-samples) repository for
+   submitting package build jobs, and update the Windows source artifact hash in the maya-2025 conda
+   build recipe meta.yaml.

--- a/conda_recipes/maya-2025/deadline-cloud.yaml
+++ b/conda_recipes/maya-2025/deadline-cloud.yaml
@@ -1,0 +1,16 @@
+condaPlatforms:
+  - platform: linux-64
+    defaultSubmit: true
+    sourceArchiveFilename:
+    - Autodesk_Maya_2025_Linux_64bit.tgz
+    sourceDownloadInstructions: 'Download the Autodesk_Maya_2025_Linux_64bit.tgz full download file from Autodesk.'
+    buildTool: rattler-build
+  - platform: win-64
+    defaultSubmit: false
+    sourceArchiveFilename:
+    - Autodesk_Maya_2025_0_Windows_installation.zip
+    sourceDownloadInstructions: 'Follow the instructions in README.md to construct the archive zip file.'
+    buildTool: conda-build
+jobParameters:
+  - name: CondaChannels
+    value: conda-forge

--- a/conda_recipes/maya-2025/recipe/bld.bat
+++ b/conda_recipes/maya-2025/recipe/bld.bat
@@ -1,0 +1,2 @@
+bash %RECIPE_DIR%/build_win.sh
+if errorlevel 1 exit 1

--- a/conda_recipes/maya-2025/recipe/build.sh
+++ b/conda_recipes/maya-2025/recipe/build.sh
@@ -1,0 +1,119 @@
+#!/bin/sh
+
+# Echo all the commands so debugging from log output is simpler
+set -x
+# Fail the script if any commands it runs fail
+set -euo pipefail
+
+# The version without the update number
+MAYA_VERSION=${PKG_VERSION%.*}
+# The location within $PREFIX where the RPM file extracts Maya
+AUTODESK_ROOT="usr/autodesk"
+MAYA_ROOT="$AUTODESK_ROOT/maya$MAYA_VERSION"
+INSTALL_DIR="$PREFIX/$MAYA_ROOT"
+
+cd "$PREFIX"
+
+# Extract the Maya RPM
+rpm2cpio "$SRC_DIR/installer/Packages"/Maya${MAYA_VERSION}_64-$PKG_VERSION-*.x86_64.rpm | cpio -idm
+
+# Remove examples, they're not needed on the farm
+rm -r "$MAYA_ROOT"/Examples
+
+# Maya needs this symlink that rpm2cpio did not create
+ln -r -s "$INSTALL_DIR/bin/maya$MAYA_VERSION" "$INSTALL_DIR/bin/maya"
+
+# Install dependencies not available on Deadline Cloud service-managed fleets
+# from the system package manager, dnf.
+mkdir -p "$SRC_DIR/download"
+cd "$SRC_DIR/download"
+dnf download --resolve -y freetype alsa-lib fontconfig harfbuzz libbrotli graphite2 libxkbfile
+for RPM_FILE in *.rpm; do
+    rpm2cpio "$RPM_FILE" | cpio -idm
+done
+
+# Use patchelf to add relative RPATHs to the .so files where necessary.
+# This is to follow the recommendation of https://docs.conda.io/projects/conda-build/en/latest/resources/use-shared-libraries.html
+# to never use LD_LIBRARY_PATH in Conda environments.
+
+# Copy the .so libraries to the Maya lib directory, adding to their RPATHs so they see each other
+find . -type f,l -iname "*.so.*" -exec patchelf --add-rpath '$ORIGIN/.' {} \;
+find . -type f,l -iname "*.so.*" -exec cp -P {} "$INSTALL_DIR/lib/" \;
+
+# The Maya RPM has libraries in both $MAYA_ROOT/lib and $MAYA_ROOT/lib/el9
+patchelf --add-rpath '$ORIGIN/../..' "$INSTALL_DIR"/lib/python*/site-packages/*.so
+patchelf --add-rpath '$ORIGIN/../..' "$INSTALL_DIR"/lib/python*/site-packages/*/*.so
+patchelf --add-rpath '$ORIGIN/../..' "$INSTALL_DIR"/lib/python*/lib-dynload/*.so
+patchelf --add-rpath '$ORIGIN/../../el9' "$INSTALL_DIR"/lib/python*/lib-dynload/*.so
+
+# Work around rattler-build issue https://github.com/prefix-dev/rattler-build/issues/1191 that it excludes intentional .pyc files without corresponding .py.
+# Rename every .pyc file to .pyc2.
+for PYC in "$INSTALL_DIR"/lib/python*/site-packages/maya/*.pyc; do
+    mv "$PYC" "${PYC}2"
+done
+
+# Use thin client licensing configuration to use the ProductInformation.pit from the Arnold installation.
+#
+# To learn more, see the Autodesk article "Thin Client Licensing for Maya and MotionBuilder"
+# at https://www.autodesk.com/support/technical/article/caas/tsarticles/ts/2zqRBCuGDrcPZDzULJQ27p.html
+# and the Arnold support tip "error: (44) Product key not found"
+# at https://arnoldsupport.com/2022/02/02/error-44-product-key-not-found/.
+
+# Use the ProductInformation.pit from the included Arnold
+unzip -j "$SRC_DIR/installer/Packages/package.zip" bin/ProductInformation.pit -d "$INSTALL_DIR"
+
+cat <<EOF > "$INSTALL_DIR"/AdlmThinClientCustomEnv.xml
+<?xml version="1.0"encoding="utf-8"?>
+<ADLMCUSTOMENV VERSION="1.0.0.0">
+    <PLATFORM OS="Linux">
+        <KEY ID="ADLM_PIT_FILE_LOCATION">
+        <!--Path to the ProductInformation.pit file-->
+        <!--Default: /var/opt/Autodesk/Adlm/.config-->
+        <STRING>$INSTALL_DIR</STRING>
+        </KEY>
+    </PLATFORM>
+</ADLMCUSTOMENV>
+EOF
+
+# See https://docs.conda.io/projects/conda/en/latest/dev-guide/deep-dives/activation.html
+# for details on activation.
+
+# Activation scripts to set/unset environment variables
+mkdir -p "$PREFIX/etc/conda/activate.d"
+cat <<EOF > "$PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.sh"
+export MAYA_LOCATION="\$CONDA_PREFIX/$MAYA_ROOT"
+export MAYA_VERSION="$MAYA_VERSION"
+
+# Turn off the Maya application home for the render farm
+export MAYA_NO_HOME=1
+
+# Set the Maya module path to include the virtual environment equivalent of the default system module paths
+export MAYA_MODULE_PATH="\$CONDA_PREFIX/usr/autodesk/maya$MAYA_VERSION/modules:\$CONDA_PREFIX/usr/autodesk/modules/maya/$MAYA_VERSION:\$CONDA_PREFIX/usr/autodesk/modules/maya"
+export PATH="\$MAYA_LOCATION/bin:\$PATH"
+
+# Set thin client mode to use the correct ProductInformation.pit file
+export AUTODESK_ADLM_THINCLIENT_ENV='$INSTALL_DIR/AdlmThinClientCustomEnv.xml'
+export MAYA_LEGACY_THINCLIENT=1
+
+# Work around rattler-build issue https://github.com/prefix-dev/rattler-build/issues/1191 that it excludes intentional .pyc files without corresponding .py.
+# Rename every .pyc2 file back to .pyc.
+if [ -f "\$MAYA_LOCATION"/lib/python*/site-packages/maya/OpenMaya.pyc2 ]; then
+    for PYC2 in "\$MAYA_LOCATION"/lib/python*/site-packages/maya/*.pyc2; do
+        mv "\$PYC2" "\${PYC2%2}"
+    done
+fi
+
+EOF
+cat "$PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.sh"
+
+mkdir -p "$PREFIX/etc/conda/deactivate.d"
+cat <<EOF > "$PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.sh"
+unset MAYA_LEGACY_THINCLIENT
+unset AUTODESK_ADLM_THINCLIENT_ENV
+unset MAYA_MODULE_PATH
+export PATH="\${PATH/\$MAYA_LOCATION\\/bin:/}"
+unset MAYA_NO_HOME
+unset MAYA_VERSION
+unset MAYA_LOCATION
+EOF
+cat "$PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.sh"

--- a/conda_recipes/maya-2025/recipe/build_win.sh
+++ b/conda_recipes/maya-2025/recipe/build_win.sh
@@ -1,0 +1,127 @@
+# Echo all the commands so debugging from log output is simpler
+set -x
+# Fail the script if any commands it runs fail
+set -euo pipefail
+
+# The version without the update number
+MAYA_VERSION=${PKG_VERSION%.*}
+# The location within $PREFIX where Maya will be installed
+AUTODESK_ROOT="usr/Autodesk"
+MAYA_ROOT="$AUTODESK_ROOT/Maya$MAYA_VERSION"
+INSTALL_DIR="$PREFIX/$MAYA_ROOT"
+
+mkdir -p "$PREFIX/$AUTODESK_ROOT"
+
+pushd $SRC_DIR
+find .
+popd
+
+# Move all the files into the prefix. Use cmd to move the files as it works
+# more reliably with permissions and locking.
+cmd <<EOF
+move $SRC_DIR\\installer\\Maya$MAYA_VERSION "$PREFIX\\$AUTODESK_ROOT\\"
+move $SRC_DIR\\installer\\ProductInformation.pit "$INSTALL_DIR\\"
+EOF
+
+# See https://www.autodesk.com/support/technical/article/caas/tsarticles/ts/75wD5ycdkRVPHQtG4eUwBL.html
+# titled "Deploying Maya Batch on the Cloud" about making Maya for Windows cloud compliant.
+cd "$INSTALL_DIR"
+./bin/mayapy.exe "$SRC_DIR/cleanMayaForCloud.py"
+
+# The conda-build environment is configured for packaging one pypi package into one conda package.
+# We turn off the following defaults for the below mayapy.exe pip install.
+unset PIP_NO_DEPENDENCIES
+unset PIP_IGNORE_INSTALLED
+unset PIP_NO_INDEX
+
+# Currently, the maya-openjd command from the deadline-cloud-for-maya package requires that
+# pywin32 be installed inside Maya's Python. This command adds it to the Maya package.
+./bin/mayapy.exe -m pip install pywin32
+
+## You can uncomment this to get a verbose listing of all the files
+# pushd $PREFIX
+# find .
+# popd
+
+# Remove docs, they're not needed on the farm
+rm -r "$INSTALL_DIR"/docs
+
+# Remove examples, they're not needed on the farm
+rm -r "$INSTALL_DIR"/Examples
+
+# Use thin client licensing configuration to use the ProductInformation.pit from the Arnold installation.
+#
+# To learn more, see the Autodesk article "Thin Client Licensing for Maya and MotionBuilder"
+# at https://www.autodesk.com/support/technical/article/caas/tsarticles/ts/2zqRBCuGDrcPZDzULJQ27p.html
+# and the Arnold support tip "error: (44) Product key not found"
+# at https://arnoldsupport.com/2022/02/02/error-44-product-key-not-found/.
+
+cat <<EOF > "$INSTALL_DIR"/AdlmThinClientCustomEnv.xml
+<?xml version="1.0"encoding="utf-8"?>
+<ADLMCUSTOMENV VERSION="1.0.0.0">
+    <PLATFORM OS="Linux">
+        <KEY ID="ADLM_PIT_FILE_LOCATION">
+        <!--Path to the ProductInformation.pit file-->
+        <!--Default: /var/opt/Autodesk/Adlm/.config-->
+        <STRING>$INSTALL_DIR</STRING>
+        </KEY>
+    </PLATFORM>
+</ADLMCUSTOMENV>
+EOF
+
+# See https://docs.conda.io/projects/conda/en/latest/dev-guide/deep-dives/activation.html
+# for details on activation. The Deadline Cloud sample queue environments use bash
+# to activate environments on Windows, so we recommend always producing both .bat and .sh files.
+
+mkdir -p "$PREFIX/etc/conda/activate.d"
+mkdir -p "$PREFIX/etc/conda/deactivate.d"
+
+cat <<EOF > "$PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.sh"
+export MAYA_VERSION=$MAYA_VERSION
+export MAYA_LOCATION='$INSTALL_DIR'
+export PATH="\$(cygpath '$INSTALL_DIR/bin'):\$PATH"
+
+# Turn off the Maya application home for the render farm
+export MAYA_NO_HOME=1
+
+# Set the Maya module path to include the virtual environment equivalent of a system default path
+export MAYA_MODULE_PATH='$PREFIX/usr/autodesk/maya$MAYA_VERSION/modules;$PREFIX/usr/autodesk/modules/maya/$MAYA_VERSION;$PREFIX/usr/autodesk/modules/maya'
+
+# Set thin client mode to use the correct ProductInformation.pit file
+export AUTODESK_ADLM_THINCLIENT_ENV='$INSTALL_DIR/AdlmThinClientCustomEnv.xml'
+export MAYA_LEGACY_THINCLIENT=1
+EOF
+cat "$PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.sh"
+
+cat <<EOF > "$PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.bat"
+set "MAYA_LOCATION=$INSTALL_DIR"
+set "MAYA_VERSION=$MAYA_VERSION"
+set "PATH=$INSTALL_DIR/bin;%PATH%"
+set MAYA_NO_HOME=1
+set MAYA_MODULE_PATH="$PREFIX/usr/autodesk/maya$MAYA_VERSION/modules;$PREFIX/usr/autodesk/modules/maya/$MAYA_VERSION;$PREFIX/usr/autodesk/modules/maya"
+set "AUTODESK_ADLM_THINCLIENT_ENV=$INSTALL_DIR/AdlmThinClientCustomEnv.xml"
+set MAYA_LEGACY_THINCLIENT=1
+EOF
+cat "$PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.bat"
+
+cat <<EOF > "$PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.sh"
+unset MAYA_LEGACY_THINCLIENT
+unset AUTODESK_ADLM_THINCLIENT_ENV
+unset MAYA_MODULE_PATH
+unset MAYA_NO_HOME
+export PATH="\${PATH/\$(cygpath '$INSTALL_DIR/bin'):/}"
+unset MAYA_LOCATION
+unset MAYA_VERSION
+EOF
+cat "$PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.sh"
+
+cat <<EOF > "$PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.bat"
+set "PATH=%PATH:$INSTALL_DIR/bin;=%"
+set MAYA_LEGACY_THINCLIENT=
+set AUTODESK_ADLM_THINCLIENT_ENV=
+set MAYA_MODULE_PATH=
+set MAYA_NO_HOME=
+set MAYA_LOCATION=
+set MAYA_VERSION=
+EOF
+cat "$PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.bat"

--- a/conda_recipes/maya-2025/recipe/meta.yaml
+++ b/conda_recipes/maya-2025/recipe/meta.yaml
@@ -1,0 +1,35 @@
+# Recipe in conda-build format.
+# This recipe is only for Windows, see recipe.yaml for the Linux recipe in rattler-build format.
+
+# See https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html for information
+# about this file.
+
+{% set version = "2025.0" %}
+
+package:
+  name: maya
+  version: "{{ version }}"
+
+source:
+- url: archive_files/Autodesk_Maya_{{ version.replace(".", "_") }}_Windows_installation.zip # [win64]
+  sha256: 57490abc4e1d7c7a8a057a29d718e79172a3ecd17cc04c5863600b11fc437d57 # [win64]
+  folder: installer
+# See https://www.autodesk.com/support/technical/article/caas/tsarticles/ts/75wD5ycdkRVPHQtG4eUwBL.html
+# titled "Deploying Maya Batch on the Cloud" about making Maya for Windows cloud compliant.
+- url: https://download.autodesk.com/us/support/files/maya_batch_cloud/cleanMayaForCloud.py # [win64]
+  sha256: 8605e6e28ed5d47ee79156a42166e85750b041456679cb7339128113f2328e0a # [win64]
+
+build:
+  skip: true  # [not win64]
+  number: 0
+  # These build options for repackaging an application
+  # https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html
+  binary_relocation: False
+  detect_binary_files_with_prefix: False
+  missing_dso_whitelist:
+  - "**"
+
+about:
+  home: https://www.autodesk.com/products/maya/overview
+  license: Commercial
+  summary: Maya is professional 3D software for creating realistic characters and blockbuster-worthy effects.

--- a/conda_recipes/maya-2025/recipe/recipe.yaml
+++ b/conda_recipes/maya-2025/recipe/recipe.yaml
@@ -1,0 +1,60 @@
+# Recipe in rattler-build format.
+# See https://prefix-dev.github.io/rattler-build/latest/
+
+context:
+  version: "2025.0"
+  major_version: "2025"
+  minor_version: "0"
+
+package:
+  name: maya
+  version: ${{ version }}
+
+source:
+  - if: linux
+    then:
+      url: file://archive_files/Autodesk_Maya_${{ major_version }}_Linux_64bit.tgz
+      sha256: 72ac8d1d4aed4fe19b37b995e62ed8507186e5f382fb7bac35fe11f65748bd93
+      target_directory: installer
+  - if: win
+    then:
+      - url: file://archive_files/Autodesk_Maya_${{ major_version }}_${{ minor_version }}_Windows_installation.zip
+        sha256: 2a8943ef911ac88faf2342e4feda6ac1a1c38aecbd164ea6441263283696c505
+        target_directory: installer
+      # See https://www.autodesk.com/support/technical/article/caas/tsarticles/ts/75wD5ycdkRVPHQtG4eUwBL.html
+      # titled "Deploying Maya Batch on the Cloud" about making Maya for Windows cloud compliant.
+      - url: https://download.autodesk.com/us/support/files/maya_batch_cloud/cleanMayaForCloud.py
+        sha256: 8605e6e28ed5d47ee79156a42166e85750b041456679cb7339128113f2328e0a
+
+build:
+  number: 0
+  # These build options for repackaging an application
+  # https://prefix-dev.github.io/rattler-build/latest/build_options/#prefix-detection-replacement-options
+  prefix_detection:
+    ignore_binary_files: True
+  # https://prefix-dev.github.io/rattler-build/latest/build_options/#dynamic-linking-configuration
+  dynamic_linking:
+    binary_relocation: False
+    missing_dso_allowlist:
+    - "**"
+
+requirements:
+  build:
+    - if: linux
+      then:
+      - patchelf
+
+tests:
+  - script:
+    # Maya's Python interpreter
+    - mayapy --help
+    # Confirm that mayapy can initialize maya.standalone, and that both OpenMaya 1.0 and 2.0 are available
+    - mayapy -c 'import maya; import maya.standalone; import maya.OpenMaya as om1; import maya.api.OpenMaya as om2; maya.standalone.initialize(); print("Hello from mayapy"); maya.standalone.uninitialize()'
+    # The maya -batch command
+    - maya -batch -command 'print "Hello from maya -batch"; quit -exitCode 0 -force'
+
+
+about:
+  homepage: https://www.autodesk.com/products/maya/overview
+  license: LicenseRef-AutodeskEULA
+  summary: Maya is professional 3D software for creating realistic characters and blockbuster-worthy effects.

--- a/conda_recipes/maya-mtoa-2025/README.md
+++ b/conda_recipes/maya-mtoa-2025/README.md
@@ -1,0 +1,6 @@
+# Maya to Arnold 2025 conda build recipe
+
+This recipe needs the same source archives as the [Maya 2025 recipe](../maya-2025).
+See the [README from the maya-2025 package recipe](../maya-2025/README.md) for
+instructions on how to acquire or create them, and details about how a conda package
+for a Maya plugin can integrate.

--- a/conda_recipes/maya-mtoa-2025/deadline-cloud.yaml
+++ b/conda_recipes/maya-mtoa-2025/deadline-cloud.yaml
@@ -1,0 +1,13 @@
+condaPlatforms:
+  - platform: linux-64
+    defaultSubmit: true
+    sourceArchiveFilename:
+    - Autodesk_Maya_2025_Linux_64bit.tgz
+    sourceDownloadInstructions: 'Download the Autodesk_Maya_2025_Linux_64bit.tgz full download file from Autodesk.'
+    buildTool: rattler-build
+  - platform: win-64
+    defaultSubmit: false
+    sourceArchiveFilename:
+    - Autodesk_Maya_2025_0_Windows_installation.zip
+    sourceDownloadInstructions: 'Follow the instructions in README.md to construct the archive zip file.'
+    buildTool: conda-build

--- a/conda_recipes/maya-mtoa-2025/recipe/bld.bat
+++ b/conda_recipes/maya-mtoa-2025/recipe/bld.bat
@@ -1,0 +1,2 @@
+bash %RECIPE_DIR%/build_win.sh
+if errorlevel 1 exit 1

--- a/conda_recipes/maya-mtoa-2025/recipe/build.sh
+++ b/conda_recipes/maya-mtoa-2025/recipe/build.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+set -xeuo pipefail
+
+# Get the version number without the update
+MAYA_VERSION=${PKG_VERSION%.*}
+
+# This is where to install MtoA within the installation prefix
+MTOA_ROOT="usr/autodesk/arnold/maya$MAYA_VERSION"
+
+# Change the current directory to the installation prefix
+mkdir -p "$PREFIX/$MTOA_ROOT"
+cd "$PREFIX/$MTOA_ROOT"
+
+# Extract the MtoA package file into the installation prefix
+unzip "$SRC_DIR/installer/Packages/package.zip"
+
+# Create the mtoa.mod file so Maya loads the plugin.
+#
+# The maya package has set the Maya module path to include virtual environment-equivalents of
+# the system module paths, so this is the usual installation location after the virtual environment
+# prefix.
+mkdir -p "$PREFIX/usr/autodesk/modules/maya/$MAYA_VERSION"
+cat <<EOF > "$PREFIX/usr/autodesk/modules/maya/$MAYA_VERSION/mtoa.mod"
++ mtoa any $PREFIX/$MTOA_ROOT
+PATH +:= bin
+MAYA_CUSTOM_TEMPLATE_PATH +:= scripts/mtoa/ui/templates
+MAYA_SCRIPT_PATH +:= scripts/mtoa/mel
+MAYA_RENDER_DESC_PATH += $PREFIX/$MTOA_ROOT
+MAYA_PXR_PLUGINPATH_NAME += $PREFIX/$MTOA_ROOT/usd
+EOF
+
+# Make symlinks to the MtoA commands from the Maya installation
+mkdir -p "$PREFIX/bin"
+for BINARY in kick maketx noice oslc oslinfo; do
+    chmod u+x "$PREFIX/$MTOA_ROOT/bin/$BINARY"
+    ln -r -s "$PREFIX/$MTOA_ROOT/bin/$BINARY" "$MAYA_LOCATION/bin/$BINARY"
+done

--- a/conda_recipes/maya-mtoa-2025/recipe/build_win.sh
+++ b/conda_recipes/maya-mtoa-2025/recipe/build_win.sh
@@ -1,0 +1,81 @@
+# Echo all the commands so debugging from log output is simpler
+set -x
+# Fail the script if any commands it runs fail
+set -euo pipefail
+
+# The location within $PREFIX where Maya will be installed
+# The value of $MAYA_VERSION comes from the maya package dependency
+AUTODESK_ROOT="opt/Autodesk"
+MTOA_ROOT="opt/Autodesk/Arnold/maya$MAYA_VERSION"
+INSTALL_DIR="$PREFIX/$MTOA_ROOT"
+
+mkdir -p "$PREFIX/$AUTODESK_ROOT"
+
+ls "$SRC_DIR/installer"
+
+# Move all the files into the prefix. Using cmd to move the files as it works
+# more reliably with permissions and locking.
+cmd <<EOF
+move $SRC_DIR\\installer\\Arnold "$PREFIX\\$AUTODESK_ROOT"
+EOF
+
+## You can uncomment this to get a verbose listing of all the files
+# pushd $PREFIX
+# find .
+# popd
+
+# Remove installers, they're not needed on the farm
+rm -r "$INSTALL_DIR"/license/installer
+
+# Remove docs, they're not needed on the farm
+rm -r "$INSTALL_DIR"/docs
+
+# Create the mtoa.mod file so Maya loads the plugin.
+#
+# The maya package has set the Maya module path to include virtual environment-equivalents of
+# the system module paths, so this is the usual installation location after the virtual environment
+# prefix.
+mkdir -p "$PREFIX/usr/Autodesk/modules/maya/$MAYA_VERSION"
+cat <<EOF > "$PREFIX/usr/Autodesk/modules/maya/$MAYA_VERSION/mtoa.mod"
++ mtoa any $PREFIX/$MTOA_ROOT
+PATH +:= bin
+MAYA_CUSTOM_TEMPLATE_PATH +:= scripts/mtoa/ui/templates
+MAYA_SCRIPT_PATH +:= scripts/mtoa/mel
+MAYA_RENDER_DESC_PATH += $PREFIX/$MTOA_ROOT
+MAYA_PXR_PLUGINPATH_NAME += $PREFIX/$MTOA_ROOT/usd
+EOF
+
+# See https://docs.conda.io/projects/conda/en/latest/dev-guide/deep-dives/activation.html
+# for details on activation. The Deadline Cloud sample queue environments use bash
+# to activate environments on Windows, so we recommend always producing both .bat and .sh files.
+
+mkdir -p "$PREFIX/etc/conda/activate.d"
+mkdir -p "$PREFIX/etc/conda/deactivate.d"
+
+cat <<EOF > "$PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.sh"
+export MTOA_VERSION=$MAYA_VERSION
+export MTOA_LOCATION='$INSTALL_DIR'
+export PATH="\$(cygpath '$INSTALL_DIR/bin'):\$PATH"
+EOF
+cat "$PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.sh"
+
+cat <<EOF > "$PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.bat"
+set "MTOA_LOCATION=$INSTALL_DIR"
+set "MTOA_VERSION=$MAYA_VERSION"
+set "PATH=$INSTALL_DIR/bin;%PATH%"
+EOF
+cat "$PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.bat"
+
+cat <<EOF > "$PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.sh"
+export PATH="\${PATH/\$(cygpath '$INSTALL_DIR/bin'):/}"
+unset MTOA_LOCATION
+unset MTOA_VERSION
+EOF
+cat "$PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.sh"
+
+cat <<EOF > "$PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.bat"
+set "PATH=%PATH:$INSTALL_DIR/bin;=%"
+set MTOA_LOCATION=
+set MTOA_VERSION=
+EOF
+cat "$PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.bat"

--- a/conda_recipes/maya-mtoa-2025/recipe/meta.yaml
+++ b/conda_recipes/maya-mtoa-2025/recipe/meta.yaml
@@ -1,0 +1,34 @@
+# See https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html for information
+# about this file.
+
+{% set version = "2025.0" %}
+
+package:
+  name: maya-mtoa
+  version: {{ version }}
+
+source:
+source:
+- url: archive_files/Autodesk_Maya_{{ version.replace(".", "_") }}_Windows_installation.zip # [win64]
+  sha256: 57490abc4e1d7c7a8a057a29d718e79172a3ecd17cc04c5863600b11fc437d57 # [win64]
+  folder: installer
+
+build:
+  number: 0
+  # These build options for repackaging an application
+  # https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html
+  binary_relocation: False
+  detect_binary_files_with_prefix: False
+  missing_dso_whitelist:
+  - "**"
+
+requirements:
+  build:
+    - maya =={{ version }}.*
+  run:
+    - maya =={{ version }}.*
+
+about:
+  home: https://help.autodesk.com/view/ARNOL/ENU/?guid=arnold_for_maya_am_Arnold_for_Maya_User_Guide_html
+  license: Commercial
+  summary: Autodesk Arnold is an advanced cross-platform rendering library, or API, developed by Solid Angle and used by a number of prominent organizations in film, television, and animation, including Sony Pictures Imageworks. It was developed as a photo-realistic, physically-based ray tracing alternative to traditional scanline-based rendering software for CG animation.

--- a/conda_recipes/maya-mtoa-2025/recipe/recipe.yaml
+++ b/conda_recipes/maya-mtoa-2025/recipe/recipe.yaml
@@ -1,0 +1,58 @@
+# Recipe in rattler-build format.
+# See https://prefix-dev.github.io/rattler-build/latest/
+
+context:
+  version: "2025.0"
+  major_version: "2025"
+  minor_version: "0"
+
+package:
+  name: maya-mtoa
+  version: ${{ version }}
+
+source:
+  - if: linux
+    then:
+      url: file://archive_files/Autodesk_Maya_${{ major_version }}_Linux_64bit.tgz
+      sha256: 72ac8d1d4aed4fe19b37b995e62ed8507186e5f382fb7bac35fe11f65748bd93
+      target_directory: installer
+  - if: win
+    then:
+      - url: file://archive_files/Autodesk_Maya_${{ major_version }}_Windows_installation.zip
+        sha256: 2a8943ef911ac88faf2342e4feda6ac1a1c38aecbd164ea6441263283696c505
+        target_directory: installer
+      - url: https://download.autodesk.com/us/support/files/maya_batch_cloud/cleanMayaForCloud.py
+        sha256: 8605e6e28ed5d47ee79156a42166e85750b041456679cb7339128113f2328e0a
+
+build:
+  number: 0
+  # These build options for repackaging an application
+  # https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html
+  prefix_detection:
+    ignore_binary_files: True
+  dynamic_linking:
+    binary_relocation: False
+    missing_dso_allowlist:
+    - "**"
+
+requirements:
+  build:
+    - maya ${{ version }}.*
+  run:
+    - maya ${{ version }}.*
+
+tests:
+  - script:
+    # Maya's Python interpreter
+    - mayapy --help
+    # Confirm that the mtoa plugin is available in mayapy
+    # - mayapy -c 'import maya.standalone; maya.standalone.initialize(); import mtoa; from maya.cmds import arnoldRender; print("Hello from mayapy"); print(dir(mtoa)); maya.standalone.uninitialize()'
+    - mayapy -c 'import maya.standalone; maya.standalone.initialize(); import mtoa; print("Hello from mayapy"); print(dir(mtoa)); maya.standalone.uninitialize()'
+    # The maya -batch command
+    - maya -batch -command 'print "Hello from maya -batch"; quit -exitCode 0 -force'
+
+
+about:
+  homepage: https://www.autodesk.com/products/maya/overview
+  license: LicenseRef-AutodeskEULA
+  summary: Maya is professional 3D software for creating realistic characters and blockbuster-worthy effects.

--- a/job_bundles/turntable_with_maya_arnold/template.yaml
+++ b/job_bundles/turntable_with_maya_arnold/template.yaml
@@ -188,7 +188,7 @@ parameterDefinitions:
 - name: CondaPackages
   type: STRING
   description: Choose which Conda packages to install for the render. Requires a conda queue environment to process the value.
-  default: maya=2024 maya-mtoa maya-openjd=0.14 ffmpeg
+  default: maya>=2024 maya-mtoa maya-openjd=0.14 ffmpeg
   userInterface:
     control: LINE_EDIT
     label: Conda Packages


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

While bringing applications to Deadline Cloud service-managed fleets is open-ended with custom [queue environments](https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/provide-applications.html#provide-applications-other-package), its default configuration consumes conda packages. The best way to bring your own applications distributed with installers for use by conda is not obvious, but a set of sample package recipes provides a great starting point, and we want to grow the set of samples.

### What was the solution? (How)

Implement a sample package recipe for Autodesk Maya 2025 that works both on Linux and Windows. Add a second sample for MtoA, the Arnold renderer plugin for Maya, that integrates with the first one.

* Linux recipes are using rattler-build, Windows recipes using conda-build
* Supports both Linux and Windows
* The Linux recipe uses the upstream artifact from Autodesk
* The Windows recipe includes instructions on how to create a source artifact in the recipe README
* Both recipes include many comments to explain their structure
* Modify the Maya/Arnold turntable sample to use Maya >= 2024 instead of requiring specifically 2024.

Filed an issue with rattler-build about its behavior excluding .pyc files: https://github.com/prefix-dev/rattler-build/issues/1191

### What is the impact of this change?

Customers can create their own Maya package, and can use the example 

### How was this change tested?

Submitted package builds, and then submitted the Maya/Arnold turntable sample to render with those packages. Verified the newly built packages were used, and that the output video is as expected.

### Was this change documented?

The recipe includes README content.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*