### PR TITLE
docs: remove patch version for After Effects source bundle

### DIFF
--- a/conda_recipes/aftereffects-25.0/README.md
+++ b/conda_recipes/aftereffects-25.0/README.md
@@ -37,9 +37,9 @@ install Adobe After Effects 25 on a freshly created EC2 instance as Administrato
    3. The After Effects installer will launch. Proceed to install as normal with the components you want included.
    4. Log in with a powershell window again, either from the EC2 management console session manager or reconnecting to RDP.
    5. Run the following commands to create the archive.
-      1. `Compress-Archive -Path 'C:\Program Files\Adobe\Adobe After Effects 2025\Support Files' -DestinationPath Adobe_AfterEffects_25_0_1_Windows_installation.zip`
-      2. `(Get-FileHash -Path "Adobe_AfterEffects_25_0_1_Windows_installation.zip" -Algorithm SHA256).Hash.ToLower()`
+      1. `Compress-Archive -Path 'C:\Program Files\Adobe\Adobe After Effects 2025\Support Files' -DestinationPath Adobe_AfterEffects_25_0_Windows_installation.zip`
+      2. `(Get-FileHash -Path "Adobe_AfterEffects_25_0_Windows_installation.zip" -Algorithm SHA256).Hash.ToLower()`
    6. Record the file sha256 hash, and upload the archive to your private S3 bucket. You can use a PowerShell command like
-      `Write-S3Object -BucketName MY_BUCKET_NAME -Key Adobe_AfterEffects_25_0_1_Windows_installation.zip -File Adobe_AfterEffects_25_0_1_Windows_installation.zip`.
+      `Write-S3Object -BucketName MY_BUCKET_NAME -Key Adobe_AfterEffects_25_0_Windows_installation.zip -File Adobe_AfterEffects_25_0_Windows_installation.zip`.
 4. From the AWS EC2 management console, select the instance you used and terminate it.
 5. Download the zip file to the `conda_recipes/archive_files` directory in your git clone of the [deadline-cloud-samples](https://github.com/aws-deadline/deadline-cloud-samples) repository for submitting package build jobs, and update the Windows source artifact hash in the aftereffects-25 conda build recipe meta.yaml.


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The After Effects deadline-cloud.yaml and meta.yaml files do not have the correct minor version set up for the After Effects zip file that gets generated from zipping up After Effects in Windows. As a result, when attempting to submit a job to my packaging queue, I get the following error:

```
ERROR: File(s) Adobe_AfterEffects_25_0_Windows_installation.zip not found in /Users/viknith/Documents/Github/deadline-cloud-samples/conda_recipes/archive_files.
To submit the aftereffects-25.0 package build, you need these files.
To acquire this archive, follow these instructions and place it in the /Users/viknith/Documents/Github/deadline-cloud-samples/conda_recipes/archive_files directory:
    Follow the instructions in README.md to construct the archive zip file.
```
But the AfterEffects README refers to AfterEffects zip as 25_0_1, not 25_0.

### What was the solution? (How)

Fix the minor version typo in the README

### What is the impact of this change?

Improves consistency between our conda recipe files and our documentation

### How was this change tested?

Ran `./submit-package-job aftereffects-25.0`
```
viknith@7cf34df03377 conda_recipes % ./submit-package-job aftereffects-25.0
No channel URL was provided, using a default prefix on the queue's job attachments bucket
Building packages into channel s3://viknith-job-attachments/Conda/Default
Applying job parameter CondaChannels=conda-forge
Creating steps for conda platforms: win-64
Wrote job bundle:
  '/Users/viknith/.deadline/job_history/viknith-us-west-2/2024-12/2024-12-23-04-CondaBuild-CondaBuild'
Submitting to Queue: Package Build Queue
Hashing: 100.0%      
Hashing Summary:
    Processed 12 files totaling 1.81 GB.
    Skipped re-processing 0 files totaling 0.0 B.
    Total processing time of 0.51848 seconds at 3.49 GB/s.

Uploading: 100.0%      
Upload Summary:
    Processed 1 file totaling 1.03 KB.
    Skipped re-processing 11 files totaling 1.81 GB.
    Total processing time of 0.35817 seconds at 2.88 KB/s.

Waiting for Job to be created...
Submitted job bundle:
   /Users/viknith/.deadline/job_history/viknith-us-west-2/2024-12/2024-12-23-04-CondaBuild-CondaBuild
Job creation completed successfully
job-362a62d6c20842e390d994f3e10a74ce
```

Job was created and succeeded! 
![Screenshot 2024-12-23 at 1 13 48 PM](https://github.com/user-attachments/assets/d66c5e54-84b9-4ae4-a993-7c4f397648ad)


### Was this change documented?

Yes, already documented, just needed to update the config files to match the documentation.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*