### PR TITLE
chore: Update conda recipe versions

### DIFF
--- a/conda_recipes/blender-4.1/deadline-cloud.yaml
+++ b/conda_recipes/blender-4.1/deadline-cloud.yaml
@@ -2,10 +2,10 @@ condaPlatforms:
   - platform: linux-64
     defaultSubmit: true
     sourceArchiveFilename: blender-4.1.1-linux-x64.tar.xz
-    sourceDownloadInstructions: 'Run "curl -LO https://download.blender.org/release/Blender4.1/blender-4.1.1-linux-x64.tar.xz"'
+    sourceDownloadInstructions: 'Run "curl -LO https://download.blender.org/release/Blender4.1/blender-4.1.1-linux-x64.tar.xz --output-dir archive_files"'
     buildTool: rattler-build
   - platform: win-64
     defaultSubmit: false
     sourceArchiveFilename: blender-4.1.1-windows-x64.zip
-    sourceDownloadInstructions: 'Run "curl -LO https://download.blender.org/release/Blender4.1/blender-4.1.1-windows-x64.zip"'
+    sourceDownloadInstructions: 'Run "curl -LO https://download.blender.org/release/Blender4.1/blender-4.1.1-windows-x64.zip --output-dir archive_files"'
     buildTool: conda-build

--- a/conda_recipes/blender-4.2/deadline-cloud.yaml
+++ b/conda_recipes/blender-4.2/deadline-cloud.yaml
@@ -1,11 +1,11 @@
 condaPlatforms:
   - platform: linux-64
     defaultSubmit: true
-    sourceArchiveFilename: blender-4.2.3-linux-x64.tar.xz
-    sourceDownloadInstructions: 'Run "curl -LO https://download.blender.org/release/Blender4.2/blender-4.2.3-linux-x64.tar.xz"'
+    sourceArchiveFilename: blender-4.2.5-linux-x64.tar.xz
+    sourceDownloadInstructions: 'Run "curl -LO https://download.blender.org/release/Blender4.2/blender-4.2.5-linux-x64.tar.xz --output-dir archive_files"'
     buildTool: rattler-build
   - platform: win-64
     defaultSubmit: false
-    sourceArchiveFilename: blender-4.2.3-windows-x64.zip
-    sourceDownloadInstructions: 'Run "curl -LO https://download.blender.org/release/Blender4.2/blender-4.2.3-windows-x64.zip"'
+    sourceArchiveFilename: blender-4.2.5-windows-x64.zip
+    sourceDownloadInstructions: 'Run "curl -LO https://download.blender.org/release/Blender4.2/blender-4.2.5-windows-x64.zip --output-dir archive_files"'
     buildTool: conda-build

--- a/conda_recipes/blender-4.2/recipe/meta.yaml
+++ b/conda_recipes/blender-4.2/recipe/meta.yaml
@@ -1,7 +1,7 @@
 # Recipe in conda-build format.
 # This recipe is only for Windows, see recipe.yaml for the Linux recipe in rattler-build format.
 
-{% set version = "4.2.3" %}
+{% set version = "4.2.5" %}
 {% set major_minor_version = ".".join(version.split(".")[:2]) %}
 
 package:
@@ -10,7 +10,7 @@ package:
 
 source:
   url: https://download.blender.org/release/Blender{{major_minor_version}}/blender-{{version}}-windows-x64.zip # [win64]
-  sha256: 7f8be9b1dc904e7689b3112659791c29cc9ed9d46ce57c4ea5b31a0621489b3a # [win64]
+  sha256: 633a0e62734537cfc6a4244e856909ba0742f263d9fddccc72da9d250ba44ec3 # [win64]
   folder: blender
 
 build:

--- a/conda_recipes/blender-4.2/recipe/recipe.yaml
+++ b/conda_recipes/blender-4.2/recipe/recipe.yaml
@@ -2,7 +2,7 @@
 # See https://prefix-dev.github.io/rattler-build/latest/
 
 context:
-  version: "4.2.3"
+  version: "4.2.5"
   major_minor_version: "4.2"
 
 package:
@@ -13,12 +13,12 @@ source:
   - if: linux
     then:
       url: https://download.blender.org/release/Blender${{ major_minor_version }}/blender-${{ version }}-linux-x64.tar.xz
-      sha256: 3a64efd1982465395abab4259b4091d5c8c56054c7267e9633e4f702a71ea3f4
+      sha256: cd28ab8164d88237c0c45a188ef7e4974bcb8c651de15fcbc3635166e584e4b3
       target_directory: blender
   - if: win
     then:
       url: https://download.blender.org/release/Blender${{ major_minor_version }}/blender-${{ version }}-windows-x64.zip
-      sha256: 7f8be9b1dc904e7689b3112659791c29cc9ed9d46ce57c4ea5b31a0621489b3a
+      sha256: 633a0e62734537cfc6a4244e856909ba0742f263d9fddccc72da9d250ba44ec3
       target_directory: blender
 
 build:

--- a/conda_recipes/blender-4.3/deadline-cloud.yaml
+++ b/conda_recipes/blender-4.3/deadline-cloud.yaml
@@ -1,11 +1,11 @@
 condaPlatforms:
   - platform: linux-64
     defaultSubmit: true
-    sourceArchiveFilename: blender-4.3.0-linux-x64.tar.xz
-    sourceDownloadInstructions: 'Run "curl -LO https://download.blender.org/release/Blender4.3/blender-4.3.0-linux-x64.tar.xz"'
+    sourceArchiveFilename: blender-4.3.2-linux-x64.tar.xz
+    sourceDownloadInstructions: 'Run "curl -LO https://download.blender.org/release/Blender4.3/blender-4.3.2-linux-x64.tar.xz --output-dir archive_files"'
     buildTool: rattler-build
   - platform: win-64
     defaultSubmit: false
-    sourceArchiveFilename: blender-4.3.0-windows-x64.zip
-    sourceDownloadInstructions: 'Run "curl -LO https://download.blender.org/release/Blender4.3/blender-4.3.0-windows-x64.zip"'
+    sourceArchiveFilename: blender-4.3.2-windows-x64.zip
+    sourceDownloadInstructions: 'Run "curl -LO https://download.blender.org/release/Blender4.3/blender-4.3.2-windows-x64.zip --output-dir archive_files"'
     buildTool: conda-build

--- a/conda_recipes/blender-4.3/recipe/meta.yaml
+++ b/conda_recipes/blender-4.3/recipe/meta.yaml
@@ -1,7 +1,7 @@
 # Recipe in conda-build format.
 # This recipe is only for Windows, see recipe.yaml for the Linux recipe in rattler-build format.
 
-{% set version = "4.3.0" %}
+{% set version = "4.3.2" %}
 {% set major_minor_version = ".".join(version.split(".")[:2]) %}
 
 package:
@@ -10,7 +10,7 @@ package:
 
 source:
   url: https://download.blender.org/release/Blender{{major_minor_version}}/blender-{{version}}-windows-x64.zip # [win64]
-  sha256: 68777b84f1e8970859428b3c4bc8e8675e8322b19e1566e0a90d575d00d257ac # [win64]
+  sha256: 933a62a770c941e316535f893629ff106ddd2aa5a956f0081ec557439073d4f6 # [win64]
   folder: blender
 
 build:

--- a/conda_recipes/blender-4.3/recipe/recipe.yaml
+++ b/conda_recipes/blender-4.3/recipe/recipe.yaml
@@ -2,7 +2,7 @@
 # See https://prefix-dev.github.io/rattler-build/latest/
 
 context:
-  version: "4.3.0"
+  version: "4.3.2"
   major_minor_version: "4.3"
 
 package:
@@ -13,12 +13,12 @@ source:
   - if: linux
     then:
       url: https://download.blender.org/release/Blender${{ major_minor_version }}/blender-${{ version }}-linux-x64.tar.xz
-      sha256: 6264ff4cf50baf6be6091a28d3c29cf25dc38d8daa3082874ce94d520d3e6ab6
+      sha256: 4da1c956673c0485e63054e563ee69198cc8f80d8157dd7592dffc8a6a5592e6
       target_directory: blender
   - if: win
     then:
       url: https://download.blender.org/release/Blender${{ major_minor_version }}/blender-${{ version }}-windows-x64.zip
-      sha256: 68777b84f1e8970859428b3c4bc8e8675e8322b19e1566e0a90d575d00d257ac
+      sha256: 933a62a770c941e316535f893629ff106ddd2aa5a956f0081ec557439073d4f6
       target_directory: blender
 
 build:

--- a/conda_recipes/deadline/recipe/recipe.yaml
+++ b/conda_recipes/deadline/recipe/recipe.yaml
@@ -32,8 +32,8 @@ requirements:
     - pyyaml >=6.0
     - typing-extensions >=4.8
     - python-xxhash >=3.4,<3.6
-    - jsonschema 4.17
-    - qtpy 2.4
+    - jsonschema 4.17.*
+    - qtpy 2.4.*
     - ${{ "pywin32 >=307,<309" if win }}
 
 tests:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Some recipes were stale, and the deadline recipe was failing with rattler-build.

### What was the solution? (How)

* Update the Blender 4.2 recipe to 4.2.5 and the Blender 4.3 recipe to 4.3.2.
* Add the `--output-dir archive_files` option to the download instructions to remove a necessary step when using the recipe.
* Update the deadline recipe to disambiguate a dependency version that was failing with rattler-build.

### What is the impact of this change?

Users of these samples get newer software by default and have fewer errors.

### How was this change tested?

Submitted the package builds to a Deadline farm and confirmed they succeeded.

### Was this change documented?

No

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*