### PR TITLE
feat: Add V-Ray job bundle template

### DIFF
--- a/job_bundles/README.md
+++ b/job_bundles/README.md
@@ -58,6 +58,7 @@ and a short script that substitutes job parameters and the Frame task parameter 
 * [afterfx_render_one_task](afterfx_render_one_task)
 * [maya_cli_render](maya_cli_render)
 * [houdini_husk_usd_render](houdini_husk_usd_render)
+* [vray_render](vray_render/template.yaml)
 
 If you've created a similar job for your favorite DCC, see [CONTRIBUTING.md](../CONTRIBUTING.md) for how to add it here.
 

--- a/job_bundles/vray_render/README.md
+++ b/job_bundles/vray_render/README.md
@@ -1,0 +1,13 @@
+# V-Ray sample job bundle
+Use this job bundle to create a V-Ray job to use with AWS Deadline Cloud. \
+Read more about job bundle and how to use it with AWS Deadline Cloud [here](../README.md). \
+Read more about how to customize this job bundle bellow
+
+## Prerequisite
+- Have V-Ray conda package host on a conda channel. \
+Read more about how to create V-Ray conda package [here](../../conda_recipes/vray/README.md)
+- Have a sample `.vrscene` and its dependencies files.
+
+## Job bundle customization
+- All available customization flags could be found on [Chaos guide](https://docs.chaos.com/display/VNS/V-Ray+Standalone+Command+Line+Options) to tailor this job bundle
+- Sample command line for V-Ray could be found on [Chaos example](https://docs.chaos.com/display/VNS/Getting+Started+with+Commands)

--- a/job_bundles/vray_render/template.yaml
+++ b/job_bundles/vray_render/template.yaml
@@ -30,23 +30,22 @@ parameterDefinitions:
     groupLabel: Render Parameters
   default: "./output"
   description: Choose the render output directory.
-- name: OutputPattern
+- name: OutputFilename
   type: STRING
   userInterface:
     control: LINE_EDIT
-    label: Output File Pattern
+    label: Output File Name
     groupLabel: Render Parameters
-  default: "output_####"
-  description: Enter the output filename pattern (without extension).
+  default: "output"
+  description: Enter the output filename (without extension).
 - name: Format
   type: STRING
   userInterface:
-    control: DROPDOWN_LIST
+    control: LINE_EDIT
     label: Output File Format
     groupLabel: Render Parameters
-  description: Choose the file format to render as.
-  default: JPEG
-  allowedValues: [TGA, RAWTGA, JPEG, IRIS, IRIZ, PNG, HDR, TIFF, OPEN_EXR, OPEN_EXR_MULTILAYER, CINEON, DPX, DDS, JP2, WEBP]
+  default: png
+  description: Enter the file format to render as.
 
 # Software Environment
 - name: CondaPackages
@@ -76,7 +75,7 @@ steps:
           # Configure the task to fail if any individual command fails.
           set -xeuo pipefail
           vray -sceneFile='{{Param.VraySceneFile}}' \
-               -imgFile='{{Param.OutputDir}}/{{Param.OutputPattern}}.{{Param.Format}}' \
+               -imgFile='{{Param.OutputDir}}/{{Param.OutputFilename}}.{{Param.Format}}' \
                -display=0
   hostRequirements:
     attributes:

--- a/job_bundles/vray_render/template.yaml
+++ b/job_bundles/vray_render/template.yaml
@@ -36,16 +36,8 @@ parameterDefinitions:
     control: LINE_EDIT
     label: Output File Name
     groupLabel: Render Parameters
-  default: "output"
-  description: Enter the output filename (without extension).
-- name: Format
-  type: STRING
-  userInterface:
-    control: LINE_EDIT
-    label: Output File Format
-    groupLabel: Render Parameters
-  default: png
-  description: Enter the file format to render as.
+  default: "output.png"
+  description: Enter the output filename (with extension of choice).
 
 # Software Environment
 - name: CondaPackages
@@ -75,7 +67,7 @@ steps:
           # Configure the task to fail if any individual command fails.
           set -xeuo pipefail
           vray -sceneFile='{{Param.VraySceneFile}}' \
-               -imgFile='{{Param.OutputDir}}/{{Param.OutputFilename}}.{{Param.Format}}' \
+               -imgFile='{{Param.OutputDir}}/{{Param.OutputFilename}}' \
                -display=0
   hostRequirements:
     attributes:

--- a/job_bundles/vray_render/template.yaml
+++ b/job_bundles/vray_render/template.yaml
@@ -1,0 +1,85 @@
+specificationVersion: 'jobtemplate-2023-09'
+name: V-Ray Render
+
+parameterDefinitions:
+
+# Render Parameters
+- name: VraySceneFile
+  type: PATH
+  objectType: FILE
+  dataFlow: IN
+  userInterface:
+    control: CHOOSE_INPUT_FILE
+    label: Vray Scene File
+    groupLabel: Render Parameters
+    fileFilters:
+    - label: Vray Scene Files
+      patterns: ["*.vrscene"]
+    - label: All Files
+      patterns: ["*"]
+  description: >
+    Choose the Vray scene file you want to render. Use the 'Job Attachments' tab
+    to add textures and other files that the job needs.
+- name: OutputDir
+  type: PATH
+  objectType: DIRECTORY
+  dataFlow: OUT
+  userInterface:
+    control: CHOOSE_DIRECTORY
+    label: Output Directory
+    groupLabel: Render Parameters
+  default: "./output"
+  description: Choose the render output directory.
+- name: OutputPattern
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Output File Pattern
+    groupLabel: Render Parameters
+  default: "output_####"
+  description: Enter the output filename pattern (without extension).
+- name: Format
+  type: STRING
+  userInterface:
+    control: DROPDOWN_LIST
+    label: Output File Format
+    groupLabel: Render Parameters
+  description: Choose the file format to render as.
+  default: JPEG
+  allowedValues: [TGA, RAWTGA, JPEG, IRIS, IRIZ, PNG, HDR, TIFF, OPEN_EXR, OPEN_EXR_MULTILAYER, CINEON, DPX, DDS, JP2, WEBP]
+
+# Software Environment
+- name: CondaPackages
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Conda Packages
+    groupLabel: Software Environment
+  default: vray
+  description: >
+    If you have a Queue Environment that creates a Conda environment from a parameter called CondaPackages, this will
+    tell it to install vray.
+
+steps:
+- name: RenderVray
+  script:
+    actions:
+      onRun:
+        command: bash
+        args: ['{{Task.File.Run}}']
+        cancelation:
+          mode: NOTIFY_THEN_TERMINATE
+    embeddedFiles:
+      - name: Run
+        type: TEXT
+        data: |
+          # Configure the task to fail if any individual command fails.
+          set -xeuo pipefail
+          vray -sceneFile='{{Param.VraySceneFile}}' \
+               -imgFile='{{Param.OutputDir}}/{{Param.OutputPattern}}.{{Param.Format}}' \
+               -display=0
+  hostRequirements:
+    attributes:
+    - name: attr.worker.os.family
+      anyOf:
+      - linux


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We have provided conda recipe to build V-Ray conda package. Having sample job bundle for V-Ray help customer better utilize V-Ray
### What was the solution? (How)
Add job bundle for V-Ray
### What is the impact of this change?
Customer could use their newly build V-Ray conda package to render
### How was this change tested?

Submit multiple different `.vrscene` with this `template.yaml` using `deadline bundle gui-submit`

### Was this change documented?

Yes


---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*