### PR TITLE
feat: Add Husk USD Render job with asset introspection

### DIFF
--- a/job_bundles/README.md
+++ b/job_bundles/README.md
@@ -103,3 +103,9 @@ or use the `deadline.client.api.create_job_from_job_bundle` function in the [`de
 If you do not want to use the `deadline` Python package's support for features like job attachments, you can also submit the job template by calling the
 [deadline:CreateJob API](https://docs.aws.amazon.com/deadline-cloud/latest/APIReference/API_CreateJob.html) directly.
 
+
+## Example Husk USD Render with Asset Introspection 
+
+The [houdini_husk_usd_render](houdini_husk_usd_render) sample shows how to use the Houdini Husk CLI USD renderer using a short job template and service-provided Conda packages.
+Additionally, this sample shows how to write a custom asset introspection tool for job attachments, ensuring that only the required data is uploaded when using job attachments 
+while removing manual steps of the artists having to attach the required files.

--- a/job_bundles/README.md
+++ b/job_bundles/README.md
@@ -57,6 +57,7 @@ and a short script that substitutes job parameters and the Frame task parameter 
 * [keyshot_standalone](keyshot_standalone)
 * [afterfx_render_one_task](afterfx_render_one_task)
 * [maya_cli_render](maya_cli_render)
+* [houdini_husk_usd_render](houdini_husk_usd_render)
 
 If you've created a similar job for your favorite DCC, see [CONTRIBUTING.md](../CONTRIBUTING.md) for how to add it here.
 

--- a/job_bundles/houdini_husk_usd_render/README.md
+++ b/job_bundles/houdini_husk_usd_render/README.md
@@ -1,0 +1,60 @@
+# SideFX Houdini Husk USD Render
+
+## Background
+
+Husk is a CLI application provided with SideFX Houdini that renders Universal Scene Description(USD) files.
+By default Husk renders using the Houdini Karma renderer but Husk supports any Hydra-compatible USD render delegate. 
+
+
+## Job Summary
+
+This job bundle renders a USD scene using the Houdini [husk](https://www.sidefx.com/docs/houdini/ref/utils/husk.html) CLI.
+
+To run it, you will need a Houdini/Husk installation available in the PATH in one of the following ways:
+
+* As a conda package when your queue has a conda queue environment set up to provide virtual environments for jobs.
+**  For more information see the developer guide section [Provide applications for your jobs.](https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/provide-applications.html)
+* Installed on the worker hosts that run the job. You can customize your Deadline Cloud queues, fleets, and this job to fit your own production pipeline.
+
+
+The core of this job is an embedded template file that invokes
+the Houdini  `husk` command. The command is a template that substitutes job parameters and the
+frame task parameter.
+
+The `husk` command is part of an Open Job Description step. 
+It expands to a task per frame by defining a parameter space using the Frames job parameter. 
+It limits the fleets it will run on by including host requirements for Linux. 
+The KarmaXPU engine can optionally be used to render on a GPU. 
+If you intend to use KarmaXPU you must uncomment the `amount.worker.gpu` host requirement to ensure the job is scheduled on an appropriate worker. 
+Please note that when using the Karma rendering engine that a Karma license must be available. Usaged-based Karma license are available automatically from Deadline Cloud when using a service-managed fleet.
+
+The rest of the job template consists of the parameter definitions. This metadata specifies
+the names, types, and descriptions of each parameter, along with information on what user
+interface controls a GUI should use.
+The [Deadline Cloud CLI command `deadline bundle gui-submit`](https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/from-a-terminal.html#with-a-submission-window)
+uses this metadata to generate its UI. Please note that if the USD file refers to any external asset files such as textures, models, or materials
+these files must be made available to the job. When using a service-managed fleets you must use job attachments. 
+When using a customer-managed fleet you may use job attachments or alternatively use [storage profiles](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/storage-shared.html) to use shared storage.
+
+These job attachments may be attached manually or by using the included `generate_usd_job.py` script.
+
+This script introspects the USD file and find all files required by the USD stage to render.
+To use this script you must have the usd-core and deadline python libraries available in your python installation.
+`pip3 install usd-core deadline` 
+Then run the script to find required files
+`python3 generate_usd_job.py my_scene.usd`
+This script will generate a new job bundle with job attachment references for required assets and will preset the input USD file to the file you selected.
+After running, this script will open the Deadline Cloud job submissions UI. You may select which queue to use and further adjust job parameters such as resolution before submitting.
+
+Please note that husk will not render your scene if no camera is included. the `generate_usd_job.py` script will warn you if this is the case.
+
+Only a few husk parameters are included for demonstration purpose. Please see the [husk documentation](https://www.sidefx.com/docs/houdini/ref/utils/husk.html) for reference.
+
+
+## Sample Asset
+
+sample.usda is a simple scene containing a cube and a sphere. 
+This scene contains no external assets and can be rendered without
+using the `generate_usd_job.py` script or attaching any other files
+
+This work by the Deadline Cloud team is marked with [CC0 1.0](https://creativecommons.org/publicdomain/zero/1.0/?ref=chooser-v1)

--- a/job_bundles/houdini_husk_usd_render/generate_usd_job.py
+++ b/job_bundles/houdini_husk_usd_render/generate_usd_job.py
@@ -1,0 +1,85 @@
+""" 
+This script uses OpenUSD libraries to introspect a USD stage, determine all external files it depends on,
+and generate a Deadline Cloud job bundle that includes references to these assets
+After running this script the Deadline Cloud job submission UI will open ready to submit your job
+You may override parameters such as frame range, resolution, or renderer before submission
+
+Usage:
+pip3 install deadline usd-core
+python3 generate_usd_job.py <usd_file_path>
+
+Example:
+python3 generate_usd_job.py /path/to/your/usd/file.usda
+"""
+
+import json
+from pathlib import Path
+from pprint import pprint
+import shutil
+import subprocess
+import sys
+from pxr import Usd, UsdGeom, UsdUtils
+from deadline.client.job_bundle.submission import AssetReferences
+from deadline.client.job_bundle import create_job_history_bundle_dir
+
+
+def find_camera_paths(stage: Usd.Stage):
+    camera_paths = []
+
+    for prim in stage.Traverse():
+        if prim.IsA(UsdGeom.Camera):
+            camera_paths.append(prim.GetPath().pathString)
+    return camera_paths
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python script.py <usd_file_path>")
+        sys.exit(1)
+
+    usd_file_path = sys.argv[1]
+
+    usd_stage = Usd.Stage.Open(usd_file_path)
+
+    layers, assets, unresolved = UsdUtils.ComputeAllDependencies(usd_file_path)
+
+    paths = [layer.realPath for layer in layers]
+    paths = paths + assets
+
+    usd_abs_path = str(Path(usd_file_path).resolve())
+
+    references = AssetReferences(input_filenames=paths)
+
+    print(
+        f"WARNING: {len(unresolved)} paths were not resolved. Your render may not complete successfully:"
+    )
+    pprint(unresolved)
+
+    parameter_values = [{"name": "USDSceneFile", "value": usd_abs_path}]
+
+    cameras = find_camera_paths(usd_stage)
+    if not cameras:
+        print(
+            "WARNING: No cameras found in USD stage. This scene won't render. Please add a camera and try again"
+        )
+        sys.exit()
+
+    job_name = f"HuskUSDRender-{usd_file_path}"
+    job_bundle_dir = Path(create_job_history_bundle_dir("HuskUSDRender", job_name[:20]))
+    print(f"Creating Job Bundle Directory: {job_bundle_dir}")
+
+    # Write out the asset_references and parameter values to this new bundle dir
+    # and copy the template as-is
+    with open(Path.joinpath(job_bundle_dir, "asset_references.json"), "w") as f:
+        json.dump(references.to_dict(), f, indent=1)
+
+    with open(Path.joinpath(job_bundle_dir, "parameter_values.json"), "w") as f:
+        json.dump({"parameterValues": parameter_values}, f, indent=1)
+
+    shutil.copyfile(
+        Path.joinpath(Path(__file__).parents[0], "template.yaml"),
+        Path.joinpath(job_bundle_dir, "template.yaml"),
+    )
+
+    # Now pop up the deadline gui submitter for the customer to do the actual submission
+    subprocess.run(["deadline", "bundle", "gui-submit", job_bundle_dir])

--- a/job_bundles/houdini_husk_usd_render/sample.usda
+++ b/job_bundles/houdini_husk_usd_render/sample.usda
@@ -1,0 +1,33 @@
+#usda 1.0
+
+def Xform "World" {
+    def "Cube" (
+        kind = "component"
+    ) {
+        def Cube "Mesh" {
+            double size = 2.0
+            float3 xformOp:translate = (0, 0, 0)
+            uniform token[] xformOpOrder = ["xformOp:translate"]
+        }
+    }
+    
+    def "Sphere" (
+        kind = "component"
+    ) {
+        def Sphere "Mesh" {
+            double radius = 1.0
+            float3 xformOp:translate = (4, 0, 0)
+            uniform token[] xformOpOrder = ["xformOp:translate"]
+        }
+    }
+    
+    def Camera "MainCamera" {
+        float2 clippingRange = (0.1, 1000)
+        float focalLength = 30
+        float3 xformOp:translate = (4, 4, 10)
+        float3 xformOp:rotateXYZ = (-17, 12, 0)
+        uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateXYZ"]
+    }
+
+}
+

--- a/job_bundles/houdini_husk_usd_render/template.yaml
+++ b/job_bundles/houdini_husk_usd_render/template.yaml
@@ -1,0 +1,128 @@
+specificationVersion: 'jobtemplate-2023-09'
+name: Husk USD Render
+
+parameterDefinitions:
+# Render Parameters
+- name: USDSceneFile
+  type: PATH
+  default: "sample.usda"
+  objectType: FILE
+  dataFlow: IN
+  userInterface:
+    control: CHOOSE_INPUT_FILE
+    label: USD Scene File
+    groupLabel: Render Parameters
+    fileFilters:
+    - label: USD Scene Files
+      patterns: ["*.usd", "*.usdc", "*.usda", "*.usdz"]
+    - label: All Files
+      patterns: ["*"]
+  description: >
+    Choose the USD scene file you want to render. Use the 'Job Attachments' tab
+    to add textures and other files that the job needs.
+- name: Frames
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Frames
+    groupLabel: Render Parameters
+  default: "1"
+- name: OutputDir
+  type: PATH
+  default: output/
+  objectType: DIRECTORY
+  dataFlow: OUT
+  userInterface:
+    control: CHOOSE_DIRECTORY
+    label: Output Directory
+    groupLabel: Render Parameters
+  description: Choose the render output directory.
+- name: OutputPattern
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Output File Pattern
+    groupLabel: Render Parameters
+  default: "output_$F4"
+  # Husk Documentation: https://www.sidefx.com/docs/houdini/ref/utils/husk.html#:~:text=Current%20frame%20number%20with%20fixed%20number%20of
+  description: Enter the output filename pattern (without extension). Please see the Husk documentation for formatting
+- name: Format
+  type: STRING
+  userInterface:
+    control: DROPDOWN_LIST
+    label: Output File Format
+    groupLabel: Render Parameters
+  description: Choose the file format for the output render.
+  default: exr
+  allowedValues: ["exr"]
+- name: ResolutionX
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Resolution Width
+    groupLabel: Render Parameters
+  default: "1024"
+  description: >
+    Enter the resolution width in pixels. The default is 1024.
+- name: ResolutionY
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Resolution Height
+    groupLabel: Render Parameters
+  default: "768"
+  description: >
+    Enter the resolution height in pixels. The default is 768.
+- name: Renderer
+  type: STRING
+  userInterface:
+    control: DROPDOWN_LIST
+    label: Husk Render Delegate
+    groupLabel: Render Parameters
+  description: Choose the renderer you wish to use. BRAY_HdKarma uses the CPU while BRAY_HdKarmaXPU requires a GPU fleet. If you select BRAY_HdKarmaXPU your queue must be associated with a GPU fleet. 
+  default: BRAY_HdKarma
+  allowedValues: [BRAY_HdKarma, BRAY_HdKarmaXPU]
+- name: CondaPackages
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Conda Packages
+    groupLabel: Software Environment
+  default: "houdini=20.5"
+  description: >
+    This parameter assumes the presence of the default Conda environment. By default, Houdini 20.5 is installed to provide the husk executable.
+steps:
+- name: HuskRender
+  parameterSpace:
+    taskParameterDefinitions:
+    - name: Frame
+      type: INT
+      range: "{{Param.Frames}}"
+  script:
+    actions:
+      onRun:
+        command: bash
+        args: ['{{Task.File.Run}}']
+    embeddedFiles:
+      - name: Run
+        type: TEXT
+        data: |
+          set -xeuo pipefail
+          mkdir -p '{{Param.OutputDir}}'
+          # The 'husk' executable exists on the path when using a Deadline Cloud-provided Houdini conda package
+          husk -r {{Param.ResolutionX}} {{Param.ResolutionY}} \
+          -R {{Param.Renderer}} \
+          -f {{Task.Param.Frame}} \
+          '{{Param.USDSceneFile}}' \
+          -o '{{Param.OutputDir}}/{{Param.OutputPattern}}.{{Param.Format}}'
+  hostRequirements:
+    # Add this requirement when rendering with the GPU to ensure the job is only scheduled on GPU-enabled fleets.
+    # amounts:
+    # - name: amount.worker.gpu
+    #   min: 1
+    attributes:
+    # The Houdini package is currently only availabling on Linux in Deadline Cloud SMF
+    - name: attr.worker.os.family
+      anyOf:
+      - linux
+


### PR DESCRIPTION
This sample is a standalone job template that uses Husk from Houdini to render a USD scene.

Also included is a python script that uses the OpenUSD library to introspect a USD file to identify all assets and create a new job bundle with these asset references.

### What was the problem/requirement? (What/Why)
Customers have asked for a sample job template that renders a USD scene

### What was the solution? (How)
This sample uses Houdini's Husk CLI USD renderer.
This solution also includes an asset introspection script which provides an example of introspecting an asset and identifying all files that need to be attached via Job Attachments for the job to render in a Deadline Cloud service-managed fleet. 

### What is the impact of this change?
Deadline Cloud developers have access to a sample that renders USD scenes using Husk with a choice of resolution and renderer.

### How was this change tested?

- This sample has been tested using the included simple USD scene, as well as a number of samples from the [SideFX content library](https://www.sidefx.com/contentlibrary)
- I have tested these scenes successfully on the new Deadline Cloud GPU Service-managed fleets using the houdini conda package and Karma licensing and XPU renderer

### Was this change documented?

- A README is included with this sample
---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*