### PR TITLE
feat: add Cinema 4D 2024 Conda recipe

### DIFF
--- a/conda_recipes/cinema4d-2024/README.md
+++ b/conda_recipes/cinema4d-2024/README.md
@@ -1,10 +1,10 @@
-# Cinema 2025 conda build recipe
+# Cinema 2024 conda build recipe
 
 ## Creating an archive file for Windows
 
 The Windows installer requires Administrator permissions that are not available in most conda package
 build environments, such as on a Deadline Cloud service-managed fleets. Follow these instructions to
-install Cinema4D 2025 on a freshly created EC2 instance as Administrator, and create an archive file
+install Cinema4D 2024 on a freshly created EC2 instance as Administrator, and create an archive file
 for use by the conda build recipe.
 
 1. Launch a fresh Windows Server 2022 instance.
@@ -35,7 +35,7 @@ for use by the conda build recipe.
         2. User name: `Administrator`
     5. Enter the password you set for Administrator after you created the instance. You should now have a remote desktop session to your instance.
 3. Install Cinema 4D 2025 on the instance.
-    1. Download the Cinema 4D 2025 installer for Windows from Maxon (https://www.maxon.net/en/downloads/cinema-4d-2025-downloads). For example, the files `Cinema4D_2025_2025.0.2_Win.exe`.
+    1. Download the Cinema 4D 2025 installer for Windows from Maxon (https://www.maxon.net/en/downloads/cinema-4d-2025-downloads). For example, the files `Cinema4D_2024_2024.5.1_Win.exe`.
        If you have placed them on S3, you can use a PowerShell command like `Read-S3Object -BucketName MY_BUCKET_NAME -Key MY_UPLOADED_KEY_NAME -File MY_FILE_NAME`.
     2. Run the installer. Accept the prompts to continue.
     3. The Cinema 4D installer will launch. Proceed to install as normal with the components you want included.
@@ -43,9 +43,9 @@ for use by the conda build recipe.
     5. Log in with a PowerShell window again, either from the EC2 management console session manager or reconnecting to RDP.
     5. Run the following commands to create the archive.
         1. `cd 'C:\Program Files\'`
-        2. `Compress-Archive -Path '.\Maxon Cinema 4D 2025\' -DestinationPath Cinema4D_2025_2025.0.2_Win.zip`
-        3. `(Get-FileHash -Path .\Cinema4D_2025_2025.0.2_Win.zip -Algorithm SHA256).Hash.ToLower()`
+        2. `Compress-Archive -Path '.\Maxon Cinema 4D 2024\' -DestinationPath Cinema4D_2024_2024.5.1_Win.zip`
+        3. `(Get-FileHash -Path .\Cinema4D_2024_2024.5.1_Win.zip -Algorithm SHA256).Hash.ToLower()`
     6. Record the file sha256 hash, and upload the archive to your private S3 bucket. You can use a PowerShell command like
-       `Write-S3Object -BucketName MY_BUCKET_NAME -Key Cinema4D_2025_2025.0.2_Win.zip -File Cinema4D_2025_2025.0.2_Win.zip`.
+       `Write-S3Object -BucketName MY_BUCKET_NAME -Key Cinema4D_2024_2024.5.1_Win.zip -File Cinema4D_2024_2024.5.1_Win.zip`.
 4. From the AWS EC2 management console, select the instance you used and terminate it.
 5. Download the zip file to the `conda_recipes/archive_files` directory in your git clone of the [deadline-cloud-samples](https://github.com/aws-deadline/deadline-cloud-samples) repository for submitting package build jobs, and update the Windows source artifact hash in the Cinema 4D-2025 conda build recipe meta.yaml.

--- a/conda_recipes/cinema4d-2024/deadline-cloud.yaml
+++ b/conda_recipes/cinema4d-2024/deadline-cloud.yaml
@@ -1,0 +1,6 @@
+condaPlatforms:
+  - platform: win-64
+    defaultSubmit: true
+    sourceArchiveFilename: Cinema4D_2024_2024.5.1_Win.zip
+    sourceDownloadInstructions: 'Follow the instructions from README in this folder on how to make this file.'
+    buildTool: conda-build

--- a/conda_recipes/cinema4d-2024/recipe/bld.bat
+++ b/conda_recipes/cinema4d-2024/recipe/bld.bat
@@ -1,0 +1,2 @@
+bash %RECIPE_DIR%/build_win.sh
+if errorlevel 1 exit 1

--- a/conda_recipes/cinema4d-2024/recipe/build_win.sh
+++ b/conda_recipes/cinema4d-2024/recipe/build_win.sh
@@ -1,0 +1,57 @@
+# Fail the script if any commands it runs fail
+set -euo pipefail
+
+# The version without the update number
+CINEMA_4D_VERSION=${PKG_VERSION%.*}
+
+# The conda-build environment is configured for packaging one pypi package into one conda package.
+# We turn off the following defaults for the below pip install.
+unset PIP_NO_DEPENDENCIES
+unset PIP_IGNORE_INSTALLED
+unset PIP_NO_INDEX
+
+# Move all the files into the prefix. Use cmd to move the files as it works
+# more reliably with permissions and locking.
+cmd <<EOF
+move $SRC_DIR\\cinema4d $PREFIX\\
+EOF
+
+# Currently, the cinema4d-openjd command from deadline-cloud-for-cinema4d
+# requires that pywin32 be installed inside Cinema4D's python.
+"$PREFIX\\cinema4d\\resource\\modules\\python\\libs\\win64\\python.exe" -m ensurepip
+"$PREFIX\\cinema4d\\resource\\modules\\python\\libs\\win64\\python.exe" -m pip install pywin32
+
+mkdir -p "$PREFIX/etc/conda/activate.d"
+mkdir -p "$PREFIX/etc/conda/deactivate.d"
+
+# See https://docs.conda.io/projects/conda/en/latest/dev-guide/deep-dives/activation.html
+# for details on activation. The Deadline Cloud sample queue environments use bash
+# to activate environments on Windows, so we recommend always producing both .bat and .sh files.
+
+cat <<EOF > "$PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.sh"
+export C4D_VERSION=$CINEMA_4D_VERSION
+export C4D_LOCATION="$PREFIX\\cinema4d"
+export CINEMA4D_ADAPTOR_COMMANDLINE_EXE="$PREFIX\\cinema4d\\Commandline.exe"
+EOF
+cat "$PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.sh"
+
+cat <<EOF > "$PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.bat"
+set "C4D_VERSION=$CINEMA_4D_VERSION"
+set "C4D_LOCATION=$PREFIX\cinema4d"
+set "CINEMA4D_ADAPTOR_COMMANDLINE_EXE=$PREFIX\cinema4d\Commandline.exe"
+EOF
+cat "$PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.bat"
+
+cat <<EOF > "$PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.sh"
+unset C4D_VERSION
+unset C4D_LOCATION
+unset CINEMA4D_ADAPTOR_COMMANDLINE_EXE
+EOF
+cat "$PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.sh"
+
+cat <<EOF > "$PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.bat"
+set C4D_VERSION=
+set C4D_LOCATION=
+set CINEMA4D_ADAPTOR_COMMANDLINE_EXE=
+EOF
+cat "$PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.bat"

--- a/conda_recipes/cinema4d-2024/recipe/meta.yaml
+++ b/conda_recipes/cinema4d-2024/recipe/meta.yaml
@@ -1,0 +1,35 @@
+{% set name = "cinema4d" %}
+{% set display_name = "Cinema4D" %}
+{% set version_major = "2024" %}
+{% set version_minor = "5" %}
+{% set version_patch = "1" %}
+{% set version = version_major + "." + version_minor + "." + version_patch %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: archive_files/{{ display_name }}_{{ version_major }}_{{ version }}_Win.zip # [win64]
+  sha256: 688cc0f087c3b54c633e5743baf30f5649d7d46e19538ce1fab88322b64d7fd3
+  folder: cinema4d
+
+build:
+  number: 0
+  binary_relocation: False
+  detect_binary_files_with_prefix: False
+  # The binary is built to be relocatable, so can ignore the warnings about DSOs.
+  missing_dso_whitelist:
+  - "**"
+
+test:
+ commands:
+   # Turning off the test because Cinema4D tries to pull a license even when
+   # just printing the help text
+   # - Commandline -help
+
+about:
+  home: https://www.maxon.net/en/cinema-4d
+  license: Commercial
+  summary: >
+    3D computer animation, modeling, simulation, and rendering software


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Added a sample Cinema 4D 2024 Conda package to help customers build their own.

### How was this change tested?
Submitted the bundle using `python submit-package-job-script.py cinema4d-2024` to a farm configured as described [here](https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/configure-jobs-s3-channel.html).

The bundle was submitted successfully, the job succeeded, and I was able to submit and run the [physical cube job output test](https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/tree/mainline/job_bundle_output_tests/physical) that used the package!

### Was this change documented?
Yes, the package contains a README with information about how to setup and use the package.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*