### PR TITLE
chore: add needed package for Maya 2025 to work with V-Ray

### DIFF
--- a/conda_recipes/maya-2025/recipe/build.sh
+++ b/conda_recipes/maya-2025/recipe/build.sh
@@ -27,7 +27,9 @@ ln -r -s "$INSTALL_DIR/bin/maya$MAYA_VERSION" "$INSTALL_DIR/bin/maya"
 # from the system package manager, dnf.
 mkdir -p "$SRC_DIR/download"
 cd "$SRC_DIR/download"
-dnf download --resolve -y freetype alsa-lib fontconfig harfbuzz libbrotli graphite2 libxkbfile
+dnf download --resolve -y freetype alsa-lib fontconfig harfbuzz libbrotli graphite2 \
+    libxkbfile xcb-util-cursor xcb-util-wm xcb-util-keysyms libxkbcommon-x11
+
 for RPM_FILE in *.rpm; do
     rpm2cpio "$RPM_FILE" | cpio -idm
 done


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
When building V-Ray for Maya, we identify some missing dependencies for Maya.
In particular, Qt6 package from Maya need some dependencies such as:
- `libxcb-icccm`
- `libxcb-cursor`
- `libxcb-keysyms`
- `libxkbcommon-x1`
### What was the solution? (How)
We need to add those dependencies in to ensure Maya functionality. In specific, we need:
- xcb-util-wm for `libxcb-icccm`
- xcb-util-cursor for `libxcb-cursor`
- xcb-util-keysyms for `libxcb-keysyms`
- libxkbcommon-x11 for `libxkbcommon-x1`
### What is the impact of this change?
Maya 2025 will have enough dependencies to make it work reliably 
### How was this change tested?

`./submit-package-job maya-2025`
Submit a Maya job + a V-Ray for Maya job and was able to render successfully
### Was this change documented?
Yes


---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*