### PR TITLE
chore: update maya adapter version for conda recipe

### DIFF
--- a/conda_recipes/maya-openjd/recipe/meta.yaml
+++ b/conda_recipes/maya-openjd/recipe/meta.yaml
@@ -2,7 +2,7 @@
 # See recipe.yaml for the recipe in rattler-build format.
 
 {% set name = "maya-openjd" %}
-{% set version = "0.14.3" %}
+{% set version = "0.14.4" %}
 
 package:
   name: {{ name }}
@@ -11,7 +11,7 @@ package:
 # This source reference uses the source archive published to PyPI
 source:
  url: https://pypi.io/packages/source/d/deadline-cloud-for-maya/deadline_cloud_for_maya-{{ version }}.tar.gz
- sha256: d3789e4a14144b43224bc0657eacdb3e39e333aedc22ad29b8591530a185f845
+ sha256: 9b86a6c02df800ed3e69a3094c0f7d2aaa8b07304af34068fc41e2e14313268e
  patches:
    - 0001-Remove-version-hook.patch
 
@@ -38,7 +38,7 @@ requirements:
   run:
     # For the variant config file in deadline-cloud.yaml to work, python must not specify a version here.
     - python
-    - deadline ==0.48.*
+    - deadline ==0.49.*
     - openjd-adaptor-runtime ==0.8.*
 
 test:


### PR DESCRIPTION

### What was the problem/requirement? (What/Why)
Maya Adapter just release a new version and the corresponding conda package need to be update
### What was the solution? (How)
Update meta.yaml file to pull newest version from pypi
### What is the impact of this change?
Maya-openjd conda package now have the latest version
### How was this change tested?

`./submit-package-job maya-openjd`
Submit a maya job to render using maya adapter and was successful

### Was this change documented?

Yes


---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*