### PR TITLE
fix: In package build modify original instead of rendered rattler-build recipe

### DIFF
--- a/conda_recipes/conda_build_linux_package/scripts/enter-package-build-env.sh
+++ b/conda_recipes/conda_build_linux_package/scripts/enter-package-build-env.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 ENV_NAME=
 CONDA_BLD_DIR=
 REUSE_ENV=1
+TEMP_DIR=
 
 # Parse the CLI arguments
 while [ $# -gt 0 ]; do
@@ -11,6 +12,7 @@ while [ $# -gt 0 ]; do
     --reuse-env) REUSE_ENV="$2" ; shift 2 ;;
     --env-name) ENV_NAME="$2" ; shift 2 ;;
     --conda-bld-dir) CONDA_BLD_DIR="$2" ; shift 2 ;;
+    --temp-dir) TEMP_DIR="$2" ; shift 2 ;;
     *) echo "Unexpected option: $1" ; exit 1 ;;
   esac
 done
@@ -22,6 +24,17 @@ fi
 if [ -z "$CONDA_BLD_DIR" ]; then
     echo "ERROR: Option --conda-bld-dir is required."
     exit 1
+fi
+
+if [ -n "$TEMP_DIR" ]; then
+    # Use an alternative temp dir
+    mkdir -p "$TEMP_DIR"
+    export TMP="$TEMP_DIR"
+    export TEMP="$TEMP_DIR"
+    export TMPDIR="$TEMP_DIR"
+    echo "openjd_env: TMP=$TMP"
+    echo "openjd_env: TEMP=$TEMP"
+    echo "openjd_env: TMPDIR=$TMPDIR"
 fi
 
 # Install an error handler to clean the Conda cache

--- a/conda_recipes/conda_build_linux_package/template.yaml
+++ b/conda_recipes/conda_build_linux_package/template.yaml
@@ -182,6 +182,8 @@ jobEnvironments:
         - '{{Session.WorkingDirectory}}/conda-bld'
         - '--reuse-env'
         - '{{Param.ReusePackageBuildEnv}}'
+        - '--temp-dir'
+        - '{{Session.WorkingDirectory}}/temp'
 
 steps:
 

--- a/conda_recipes/maya-openjd/recipe/recipe.yaml
+++ b/conda_recipes/maya-openjd/recipe/recipe.yaml
@@ -2,7 +2,7 @@
 # See https://prefix-dev.github.io/rattler-build/latest/
 
 context:
-  version: "0.14.3"
+  version: "0.14.4"
 
 package:
   name: maya-openjd
@@ -11,7 +11,7 @@ package:
 # This source reference uses the source archive published to PyPI
 source:
   url: https://pypi.io/packages/source/d/deadline-cloud-for-maya/deadline_cloud_for_maya-${{ version }}.tar.gz
-  sha256: d3789e4a14144b43224bc0657eacdb3e39e333aedc22ad29b8591530a185f845
+  sha256: 9b86a6c02df800ed3e69a3094c0f7d2aaa8b07304af34068fc41e2e14313268e
   patches:
     - 0001-Remove-version-hook.patch
 
@@ -28,7 +28,7 @@ requirements:
     - pip
   run:
     - python
-    - deadline 0.48.*
+    - deadline 0.49.*
     - openjd-adaptor-runtime 0.8.*
 
 tests:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Rendering a rattler-build recipe places both the build number and the build string in the rendered recipe. The code was substituting a new build number, and this did not reflect correctly into the build string.

In testing the recipes with the update, found that the maya-openjd recipe needed an update as well.

### What was the solution? (How)

Change the package build job to read values from the rendered recipe, but substitute them into to original recipe. Updated the maya-openjd recipe.yaml to match meta.yaml.

### What is the impact of this change?

Correct build number/string behavior when building with rattler-build.

### How was this change tested?

Built a majority of the sample recipes.

### Was this change documented?

No docs update.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*