### PR TITLE
chore: upgrade cinema4d-openjd, openjd-adaptor-runtime, deadline recipes

### DIFF
--- a/conda_recipes/cinema4d-openjd/recipe/meta.yaml
+++ b/conda_recipes/cinema4d-openjd/recipe/meta.yaml
@@ -4,7 +4,7 @@
 # https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/conda_recipes
 
 {% set name = "cinema4d-openjd" %}
-{% set version = "0.4.1" %}
+{% set version = "0.5.4" %}
 
 package:
   name: {{ name }}
@@ -12,7 +12,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/d/deadline-cloud-for-cinema-4d/deadline_cloud_for_cinema_4d-{{ version }}.tar.gz
-  sha256: 0404af9f6740a9778ced6f698c096ef52f6e8a0a73f975c4520727578a3dfabb
+  sha256: 314ea9fadc658b4e25b3616aa36a1d2ee9f24863f7c0bb39a26c512b9f976ea8
   patches:
     - 0001-Remove-version-hook.patch
 
@@ -40,7 +40,7 @@ requirements:
   run:
     # For the variant config file in deadline-cloud.yaml to work, python must not specify a version here.
     - python
-    - deadline ==0.48.*
+    - deadline ==0.49.*
     - openjd-adaptor-runtime ==0.8.*
 
 test:

--- a/conda_recipes/cinema4d-openjd/recipe/recipe.yaml
+++ b/conda_recipes/cinema4d-openjd/recipe/recipe.yaml
@@ -6,7 +6,7 @@
 # https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/conda_recipes
 
 context:
-  version: "0.4.1"
+  version: "0.5.4"
 
 package:
   name: cinema4d-openjd
@@ -15,7 +15,7 @@ package:
 # This source reference uses the source archive published to PyPI
 source:
   url: https://pypi.io/packages/source/d/deadline-cloud-for-cinema-4d/deadline_cloud_for_cinema_4d-${{ version }}.tar.gz
-  sha256: 0404af9f6740a9778ced6f698c096ef52f6e8a0a73f975c4520727578a3dfabb
+  sha256: 314ea9fadc658b4e25b3616aa36a1d2ee9f24863f7c0bb39a26c512b9f976ea8
   patches:
     - 0001-Remove-version-hook.patch
 
@@ -32,7 +32,7 @@ requirements:
     - pip
   run:
     - python
-    - deadline 0.48.*
+    - deadline 0.49.*
     - openjd-adaptor-runtime 0.8.*
 
 tests:

--- a/conda_recipes/deadline/recipe/meta.yaml
+++ b/conda_recipes/deadline/recipe/meta.yaml
@@ -2,7 +2,7 @@
 # See recipe.yaml for the recipe in rattler-build format.
 
 {% set name = "deadline" %}
-{% set version = "0.48.9" %}
+{% set version = "0.49.3" %}
 
 package:
   name: {{ name }}
@@ -10,7 +10,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/deadline-{{ version }}.tar.gz
-  sha256: ad4256b6b80325598e3ae3660f43ea0b037958c9bb7081c96ce737395ebf5a00
+  sha256: 30ff5c2bf3c9e0b9c42b777661ed470cbc6333d877cf386f9c5c31918844a553
   patches:
     - 0001-Remove-version-build-hook.patch
 
@@ -36,7 +36,7 @@ requirements:
     - typing-extensions >=4.8
     - python-xxhash >=3.4,<3.6
     - jsonschema ==4.17.*
-    - pywin32 ==306  # [win]
+    - pywin32 >=307,<309  # [win]
     - qtpy ==2.4.*
 
 test:

--- a/conda_recipes/deadline/recipe/recipe.yaml
+++ b/conda_recipes/deadline/recipe/recipe.yaml
@@ -2,7 +2,7 @@
 # See https://prefix-dev.github.io/rattler-build/latest/
 
 context:
-  version: "0.48.9"
+  version: "0.49.3"
 
 package:
   name: deadline
@@ -10,7 +10,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/d/deadline/deadline-${{ version }}.tar.gz
-  sha256: ad4256b6b80325598e3ae3660f43ea0b037958c9bb7081c96ce737395ebf5a00
+  sha256: 30ff5c2bf3c9e0b9c42b777661ed470cbc6333d877cf386f9c5c31918844a553
   patches:
     - 0001-Remove-version-build-hook.patch
 
@@ -34,7 +34,7 @@ requirements:
     - python-xxhash >=3.4,<3.6
     - jsonschema 4.17
     - qtpy 2.4
-    - ${{ "pywin32 ==306" if win }}
+    - ${{ "pywin32 >=307,<309" if win }}
 
 tests:
 - python:

--- a/conda_recipes/openjd-adaptor-runtime/recipe/meta.yaml
+++ b/conda_recipes/openjd-adaptor-runtime/recipe/meta.yaml
@@ -2,7 +2,7 @@
 # See recipe.yaml for the recipe in rattler-build format.
 
 {% set name = "openjd-adaptor-runtime" %}
-{% set version = "0.8.0" %}
+{% set version = "0.8.2" %}
 
 package:
   name: {{ name }}
@@ -11,7 +11,7 @@ package:
 # # This source reference uses the source archive published to PyPI
 # source:
 #   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/openjd_adaptor_runtime-{{ version }}.tar.gz
-#   sha256: 58e00c4a08686821df01c736e0781a3736450865cc2cf4e3799e354d324112d8
+#   sha256: 9230002d9d73e5120d211535bb9fff7fe1d9fea0c6e0f301ff0fe731cbd62747
 #   patches:
 #     - 0001-Remove-version-hook.patch
 
@@ -38,7 +38,7 @@ requirements:
     - python
     - pyyaml >=6.0,<7.dev0
     - jsonschema >=4.17.0,<5.0
-    - pywin32 ==306  # [win]
+    - pywin32 >=307  # [win]
 
 test:
   imports:

--- a/conda_recipes/openjd-adaptor-runtime/recipe/recipe.yaml
+++ b/conda_recipes/openjd-adaptor-runtime/recipe/recipe.yaml
@@ -2,7 +2,7 @@
 # See https://prefix-dev.github.io/rattler-build/latest/
 
 context:
-  version: "0.8.0"
+  version: "0.8.2"
 
 package:
   name: openjd-adaptor-runtime
@@ -10,7 +10,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/o/openjd-adaptor-runtime/openjd_adaptor_runtime-${{ version }}.tar.gz
-  sha256: 58e00c4a08686821df01c736e0781a3736450865cc2cf4e3799e354d324112d8
+  sha256: 9402ab555ad60ca81c4669fb634c569abaca794e2eefafac1dada89fdb300c2a
   patches:
     - 0001-Remove-version-hook.patch
 
@@ -29,7 +29,7 @@ requirements:
     - python
     - pyyaml >=6.0,<7.dev0
     - jsonschema >=4.17.0,<5.0
-    - ${{ "pywin32 ==306" if win }}
+    - ${{ "pywin32 >=307" if win }}
 
 tests:
 - python:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
There have been some recent releases to [deadline-cloud-for-cinema-4d](https://github.com/aws-deadline/deadline-cloud-for-cinema-4d). Updated it, as well as dependencies [deadline-cloud](https://github.com/aws-deadline/deadline-cloud) and [openjd-adaptor-runtime](https://github.com/OpenJobDescription/openjd-adaptor-runtime-for-python), which also have recent releases.

### What was the solution? (How)
Updated the recipes to use the latest version

### What is the impact of this change?
Helps customers use the latest version of Deadline and OpenJD packages.

### How was this change tested?
Ran `cd conda_recipes && python submit-package-job-script.py deadline && python submit-package-job-script.py openjd-adaptor-runtime && python submit-package-job-script.py cinema4d-openjd`. Currently blocked on the release of pywin32 in conda-forge

### Was this change documented?
No, N/A

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*