### PR TITLE
fix: Conda queue env erroring in activate/deactivate cases

### DIFF
--- a/queue_environments/conda_queue_env_improved_caching.yaml
+++ b/queue_environments/conda_queue_env_improved_caching.yaml
@@ -179,10 +179,12 @@ environment:
 
             if [ $MINUTES_SINCE_UPDATE -ge {{Param.NamedCondaEnvUpdateAfterMinutes}} ]; then
                 echo "Elapsed time greater than or equal to {{Param.NamedCondaEnvUpdateAfterMinutes}} minutes, updating the environment packages to the latest"
+                set +u
                 conda install --yes \
                     --update-all \
                     $CONDA_PACKAGES \
                     $CHANNEL_OPTS
+                set -u
 
                 # Save the channels and packages used in the environment, to help out debugging
                 LOGFILE="$CONDA_PREFIX/var/log/conda_queue_env.log"
@@ -273,7 +275,9 @@ environment:
         for ENV_NAME in $AUTO_CONDA_ENVS; do
             echo "Checking environment $ENV_NAME"
 
+            set +u
             conda activate $ENV_NAME
+            set -u
 
             LOGFILE="$CONDA_PREFIX/var/log/conda_queue_env.log"
             if [ -f "$LOGFILE" ]; then
@@ -285,7 +289,9 @@ environment:
             HOURS_SINCE_UPDATE="$(( ( $CURRENT_TIMESTAMP - $PREVIOUS_UPDATE_TIMESTAMP ) / 1440 ))"
             echo "Environment was last updated $HOURS_SINCE_UPDATE hours ago."
 
+            set +u
             conda deactivate
+            set -u
 
             if [ $HOURS_SINCE_UPDATE -gt $ENV_DELETE_AFTER_HOURS ]; then
                 echo "Elapsed time $HOURS_SINCE_UPDATE is greater than $ENV_DELETE_AFTER_HOURS hours, removing the environment."


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

When testing conda environments that include the compilers provided by conda-forge, some of the activate/deactivate scripts reference environment variables that aren't set, and fail due to the `set -u` option.

### What was the solution? (How)

* Turn off strict behavior for undefined variables when activating/deactivating during environment exit.
* Installing with package update can result in activation, so turn off strict behavior then as well.

### What is the impact of this change?

Customers using the example queue environment will have more reliable operation.

### How was this change tested?

Deployed as a queue environment, and confirmed some cases that were failing now succeed.

### Was this change documented?

N/A

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*