### PR TITLE
feat: Add sample package build recipe for Blender 4.3

### DIFF
--- a/conda_recipes/blender-4.3/deadline-cloud.yaml
+++ b/conda_recipes/blender-4.3/deadline-cloud.yaml
@@ -1,0 +1,11 @@
+condaPlatforms:
+  - platform: linux-64
+    defaultSubmit: true
+    sourceArchiveFilename: blender-4.3.0-linux-x64.tar.xz
+    sourceDownloadInstructions: 'Run "curl -LO https://download.blender.org/release/Blender4.3/blender-4.3.0-linux-x64.tar.xz"'
+    buildTool: rattler-build
+  - platform: win-64
+    defaultSubmit: false
+    sourceArchiveFilename: blender-4.3.0-windows-x64.zip
+    sourceDownloadInstructions: 'Run "curl -LO https://download.blender.org/release/Blender4.3/blender-4.3.0-windows-x64.zip"'
+    buildTool: conda-build

--- a/conda_recipes/blender-4.3/recipe/bld.bat
+++ b/conda_recipes/blender-4.3/recipe/bld.bat
@@ -1,0 +1,2 @@
+bash %RECIPE_DIR%/build_win.sh
+if errorlevel 1 exit 1

--- a/conda_recipes/blender-4.3/recipe/build.sh
+++ b/conda_recipes/blender-4.3/recipe/build.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+set -xeuo pipefail
+
+# Copy the Blender installation into the prefix
+mkdir -p $PREFIX/opt
+cp -r $SRC_DIR/blender $PREFIX/opt/
+
+# The version without the build number
+BLENDER_VERSION=${PKG_VERSION%.*}
+
+# Create symlinks to the Blender commands
+mkdir -p $PREFIX/bin
+for BINARY in blender blender-launcher blender-softwaregl blender-thumbnailer; do
+    ln -r -s $PREFIX/opt/blender/$BINARY $PREFIX/bin/$BINARY
+done
+
+# See https://docs.conda.io/projects/conda/en/latest/dev-guide/deep-dives/activation.html
+# for details on activation.
+
+mkdir -p $PREFIX/etc/conda/activate.d
+cat <<EOF > $PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.sh
+export "BLENDER_LOCATION=\$CONDA_PREFIX/opt/blender"
+export "BLENDER_VERSION=$BLENDER_VERSION"
+export "BLENDER_LIBRARY_PATH=\$BLENDER_LOCATION/lib"
+export "BLENDER_SCRIPTS_PATH=\$BLENDER_LOCATION/\$BLENDER_VERSION/scripts"
+export "BLENDER_PYTHON_PATH=\$BLENDER_LOCATION/\$BLENDER_VERSION/python"
+export "BLENDER_DATAFILES_PATH=\$BLENDER_LOCATION/\$BLENDER_VERSION/datafiles"
+EOF
+
+mkdir -p $PREFIX/etc/conda/deactivate.d
+cat <<EOF > $PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.sh
+unset BLENDER_DATAFILES_PATH
+unset BLENDER_PYTHON_PATH
+unset BLENDER_SCRIPTS_PATH
+unset BLENDER_LIBRARY_PATH
+unset BLENDER_VERSION
+unset BLENDER_LOCATION
+EOF

--- a/conda_recipes/blender-4.3/recipe/build_win.sh
+++ b/conda_recipes/blender-4.3/recipe/build_win.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+set -xeuo pipefail
+
+# Copy the Blender installation into the prefix
+mkdir -p $PREFIX/opt
+cp -r $SRC_DIR/blender $PREFIX/opt/
+
+# The version without the build number
+BLENDER_VERSION=${PKG_VERSION%.*}
+
+# See https://docs.conda.io/projects/conda/en/latest/dev-guide/deep-dives/activation.html
+# for details on activation. The Deadline Cloud sample queue environments use bash
+# to activate environments on Windows, so we recommend always producing both .bat and .sh files.
+
+mkdir -p $PREFIX/etc/conda/activate.d
+mkdir -p $PREFIX/etc/conda/deactivate.d
+
+cat <<EOF > "$PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.bat"
+set "BLENDER_LOCATION=$PREFIX/opt/blender"
+set "BLENDER_VERSION=$BLENDER_VERSION"
+set "BLENDER_LIBRARY_PATH=%BLENDER_LOCATION%/lib"
+set "BLENDER_SCRIPTS_PATH=%BLENDER_LOCATION%/%BLENDER_VERSION%/scripts"
+set "BLENDER_PYTHON_PATH=%BLENDER_LOCATION%/%BLENDER_VERSION%/python"
+set "BLENDER_DATAFILES_PATH=%BLENDER_LOCATION%/%BLENDER_VERSION%/datafiles"
+set "PATH=$PREFIX/opt/blender;%PATH%"
+EOF
+cat "$PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.bat"
+
+cat <<EOF > $PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.sh
+export "BLENDER_LOCATION=\$CONDA_PREFIX/opt/blender"
+export "BLENDER_VERSION=$BLENDER_VERSION"
+export "BLENDER_LIBRARY_PATH=\$BLENDER_LOCATION/lib"
+export "BLENDER_SCRIPTS_PATH=\$BLENDER_LOCATION/\$BLENDER_VERSION/scripts"
+export "BLENDER_PYTHON_PATH=\$BLENDER_LOCATION/\$BLENDER_VERSION/python"
+export "BLENDER_DATAFILES_PATH=\$BLENDER_LOCATION/\$BLENDER_VERSION/datafiles"
+export PATH="\$(cygpath '$PREFIX/opt/blender'):\$PATH"
+EOF
+cat $PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.sh
+
+cat <<EOF > "$PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.bat"
+set "PATH=%PATH:$PREFIX/opt/blender;=%"
+set BLENDER_DATAFILES_PATH=
+set BLENDER_PYTHON_PATH=
+set BLENDER_SCRIPTS_PATH=
+set BLENDER_LIBRARY_PATH=
+set BLENDER_VERSION=
+set BLENDER_LOCATION=
+EOF
+cat "$PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.bat"
+
+cat <<EOF > $PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.sh
+export PATH="\${PATH/\$(cygpath '$PREFIX/opt/blender'):/}"
+unset BLENDER_DATAFILES_PATH
+unset BLENDER_PYTHON_PATH
+unset BLENDER_SCRIPTS_PATH
+unset BLENDER_LIBRARY_PATH
+unset BLENDER_VERSION
+unset BLENDER_LOCATION
+EOF
+cat $PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.sh

--- a/conda_recipes/blender-4.3/recipe/meta.yaml
+++ b/conda_recipes/blender-4.3/recipe/meta.yaml
@@ -1,0 +1,36 @@
+# Recipe in conda-build format.
+# This recipe is only for Windows, see recipe.yaml for the Linux recipe in rattler-build format.
+
+{% set version = "4.3.0" %}
+{% set major_minor_version = ".".join(version.split(".")[:2]) %}
+
+package:
+  name: blender
+  version: {{ version }}
+
+source:
+  url: https://download.blender.org/release/Blender{{major_minor_version}}/blender-{{version}}-windows-x64.zip # [win64]
+  sha256: 68777b84f1e8970859428b3c4bc8e8675e8322b19e1566e0a90d575d00d257ac # [win64]
+  folder: blender
+
+build:
+  skip: true  # [not win64]
+  number: 0
+  # These build options for repackaging an application
+  # https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html
+  binary_relocation: False
+  detect_binary_files_with_prefix: False
+  missing_dso_whitelist:
+  - "**"
+
+test:
+  commands:
+    - blender -h
+
+about:
+  home: https://www.blender.org/
+  license: GPL3
+  summary: >
+    Blender is the free and open source 3D creation suite. It supports the entirety of
+    the 3D pipeline—modeling, rigging, animation, simulation, rendering, compositing
+    and motion tracking, even video editing and game creation.

--- a/conda_recipes/blender-4.3/recipe/recipe.yaml
+++ b/conda_recipes/blender-4.3/recipe/recipe.yaml
@@ -1,0 +1,45 @@
+# Recipe in rattler-build format.
+# See https://prefix-dev.github.io/rattler-build/latest/
+
+context:
+  version: "4.3.0"
+  major_minor_version: "4.3"
+
+package:
+  name: blender
+  version: ${{ version }}
+
+source:
+  - if: linux
+    then:
+      url: https://download.blender.org/release/Blender${{ major_minor_version }}/blender-${{ version }}-linux-x64.tar.xz
+      sha256: 6264ff4cf50baf6be6091a28d3c29cf25dc38d8daa3082874ce94d520d3e6ab6
+      target_directory: blender
+  - if: win
+    then:
+      url: https://download.blender.org/release/Blender${{ major_minor_version }}/blender-${{ version }}-windows-x64.zip
+      sha256: 68777b84f1e8970859428b3c4bc8e8675e8322b19e1566e0a90d575d00d257ac
+      target_directory: blender
+
+build:
+  number: 0
+  # These build options for repackaging an application
+  # https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html
+  prefix_detection:
+    ignore_binary_files: True
+  dynamic_linking:
+    binary_relocation: False
+    missing_dso_allowlist:
+    - "**"
+
+tests:
+  - script:
+    - blender -h
+
+about:
+  homepage: https://www.blender.org/
+  license: GPL-3.0
+  summary: >
+    Blender is the free and open source 3D creation suite. It supports the entirety of
+    the 3D pipeline—modeling, rigging, animation, simulation, rendering, compositing
+    and motion tracking, even video editing and game creation.


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Blender 4.3 was released recently.

### What was the solution? (How)

Make a copy of the Blender 4.2 recipe for Blender 4.3, with the version numbers and archive hashes updated.

### What is the impact of this change?

Customers can make their own Blender 4.3 package without having to modify the recipe themselves.

### How was this change tested?

Submitted package build jobs for both Linux and Windows. Then submitted render jobs using the blender_render sample, adjusting the template to run on just linux and just windows hosts. Downloaded outputs to confirm the images.

### Was this change documented?

No changes.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*