### PR TITLE
feat: Create a starter_farm CFN template sample with README

### DIFF
--- a/cloudformation/farm_templates/apply-conda-queue-env.py
+++ b/cloudformation/farm_templates/apply-conda-queue-env.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+"""
+python apply-conda-queue-env.py CFN_YAML_TEMPLATE_FILE CONDA_QUEUE_ENVIRONMENT_FILE CONDA_CHANNELS_DEFAULT
+
+Modifies a farm YAML CloudFormation template to insert a provided conda queue environment.
+It modifies the default CondaChannels parameter default to prepend a provided S3 conda channel URL.
+
+For example, here's the command that was used for the starter_farm template:
+
+python apply-conda-queue-env.py starter_farm/deadline-cloud-starter-farm-template.yaml \
+       ../../queue_environments/conda_queue_env_improved_caching.yaml \
+       's3://${JobAttachmentsBucketName}/Conda/Default ${ProdCondaChannels}'
+
+Requirements:
+  1. The CloudFormation template must have delimiters around the queue environment content to substitute,
+     indented as desired. The delimiters are "### START_QUEUE_ENV" and "### END_QUEUE_ENV".
+  2. The conda queue environment template must have 'default: "deadline-cloud"' as the text that defines
+     the default value for its CondaChannels directory.
+"""
+import argparse
+import json
+from pathlib import Path
+import sys
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("cfn_yaml_template_file", type=Path, help="The YAML CloudFormation template to modify.")
+    parser.add_argument("conda_queue_environment_file", type=Path, help="The YAML conda queue environment to insert.")
+    parser.add_argument("conda_channels_default", help="Content to replace as the CondaChannels parameter default.")
+    args = parser.parse_args()
+
+    # Load the conda queue environment, and substitute the CondaChannels parameter default
+    queue_env = args.conda_queue_environment_file.read_text(encoding="utf-8")
+    conda_channels_default = 'default: "deadline-cloud"'
+    if conda_channels_default not in queue_env:
+        print(f"The provided conda queue environment does not contain {conda_channels_default!r}.")
+        sys.exit(1)
+    queue_env = queue_env.replace(conda_channels_default, f"default: {json.dumps(args.conda_channels_default)}").splitlines()
+
+    # Load the CFN template, and substitute the conda queue environment
+    cfn_template = args.cfn_yaml_template_file.read_text(encoding="utf-8")
+    start_delim = "### START_QUEUE_ENV"
+    end_delim = "### END_QUEUE_ENV"
+    if cfn_template.count(start_delim) != 1 or cfn_template.count(end_delim) != 1:
+        print(f"The provided CloudFormation contains {cfn_template.count(start_delim)} copies of {start_delim!r} and {cfn_template.count(end_delim)} copies of {end_delim!r}. It must contain one of each.")
+        sys.exit(1)
+    cfn_template = cfn_template.splitlines()
+
+    result_cfn_template = []
+    skipping_content = False
+    for line in cfn_template:
+        if skipping_content:
+            if end_delim in line:
+                skipping_content = False
+            else:
+                continue
+
+        result_cfn_template.append(line)
+        if start_delim in line:
+            prefix = line.split(start_delim, 1)[0]
+            result_cfn_template.extend(prefix + qe_line for qe_line in queue_env)
+            skipping_content = True
+    result_cfn_template.append("")
+
+    # Write the resulting CFN template
+    args.cfn_yaml_template_file.write_text("\n".join(result_cfn_template), encoding="utf-8")
+    print("The provided queue environment has been written into the CloudFormation template. \nPlease check your template and deploy it.")
+if __name__ == "__main__":
+    main()

--- a/cloudformation/farm_templates/starter_farm/README.md
+++ b/cloudformation/farm_templates/starter_farm/README.md
@@ -1,0 +1,248 @@
+# A starter AWS Deadline Cloud farm
+
+## Overview
+
+This CloudFormation template deploys an [AWS Deadline Cloud](https://aws.amazon.com/deadline-cloud/) farm
+you can use to run jobs that render images, reconstruct 3D scenes, or transform your data
+in custom ways. Sample jobs to submit are available in the
+[deadline-cloud-samples on GitHub](https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/job_bundles#readme),
+Deadline Cloud provides many [integrated submitter plugins for applications](https://github.com/aws-deadline/#integrations),
+and you can [build your own jobs](https://docs.aws.amazon.com/en_us/deadline-cloud/latest/developerguide/building-jobs.html).
+
+The deployed production queue supports conda virtual environments for the applications that jobs need.
+It configures two conda channels by default: a private channel on an S3 bucket you provide and the
+[deadline-cloud channel](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/create-queue-environment.html#conda-queue-environment).
+The `deadline-cloud` channel provides applications like Blender, Houdini, Maya, and Nuke.
+You can add the [conda-forge channel](https://conda-forge.org/) to this list when deploying the CloudFormation
+template to access packages created and maintained by the [conda-forge community](https://conda-forge.org/community/).
+When supported applications need licenses to run, they will use Deadline Cloud's
+usage-based licensing. See [Deadline Cloud pricing](https://aws.amazon.com/deadline-cloud/pricing/) to learn which
+applications are supported and the associated costs.
+
+See the section [Customizing the farm](#a-customizing) to learn how you can use the CloudFormation template parameters
+to adjust which fleets are deployed or fork this sample into your own template.
+
+## Prerequisites
+
+Before deploying this CloudFormation template, check that you have the following resources created in
+your AWS Account. The AWS region should be the same as the one you use to deploy the CloudFormation template.
+
+1. An Amazon S3 bucket to hold job attachments and your conda channel. From the
+   [Amazon S3 management console](https://s3.console.aws.amazon.com/s3/home), create an S3 bucket.
+   You will need the bucket name to deploy the CloudFormation template.
+2. A Deadline Cloud monitor to view and manage the jobs you will submit to your queues. From the
+   [AWS Deadline Cloud management console](https://console.aws.amazon.com/deadlinecloud/home),
+   select the "Go to Monitor setup" option and follow the steps to enter a name for your monitor URL,
+   enable IAM Identity Center, and then create a user login account to access the monitor. Your
+   monitor URL will look similar to `https://<ENTERED_MONITOR_NAME>.<AWS_REGION>.deadlinecloud.amazonaws.com/`,
+   You will need this URL to log in with the Deadline Cloud monitor desktop application.
+
+## Setup Instructions
+
+### Deploy the CloudFormation template to your AWS account
+
+1. Download the [deadline-cloud-starter-farm-template.yaml](deadline-cloud-starter-farm-template.yaml)
+   CloudFormation template.
+2. From the [CloudFormation management console](https://console.aws.amazon.com/cloudformation/),
+   navigate to Create Stack > With new resources (standard).
+3. Select the option to Upload a template file, then upload the `deadline-cloud-starter-farm-template.yaml`
+   file that you downloaded.
+4. Enter a name for the stack, like "StarterFarm", the S3 bucket name you created or selected during
+   prerequisites, and any parameter customizations:
+   1. If you want to use the [conda-forge channel](https://conda-forge.org/), change the parameter
+      value for ProdCondaChannels to "deadline-cloud conda-forge". The sample job bundle
+      [Turntable with Maya/Arnold](https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/job_bundles/turntable_with_maya_arnold)
+      shows how you can use the FFmpeg provided by conda-forge to encode a video.
+   2. Edit the fleet configuration parameters if you need a higher vCPU count, more RAM, more EBS bandwidth, etc.
+5. Follow the CloudFormation console steps to complete stack creation.
+6. From the [AWS Deadline Cloud management console](https://us-west-2.console.aws.amazon.com/deadlinecloud/home),
+   navigate to the farm that you created, and select the "Access management" tab. Select "Users",
+   then "Add user", and then add the user you created for yourself from the prerequisites. Use the "Owner"
+   access level to give yourself full access.
+
+### Install the Deadline client tools on your workstation
+
+1. From the [AWS Deadline Cloud management console](https://console.aws.amazon.com/deadlinecloud/home),
+   select the "Downloads" page on the left navigation area.
+2. Download and install the Deadline Cloud monitor desktop application. Use your monitor URL and
+   the user account from the prerequisites to log in from the Deadline Cloud monitor desktop. This also
+   provides AWS credentials to the Deadline Cloud CLI.
+3. Download and install the Deadline Cloud submitter installer for your platform, or install the
+   Deadline Cloud CLI into your existing Python installation [from PyPI](https://pypi.org/project/deadline/)
+   using a command like `pip install "deadline[gui]"`. You can then use the command
+   `deadline handle-web-url --install` to install the job attachments download handler on supported operating systems.
+4. From the terminal, run the command `deadline config gui`, and select the farm and production queue you deployed.
+   Select OK to apply the settings.
+
+### Initialize the S3 conda channel
+
+#### Option 1: To initialize the channel with an empty `repodata.json`:
+
+1. Create a file `empty_channel_repodata.json` and edit to contain the following:
+   ```
+   {"info":{"subdir":"noarch"},"packages":{},"packages.conda":{},"removed":[],"repodata_version":1}
+   ```
+2. Substitute the job attachments bucket name into the following command to upload and initialize the channel:
+   ```
+   aws s3api put-object --body empty_channel_repodata.json --key Conda/Default/noarch/repodata.json --bucket <JOB_ATTACHMENTS_BUCKET>
+   ```
+
+### Option 2: To initialize the channel by building a conda package:
+
+The `deadline` package recipe used by this option depends on other packages in the `conda-forge` channel, so will work best if you
+added `conda-forge` to the ProdCondaChannels parameter to the CloudFormation template.
+
+1. If you don't have a local copy of [deadline-cloud-samples](https://github.com/aws-deadline/deadline-cloud-samples)
+   GitHub repository, you can make a git clone or
+   [download it as a ZIP](https://github.com/aws-deadline/deadline-cloud-samples/archive/refs/heads/mainline.zip).
+2. From the `conda_recipes` directory of `deadline-cloud-samples`, run the following command. If you deployed
+   different fleets than the default, you may need to adjust the conda platforms expression. See
+   [the conda recipe samples README](https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/conda_recipes#readme)
+   to learn more about this command.
+   ```
+   $ ./submit-package-build deadline -p "linux-64*"
+   ```
+3. From Deadline Cloud monitor, navigate to the package build queue to watch the job you submitted.
+   When it is running, right click on the task and select "View logs". It may take several minutes as Deadline Cloud
+   starts an instance in your fleet to run the job.
+4. When the step "ReindexCondaChannel" is complete, the S3 conda channel is initialized
+   and the `deadline` package you built is available.
+
+## Submit a test job
+
+This test job runs the `imagemagick identify` command on a directory of images to
+extract properties of the images and write them to a text file.
+
+Before proceeding with this test job, make sure the S3 conda channel is initialized according to the instructions above.
+An uninitialized conda channel will fail during the "Launch Conda" action.
+
+1. If you don't have a local copy of [deadline-cloud-samples](https://github.com/aws-deadline/deadline-cloud-samples)
+   GitHub repository, you can make a git clone or
+   [download it as a ZIP](https://github.com/aws-deadline/deadline-cloud-samples/archive/refs/heads/mainline.zip).
+2. From the `job_bundles` directory of `deadline-cloud-samples`, run the following command:
+   ```
+   $ deadline bundle gui-submit cli_job
+   ```
+3. From the "Shared job settings" tab, give the job a name like "Starter farm test job",
+   then enter "imagemagick" into the "Conda Packages" parameter and if it's not already included,
+   add "conda-forge" to the "Conda Channels" parameter. These parameters
+   are for the conda queue environment that provides applications to the job.
+4. From the "Job-specific settings" tab, select the directory `turntable_with_maya_arnold`
+   within the samples as the "Input/Output Data Directory". This directory has some .png files to process.
+5. Replace the "Bash Script" text box contents with the following script:
+   ```
+   find . -type f -iname "*.png" -exec magick identify {} \; | tee identified_images.txt
+   ```
+6. Select "Submit" and accept any prompts to submit the job to your queue.
+7. From Deadline Cloud monitor, navigate to the production queue to watch the job you submitted.
+   When it is running, right click on the task and select "View logs". It may take several minutes as
+   Deadline cloud starts an instance in your fleet to run the job. Within the log, you can find output
+   that is similar to:
+   ```
+   + find . -type f -iname '*.png' -exec magick identify '{}' ';'
+   + tee identified_images.txt
+   ./screenshots/turntable_job_bundle_submitter_gui.png PNG 657x844 657x844+0+0 8-bit sRGB 59671B 0.
+   ./screenshots/windows_desktop_submitter_bat_file.png PNG 237x231 237x231+0+0 8-bit sRGB 29790B 0.
+   ./screenshots/turntable_job_output_video_screenshot.png PNG 962x693 962x693+0+0 8-bit sRGB 674715B 0.000u 0:00.000
+   ```
+8. When it is complete, download the output of the job. The custom script you entered populates a text file
+   with image metadata. The output is written to the provided input/output directory, so look in the
+   `turntable_with_maya_arnold` directory to find a file `identified_images.txt` with contents matching
+   the logged output from the job:
+   ```
+   ./screenshots/turntable_job_bundle_submitter_gui.png PNG 657x844 657x844+0+0 8-bit sRGB 59671B 0.000u 0:00.000
+   ./screenshots/windows_desktop_submitter_bat_file.png PNG 237x231 237x231+0+0 8-bit sRGB 29790B 0.000u 0:00.000
+   ./screenshots/turntable_job_output_video_screenshot.png PNG 962x693 962x693+0+0 8-bit sRGB 674715B 0.000u 0:00.000
+   ```
+
+You can also submit the sample job with a single command from your terminal as follows:
+
+```
+$ deadline bundle submit cli_job \
+      --name "Starter farm test job" \
+      -p CondaPackages=imagemagick \
+      -p DataDir=./turntable_with_maya_arnold \
+      -p 'BashScript=find . -type f -iname "*.png" -exec magick identify {} \; | tee identified_images.txt'
+```
+
+## Use the farm for production
+
+### Set up more users and groups with farm access
+
+Use the [AWS IAM Identity Center management console](https://aws.amazon.com/iam/identity-center/)
+to create more users and groups, then give them permission to access the farm
+from the [AWS Deadline Cloud management console](https://us-west-2.console.aws.amazon.com/deadlinecloud/home).
+
+### Build more conda packages
+
+See the [conda recipe samples](../../../conda_recipes/README.md) to learn about the package building
+queue deployed by the template. If you write custom tools and plugins, you can write your own conda package recipes
+to provide them to the farm.
+
+### Run jobs from job bundles
+
+Run jobs from the [job bundle samples](../../../job_bundles/README.md). Make copies of the code and build your own.
+
+### Run jobs from DCC integrated submitters
+
+Run the submitter installer in the downloads section of the
+[AWS Deadline Cloud management console](https://console.aws.amazon.com/deadlinecloud/home),
+or start from the [submitter source code on GitHub](https://github.com/aws-deadline/).
+
+## Customize the farm<a id='a-customizing'></a>
+
+### Select fleets to deploy
+
+By deploying fleets with multiple different hardware configurations, you can create a farm that supports
+a wide variety of jobs. The starter farm CloudFormation template comes with three different fleet configurations:
+a CPU Linux fleet, a CPU Windows fleet, and a CUDA Linux fleet. Each fleet that you name will be deployed,
+and if you set its name to be empty, it will be skipped.
+
+When different steps of your jobs have different requirements, you can edit your job template to have
+[`<HostRequirements>`](https://github.com/OpenJobDescription/openjd-specifications/wiki/2023-09-Template-Schemas#33-hostrequirements)
+that control the operating system, memory requirements, or whether a GPU is available for each step.
+You can make a job that exports .vrscene files on Windows using Autodesk 3ds Max, and then renders
+them with standalone Chaos V-Ray on Linux. You can make jobs that prepare data on lower cost CPU-only
+fleets, and then train NeRF or Gaussian splatting on a CUDA fleet.
+
+### Customize the CloudFormation template parameters
+
+Each fleet has parameters to control the maximum number of workers, whether to use spot or on-demand
+instances, and control the vCPUs and RAM of worker hosts. If you use spot instances, you generally want
+to include wider ranges of these properties when possible to increase the available instance types you
+can get.
+
+The default conda channels that come after the S3 conda channel are controlled by a parameter
+that defaults to "deadline-cloud". You can modify this to include [conda-forge](https://conda-forge.org/) or
+such as [bioconda](https://bioconda.github.io/).
+
+### Modify the conda queue environment for the production queue
+
+The CloudFormation template includes a queue environment that creates conda virtual environments for jobs
+to use. By default, this is the sample queue environment
+[conda_queue_env_improved_caching.yaml](https://github.com/aws-deadline/deadline-cloud-samples/blob/mainline/queue_environments/conda_queue_env_improved_caching.yaml). You can run the provided Python script
+[apply-conda-queue-env.py](../apply-conda-queue-env.py) to substitute a different queue environment.
+For example, the following command would switch it to the sample
+[conda_queue_env_from_console.yaml](https://github.com/aws-deadline/deadline-cloud-samples/blob/mainline/queue_environments/conda_queue_env_from_console.yaml):
+
+```
+$ python ../apply-conda-queue-env.py \
+      deadline-cloud-starter-farm-template.yaml \
+      ../../../queue_environments/conda_queue_env_from_console.yaml \
+      's3://${JobAttachmentsBucketName}/Conda/Default ${ProdCondaChannels}'
+```
+
+### Create a CloudFormation template for your own farm
+
+If you want to organize the queues in your farm differently from this starter sample, or you need a different
+set of fleet configurations, you can copy this CloudFormation template and start editing it. We recommend
+you follow Infrastructure as Code best practices, such as keeping your templates in version control and
+strictly making changes by editing the template and deploying it instead of mixing CloudFormation together
+with manual infrastructure updates from the AWS console. See the
+[AWS Well-Architected guidance on Infrastructure as Code](https://docs.aws.amazon.com/wellarchitected/latest/devops-guidance/dl.eac.1-organize-infrastructure-as-code-for-scale.html)
+to dive deeper into this topic.
+
+When you strike out on your own from the starter farm sample, you may find it helpful to first delete the
+`Metadata` section that controls the user interface, and remove the `Conditions` along with where they are used.
+These sections make a single template more flexible, but when you're using the code to define one particular
+farm, they add unnecessary complexity.

--- a/cloudformation/farm_templates/starter_farm/deadline-cloud-starter-farm-template.yaml
+++ b/cloudformation/farm_templates/starter_farm/deadline-cloud-starter-farm-template.yaml
@@ -1,0 +1,1012 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: >
+  An AWS Deadline Cloud farm that you can use to run jobs on Linux or Windows. Its default configuration
+  includes a queue for production jobs, a second queue for building conda packages, and a CPU-only
+  Linux fleet. You can provide parameter values to deploy more fleet types.
+
+  See the README.md included with the CloudFormation template to learn more.
+
+Parameters:
+  JobAttachmentsBucketName:
+    Type: String
+    Description: The S3 bucket to use for job attachments and the default S3 conda channel.
+    MinLength: 1
+
+  # Deadline Cloud farm
+  FarmName:
+    Type: String
+    Description: The name of the farm.
+    Default: "Starter Deadline Cloud Farm"
+    MinLength: 1
+  FarmDescription:
+    Type: String
+    Description: The description of the farm.
+    Default: "Deadline Cloud farm deployed from the starter_farm sample CloudFormation template."
+
+  # Deadline Cloud queues
+  ProdQueueName:
+    Type: String
+    Description: The name of the production queue.
+    Default: "Production Job Queue"
+    MinLength: 1
+  ProdQueueDescription:
+    Type: String
+    Description: The description of the production queue.
+    Default: "The Deadline Cloud queue for running production jobs."
+    MinLength: 1
+  ProdCondaChannels:
+    Type: String
+    Description: >
+      The conda channels to use by default in the production queue alongside the default
+      S3 channel on the job attachments bucket. Separate each channel with a space.
+      For example, change this to "deadline-cloud conda-forge" to also include packages
+      from the https://conda-forge.org/ community.
+    Default: "deadline-cloud"
+  PackageBuildQueueName:
+    Type: String
+    Description: >
+      The name of the queue for building conda packages.
+    Default: "Package Build Queue"
+    MinLength: 1
+  PackageBuildQueueDescription:
+    Type: String
+    Description: The description of the package build queue.
+    Default: "The Deadline Cloud queue for building conda packages."
+
+  # Fleet names
+  CPULinuxFleetName:
+    Type: String
+    Description: The name of your Linux fleet with only CPUs. Set it to empty if you do not want a CPU Linux fleet.
+    Default: "CPU Linux Fleet"
+  CPUWindowsFleetName:
+    Type: String
+    Description: The name of your Windows fleet with only CPUs. Set it to empty if you do not want a CPU Windows fleet.
+    Default: ""
+  CUDALinuxFleetName:
+    Type: String
+    Description: The name of your Linux fleet with CUDA GPUs. Set it to empty if you do not want a CUDA Linux fleet.
+    Default: ""
+
+  # CPU Linux fleet properties
+  CPULinuxInstanceMarketType:
+    Type: String
+    Description: Whether to use on-demand or spot instances in the CPU Linux fleet.
+    Default: spot
+    AllowedValues:
+      - on-demand
+      - spot
+  MaxCPULinuxWorkerCount:
+    Type: Number
+    Description: How many worker hosts in the CPU Linux Fleet.
+    Default: 10
+  MinCPULinuxVcpu:
+    Type: Number
+    Description: Minimum number of vCPUs for instances in the CPU Linux fleet.
+    Default: 2
+  MaxCPULinuxVcpu:
+    Type: Number
+    Description: Maximum number of vCPUs for instances in the CPU Linux fleet.
+    Default: 8
+  MinCPULinuxRamMiB:
+    Type: Number
+    Description: Minimum MiB RAM for instances in the CPU Linux fleet.
+    Default: 16384
+
+  # CPU Windows fleet properties
+  CPUWindowsInstanceMarketType:
+    Type: String
+    Description: Whether to use on-demand or spot instances in the CPU Windows fleet.
+    Default: spot
+    AllowedValues:
+      - on-demand
+      - spot
+  MaxCPUWindowsWorkerCount:
+    Type: Number
+    Description: How many worker hosts in the CPU Windows Fleet.
+    Default: 10
+  MinCPUWindowsVcpu:
+    Type: Number
+    Description: Minimum number of vCPUs for instances in the CPU Windows fleet.
+    Default: 2
+  MaxCPUWindowsVcpu:
+    Type: Number
+    Description: Maximum number of vCPUs for instances in the CPU Windows fleet.
+    Default: 8
+  MinCPUWindowsRamMiB:
+    Type: Number
+    Description: Minimum MiB RAM for instances in the CPU Windows fleet.
+    Default: 16384
+
+  # CUDA Linux fleet properties
+  CUDALinuxInstanceMarketType:
+    Type: String
+    Description: Whether to use on-demand or spot instances in the CUDA Linux fleet.
+    Default: on-demand
+    AllowedValues:
+      - on-demand
+      - spot
+  MaxCUDALinuxWorkerCount:
+    Type: Number
+    Description: How many worker hosts in the CUDA Linux Fleet.
+    Default: 1
+  MinCUDALinuxVcpu:
+    Type: Number
+    Description: Minimum number of vCPUs for instances in the CUDA Linux fleet.
+    Default: 4
+  MaxCUDALinuxVcpu:
+    Type: Number
+    Description: Maximum number of vCPUs for instances in the CUDA Linux fleet.
+    Default: 16
+  MinCUDALinuxRamMiB:
+    Type: Number
+    Description: Minimum MiB RAM for instances in the CUDA Linux fleet.
+    Default: 32768
+
+  # EBS volume properties
+  RootEbsVolumeSizeGiB:
+    Type: Number
+    Description: EBS volume size GiB to use in the fleets.
+    Default: 300
+  RootEbsVolumeIops:
+    Type: Number
+    Description: EBS volume IOPS to use in the fleets.
+    Default: 3000
+  RootEbsVolumeThroughputMiB:
+    Type: Number
+    Description: EBS volume throughput MiB to use in the fleets.
+    Default: 125
+
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: "Required Farm Parameters"
+        Parameters:
+          - JobAttachmentsBucketName
+
+      - Label:
+          default: "Farm and Queue Names"
+        Parameters:
+          - FarmName
+          - ProdQueueName
+          - PackageBuildQueueName
+
+      - Label:
+          default: "Fleet Names (an empty name skips the fleet)"
+        Parameters:
+          - CPULinuxFleetName
+          - CPUWindowsFleetName
+          - CUDALinuxFleetName
+
+      - Label:
+          default: "Farm and Queue Configuration"
+        Parameters:
+          - ProdCondaChannels
+          - FarmDescription
+          - ProdQueueDescription
+          - PackageBuildQueueDescription
+
+      - Label:
+          default: "CPU-Linux Fleet Configuration"
+        Parameters:
+          - MaxCPULinuxWorkerCount
+          - CPULinuxInstanceMarketType
+          - MinCPULinuxVcpu
+          - MaxCPULinuxVcpu
+          - MinCPULinuxRamMiB
+
+      - Label:
+          default: "CPU-Windows Fleet Configuration"
+        Parameters:
+          - MaxCPUWindowsWorkerCount
+          - CPUWindowsInstanceMarketType
+          - MinCPUWindowsVcpu
+          - MaxCPUWindowsVcpu
+          - MinCPUWindowsRamMiB
+
+      - Label:
+          default: "CUDA-Linux Fleet Configuration"
+        Parameters:
+          - MaxCUDALinuxWorkerCount
+          - CUDALinuxInstanceMarketType
+          - MinCUDALinuxVcpu
+          - MaxCUDALinuxVcpu
+          - MinCUDALinuxRamMiB
+
+      - Label:
+          default: "EBS Volume Configuration (all fleets)"
+        Parameters:
+          - RootEbsVolumeSizeGiB
+          - RootEbsVolumeIops
+          - RootEbsVolumeThroughputMiB
+
+    ParameterLabels:
+      JobAttachmentsBucketName:
+        default: "Job Attachments S3 Bucket"
+      FarmName:
+        default: "Farm Name"
+      FarmDescription:
+        default: "Farm Description"
+      ProdQueueName:
+        default: "Production Queue Name"
+      ProdQueueDescription:
+        default: "Production Queue Description"
+      ProdCondaChannels:
+        default: "Production Queue Conda Channels"
+      PackageBuildQueueName:
+        default: "Package Build Queue Name"
+      PackageBuildQueueDescription:
+        default: "Package Build Queue Description"
+
+      CPULinuxFleetName:
+        default: "CPU-Linux Fleet Name"
+      CPULinuxInstanceMarketType:
+        default: "CPU-Linux Instance Purchase Type"
+      MaxCPULinuxWorkerCount:
+        default: "Maximum CPU-Linux Workers"
+      MinCPULinuxVcpu:
+        default: "Minimum CPU-Linux vCPUs"
+      MaxCPULinuxVcpu:
+        default: "Maximum CPU-Linux vCPUs"
+      MinCPULinuxRamMiB:
+        default: "Minimum CPU-Linux RAM (MiB)"
+
+      CPUWindowsFleetName:
+        default: "CPU-Windows Fleet Name"
+      CPUWindowsInstanceMarketType:
+        default: "CPU-Windows Instance Purchase Type"
+      MaxCPUWindowsWorkerCount:
+        default: "Maximum CPU-Windows Workers"
+      MinCPUWindowsVcpu:
+        default: "Minimum CPU-Windows vCPUs"
+      MaxCPUWindowsVcpu:
+        default: "Maximum CPU-Windows vCPUs"
+      MinCPUWindowsRamMiB:
+        default: "Minimum CPU-Windows RAM (MiB)"
+
+      CUDALinuxFleetName:
+        default: "CUDA-Linux Fleet Name"
+      CUDALinuxInstanceMarketType:
+        default: "CUDA-Linux Instance Purchase Type"
+      MaxCUDALinuxWorkerCount:
+        default: "Maximum CUDA-Linux Workers"
+      MinCUDALinuxVcpu:
+        default: "Minimum CUDA-Linux vCPUs"
+      MaxCUDALinuxVcpu:
+        default: "Maximum CUDA-Linux vCPUs"
+      MinCUDALinuxRamMiB:
+        default: "Minimum CUDA-Linux RAM (MiB)"
+
+      RootEbsVolumeSizeGiB:
+        default: "Root Volume Size (GiB)"
+      RootEbsVolumeIops:
+        default: "Root Volume IOPS"
+      RootEbsVolumeThroughputMiB:
+        default: "Root Volume Throughput (MiB)"
+
+
+Conditions:
+
+  HasCPULinuxFleet: !Not [!Equals [!Ref CPULinuxFleetName, ""]]
+  HasCPUWindowsFleet: !Not [!Equals [!Ref CPUWindowsFleetName, ""]]
+  HasCUDALinuxFleet: !Not [!Equals [!Ref CUDALinuxFleetName, ""]]
+
+
+Resources:
+
+  farm:
+    Type: AWS::Deadline::Farm
+    Properties:
+      DisplayName: !Ref FarmName
+      Description: !Ref FarmDescription
+
+  queue:
+    Type: AWS::Deadline::Queue
+    Properties:
+      DisplayName: !Ref ProdQueueName
+      Description: !Ref ProdQueueDescription
+      FarmId: !GetAtt farm.FarmId
+      JobAttachmentSettings:
+        S3BucketName: !Ref JobAttachmentsBucketName
+        RootPrefix: DeadlineCloud
+      RoleArn: !GetAtt queueIAMRole.Arn
+
+  condaQueueEnv:
+    Type: AWS::Deadline::QueueEnvironment
+    Properties:
+      FarmId: !GetAtt farm.FarmId
+      QueueId: !GetAtt queue.QueueId
+      Priority: 1
+      # The start and end delimiters are used by the apply-conda-queue-env.py script
+      # to insert a specified queue environment template. The template provided as a sample is the result
+      # of running the following:
+      #
+      # $ python ../apply-conda-queue-env.py deadline-cloud-starter-farm-template.yaml \
+      #          ../../../queue_environments/conda_queue_env_improved_caching.yaml \
+      #          's3://${JobAttachmentsBucketName}/Conda/Default ${ProdCondaChannels}'
+      Template: !Sub |
+        ### START_QUEUE_ENV
+        specificationVersion: "environment-2023-09"
+        parameterDefinitions:
+        # CondaPackages and CondaChannels are compatible with the other Conda queue environment templates
+        - name: CondaPackages
+          type: STRING
+          description: >
+            This is a space-separated list of Conda package match specifications to
+            install for the job. E.g. "blender=3.6" for a job that renders frames in
+            Blender 3.6.
+          default: ""
+          userInterface:
+            control: LINE_EDIT
+            label: Conda Packages
+        - name: CondaChannels
+          type: STRING
+          description: >
+            This is a space-separated list of Conda channels from which to install
+            packages. Deadline Cloud SMF packages are installed from the
+            "deadline-cloud" channel that is configured by Deadline Cloud.
+
+            Add "conda-forge" to get packages from the https://conda-forge.org/
+            community, and "defaults" to get packages from Anaconda Inc (make sure
+            your usage complies with https://legal.anaconda.com/policies).
+          default: "s3://${JobAttachmentsBucketName}/Conda/Default ${ProdCondaChannels}"
+          userInterface:
+            control: LINE_EDIT
+            label: Conda Channels
+
+        - name: NamedCondaEnv
+          description: |
+            If empty, the Conda environment is created only for the session. If provided,
+            a named Conda environment is reused across any jobs/sessions that run on the worker host.
+            When reusing an environment, the parameter NamedCondaEnvUpdateAfterMinutes controls
+            how long it will use the environment without checking for package updates.
+
+            If the name is "AUTOMATIC", the environment name is determined by taking the hash of the
+            CondaPackages and CondaChannels parameters, so that jobs providing identical values for
+            these parameters will share the same named Conda environment. Automatically-named environments
+            are deleted by the onExit action if they haven't been updated in more than 96 hours.
+
+            If you select a name explicitly, take care to use the environment names consistently, because
+            different jobs can define the same named environment in a different way.
+
+            When creating or updating this environment, it prints information about the operations
+            to the log file "$CONDA_PREFIX/var/log/conda_queue_env.log".
+          type: STRING
+          default: "AUTOMATIC"
+          userInterface:
+            control: LINE_EDIT
+            label: Named Conda Environment
+
+        - name: NamedCondaEnvAction
+          description: |
+            When a NamedCondaEnv is selected, controls how to treat it.
+              1. ACTIVATE activates the existing named environment, or creates one if it
+                 doesn't exist. If it's been NamedCondaEnvUpdateAfterMinutes since creation
+                 or the last update, it updates the environment.
+              2. REMOVE_AND_CREATE always removes the existing named environment, and creates
+                 a new one from scratch.
+          type: STRING
+          default: "ACTIVATE"
+          allowedValues: ["ACTIVATE", "REMOVE_AND_CREATE"]
+          userInterface:
+            control: DROPDOWN_LIST
+            label: Named Conda Environment Action
+
+        - name: NamedCondaEnvUpdateAfterMinutes
+          description: |
+            When NamedCondaEnvAction is ACTIVATE, this controls how long it will use the named
+            Conda environment before doing another update.
+          type: INT
+          default: 600
+          userInterface:
+            control: SPIN_BOX
+            label: Named Conda Environment Update After (Minutes)
+
+        - name: RunCondaClean
+          description: |
+            If set to True, runs the command 'conda clean --yes --all' before creating the Conda environment.
+            This removes Conda caches for the package index, package files, and package directories.
+          type: STRING
+          default: "False"
+          allowedValues: ["True", "False"]
+          userInterface:
+            control: CHECK_BOX
+            label: Clean the Conda Cache
+
+        environment:
+          name: Conda
+          script:
+            actions:
+              onEnter:
+                command: "bash"
+                args: ["{{Env.File.Enter}}"]
+              onExit:
+                command: "bash"
+                args: ["{{Env.File.Exit}}"]
+            embeddedFiles:
+            - name: Enter
+              filename: conda-queue-env-enter.sh
+              type: TEXT
+              data: |
+                set -euo pipefail
+
+                if [ -z '{{Param.CondaPackages}}' ]; then
+                    echo "Skipping Conda env as CondaPackages parameter was empty."
+                    exit 0
+                fi
+
+                # Install an error handler to clean the cache if there is an error creating the virtual environment
+                function conda_clean_on_error {
+                    if [ ! "$1" = "0" ]; then
+                      echo "Error detected, cleaning the Conda cache."
+                      conda clean --yes --all
+                    fi
+                }
+                trap 'conda_clean_on_error $?' EXIT
+
+                function remove_named_env {
+                    for ENVS_DIR in $(conda info --json | python -c "import json, sys; v = json.load(sys.stdin); print('\n'.join(v['envs_dirs']))"); do
+                        if [ -d $ENVS_DIR/$1 ]; then
+                            echo "Removing directory $ENVS_DIR/$1 for the environment"
+                            rm -rf $ENVS_DIR/$1
+                            if [ -d $ENVS_DIR/$1 ]; then
+                                echo "ERROR: Could not remove the directory. Possibly a permissions error or a process holding a lock."
+                                exit 1
+                            fi
+                        fi
+                    done
+                }
+
+                NAMED_CONDA_ENV='{{Param.NamedCondaEnv}}'
+
+                # If the special name 'AUTOMATIC' is provided, use the hash of the CondaChannels and CondaPackages
+                # parameters to generate the actual name.
+                if [ -n "$NAMED_CONDA_ENV" ] && [ "$NAMED_CONDA_ENV" = 'AUTOMATIC' ]; then
+                    echo 'Using an automatic name for the Conda environment, based on the hash of these values:'
+                    echo '  CondaChannels: {{Param.CondaChannels}}'
+                    echo '  CondaPackages: {{Param.CondaPackages}}'
+
+                    NAMED_CONDA_ENV="hashname_$(echo 'Channels/{{Param.CondaChannels}} -- Packages/{{Param.CondaPackages}}' | sha256sum | cut -d " " -f 1 | head -c 24)"
+                    echo "Automatic name is $NAMED_CONDA_ENV"
+                fi
+
+                # If we're not reusing the Conda env, clean up any prior ones
+                if [ '{{Param.NamedCondaEnvAction}}' = 'REMOVE_AND_CREATE' ] && [ -n "$NAMED_CONDA_ENV" ]; then
+                    echo "NamedCondaEnvAction parameter is set to REMOVE_AND_CREATE, removing the virtual environment..."
+                    remove_named_env "$NAMED_CONDA_ENV"
+                fi
+
+                # If requested, clean the Conda package cache
+                if [ '{{Param.RunCondaClean}}' = 'True' ]; then
+                    echo "RunCondaClean parameter is True, cleaning the Conda cache..."
+                    conda clean --yes --all
+                fi
+
+                # Convert the space-separated list of channels into consecutive '-c' channel options
+                CHANNEL_OPTS="$(echo '{{Param.CondaChannels}}' | sed -r 's/(\s+|^)(\S)/ -c \2/g')"
+                # Put the conda packages list in a variable, as package specs can have characters like '|' in them
+                CONDA_PACKAGES='{{Param.CondaPackages}}'
+
+                # Initialize/activate the Conda virtual environment
+                if [ -n "$NAMED_CONDA_ENV" ] && conda env list | grep -q "^$NAMED_CONDA_ENV "; then
+                    echo "Reusing the existing named Conda environment $NAMED_CONDA_ENV."
+
+                    # Activate the Conda environment
+                    python '{{Env.File.OpenJDVarsStart}}' .vars
+                    set +u
+                    conda activate "$NAMED_CONDA_ENV"
+                    set -u
+                    python '{{Env.File.OpenJDVarsCapture}}' .vars
+
+                    CUR_TIMESTAMP="$(date +%s)"
+                    TIMESTAMP_FILE="$CONDA_PREFIX/var/log/conda_queue_env_update_timestamp"
+                    if [ -f "$TIMESTAMP_FILE" ]; then
+                        PREV_UPDATE_TIMESTAMP="$(cat "$TIMESTAMP_FILE")"
+                        MINUTES_SINCE_UPDATE="$(( ( $CUR_TIMESTAMP - $PREV_UPDATE_TIMESTAMP ) / 60 ))"
+                    else
+                        echo "The file recording the previous timestamp was not found"
+                        MINUTES_SINCE_UPDATE=0
+                    fi
+                    echo "Minutes elapsed since last update of this named Conda environment: $MINUTES_SINCE_UPDATE"
+
+                    if [ $MINUTES_SINCE_UPDATE -ge {{Param.NamedCondaEnvUpdateAfterMinutes}} ]; then
+                        echo "Elapsed time greater than or equal to {{Param.NamedCondaEnvUpdateAfterMinutes}} minutes, updating the environment packages to the latest"
+                        set +u
+                        conda install --yes \
+                            --update-all \
+                            $CONDA_PACKAGES \
+                            $CHANNEL_OPTS
+                        set -u
+
+                        # Save the channels and packages used in the environment, to help out debugging
+                        LOGFILE="$CONDA_PREFIX/var/log/conda_queue_env.log"
+                        echo "Updated $NAMED_CONDA_ENV env at $(date --iso-8601=minutes)" >> "$LOGFILE"
+                        echo '  CondaChannels: {{Param.CondaChannels}}' >> "$LOGFILE"
+                        echo '  CondaPackages: {{Param.CondaPackages}}' >> "$LOGFILE"
+
+                        # Save a timestamp of when we updated
+                        echo "$CUR_TIMESTAMP" > "$CONDA_PREFIX/var/log/conda_queue_env_update_timestamp"
+                    else
+                        echo "Elapsed time less than {{Param.NamedCondaEnvUpdateAfterMinutes}} minutes, skipping updates"
+                    fi
+                elif [ -n "$NAMED_CONDA_ENV" ]; then
+                    echo "Named Conda environment $NAMED_CONDA_ENV not found, creating it."
+
+                    # Make sure there's no incomplete environment hanging around
+                    remove_named_env "$NAMED_CONDA_ENV"
+
+                    # Create the virtual environment
+                    conda create --yes \
+                        --name "$NAMED_CONDA_ENV" \
+                        $CONDA_PACKAGES \
+                        $CHANNEL_OPTS
+
+                    # Activate the Conda environment
+                    python '{{Env.File.OpenJDVarsStart}}' .vars
+                    set +u
+                    conda activate "$NAMED_CONDA_ENV"
+                    set -u
+                    python '{{Env.File.OpenJDVarsCapture}}' .vars
+
+                    # Save the channels and packages used in the environment, to help out debugging
+                    LOGFILE="$CONDA_PREFIX/var/log/conda_queue_env.log"
+                    mkdir -p "$(dirname $LOGFILE)"
+                    echo "Created $NAMED_CONDA_ENV env at $(date --iso-8601=minutes)" >> "$LOGFILE"
+                    echo '  CondaChannels: {{Param.CondaChannels}}' >> "$LOGFILE"
+                    echo '  CondaPackages: {{Param.CondaPackages}}' >> "$LOGFILE"
+
+                    # Save a timestamp of when we updated
+                    date +%s > "$CONDA_PREFIX/var/log/conda_queue_env_update_timestamp"
+                else
+                    echo "Creating temporary Conda environment in the session directory..."
+
+                    # Create the virtual environment
+                    conda create --yes \
+                        -p '{{Session.WorkingDirectory}}/.env' \
+                        $CONDA_PACKAGES \
+                        $CHANNEL_OPTS
+
+                    # Activate the Conda environment
+                    python '{{Env.File.OpenJDVarsStart}}' .vars
+                    set +u
+                    conda activate '{{Session.WorkingDirectory}}/.env'
+                    set -u
+                    python '{{Env.File.OpenJDVarsCapture}}' .vars
+                fi
+
+                # Print information about the environment
+                conda info
+            - name: Exit
+              filename: conda-queue-env-exit.sh
+              type: TEXT
+              data: |
+                set -euo pipefail
+
+                # When using this queue environment on long-lived worker hosts, such as on premises,
+                # automatically named conda environments can accumulate. This code removes them after
+                # 96 hours of unuse. 96 hours was chosen so the caches stick around for a long weekend.
+
+                DELETE_AFTER_HOURS=96
+
+                echo "Cleaning up automatically-named conda environments not updated within $DELETE_AFTER_HOURS hours."
+
+                AUTO_CONDA_ENVS="$(conda env list | grep "^hashname_" | cut -d " " -f 1)"
+                REMOVED_ENV=0
+
+                CUR_TIMESTAMP="$(date +%s)"
+                for ENV_NAME in $AUTO_CONDA_ENVS; do
+                    echo "Checking environment $ENV_NAME"
+
+                    set +u
+                    conda activate $ENV_NAME
+                    set -u
+
+                    LOGFILE="$CONDA_PREFIX/var/log/conda_queue_env.log"
+                    if [ -f "$LOGFILE" ]; then
+                        # Creation and each update outputs 3 lines to the log, so print the last 3
+                        tail -3 "$LOGFILE"
+                    fi
+
+                    PREV_UPDATE_TIMESTAMP="$(cat "$CONDA_PREFIX/var/log/conda_queue_env_update_timestamp")"
+                    HOURS_SINCE_UPDATE="$(( ( $CUR_TIMESTAMP - $PREV_UPDATE_TIMESTAMP ) / 1440 ))"
+                    echo "Environment was last updated $HOURS_SINCE_UPDATE hours ago."
+
+                    set +u
+                    conda deactivate
+                    set -u
+
+                    if [ $HOURS_SINCE_UPDATE -gt $DELETE_AFTER_HOURS ]; then
+                        echo "Elapsed time $HOURS_SINCE_UPDATE is greater than $DELETE_AFTER_HOURS hours, removing the environment."
+                        conda env remove --yes -q -n $ENV_NAME
+                        REMOVED_ENV=1
+                    fi
+                done
+
+                if [ "$REMOVED_ENV" = "1" ]; then
+                    echo "Cleaning the conda cache to reclaim disk space."
+                    conda clean --yes --all
+                else
+                    echo "Nothing to clean up."
+                fi
+
+            - name: OpenJDVarsStart
+              filename: openjd-vars-start.py
+              type: TEXT
+              data: |
+                import json
+                import os
+                import sys
+
+                # Exclude the env var "_" as it has special meaning to shells
+                before = dict(os.environ)
+                if "_" in before:
+                    del before["_"]
+
+                with open(sys.argv[1], "w", encoding="utf8") as f:
+                    json.dump(before, f)
+            - name: OpenJDVarsCapture
+              filename: openjd-vars-capture.py
+              type: TEXT
+              data: |
+                import json
+                import os
+                import sys
+
+                # Get the snapshot from `openjd-vars-start.py`, and the current environment state.
+                with open(sys.argv[1], "r", encoding="utf8") as f:
+                    before = json.load(f)
+                after = dict(os.environ)
+                # Exclude the env var "_" as it has special meaning to shells
+                if "_" in after:
+                    del after["_"]
+
+                # Identify the modified and deleted environment variables
+                vars_to_put = {k: v for k, v in after.items() if v != before.get(k)}
+                vars_to_delete = {k for k in before if k not in after}
+
+                # Print the env var changes following the Open Job Description specification
+                for k, v in vars_to_put.items():
+                    kv = json.dumps(f"{k}={v}", ensure_ascii=True)
+                    print(f"openjd_env: {kv}")
+                for k in vars_to_delete:
+                    print(f"openjd_unset_env: {k}")
+        ### END_QUEUE_ENV
+      TemplateType: YAML
+
+  queueIAMRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub
+        - "ProdQueue-${FarmId}"
+        - FarmId: !GetAtt farm.FarmId
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+              - !Sub 'deadline.${AWS::URLSuffix}'
+              - !Sub 'credentials.deadline.${AWS::URLSuffix}'
+            Action: "sts:AssumeRole"
+            Condition:
+              StringEquals:
+                aws:SourceAccount: !Sub '${AWS::AccountId}'
+              ArnEquals:
+                aws:SourceArn: !Ref farm
+      Policies:
+        - PolicyName: QueuePolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+            - Sid: JobAttachmentsReadWrite
+              Action:
+              - s3:GetObject
+              - s3:PutObject
+              - s3:ListBucket
+              - s3:GetBucketLocation
+              Effect: Allow
+              Resource:
+              - !Sub "arn:aws:s3:::${JobAttachmentsBucketName}"
+              - !Sub "arn:aws:s3:::${JobAttachmentsBucketName}/DeadlineCloud/*"
+              Condition:
+                StringEquals:
+                  aws:ResourceAccount: !Sub '${AWS::AccountId}'
+            - Sid: CondaChannelReadOnly
+              Action:
+              - s3:GetObject
+              - s3:ListBucket
+              Effect: Allow
+              Resource:
+              - !Sub "arn:aws:s3:::${JobAttachmentsBucketName}"
+              - !Sub "arn:aws:s3:::${JobAttachmentsBucketName}/Conda/*"
+              Condition:
+                StringEquals:
+                  aws:ResourceAccount: !Sub '${AWS::AccountId}'
+            - Sid: JobLogsReadOnly
+              Action:
+              - logs:GetLogEvents
+              Effect: Allow
+              Resource: !Sub
+                - "arn:aws:logs:us-west-2:${AWS::AccountId}:log-group:/aws/deadline/${FarmId}/*"
+                - FarmId: !GetAtt farm.FarmId
+            - Sid: DeadlineServiceManagedFleetSoftwareAccess
+              Action:
+              - s3:GetObject
+              - s3:ListBucket
+              Effect: Allow
+              Resource:
+              - "*"
+              Condition:
+                ArnLike:
+                  s3:DataAccessPointArn: "arn:aws:s3:*:*:accesspoint/deadline-software-*"
+                StringEquals:
+                  s3:AccessPointNetworkOrigin: VPC
+
+  queueForPackageBuild:
+    Type: AWS::Deadline::Queue
+    Properties:
+      DisplayName: !Ref PackageBuildQueueName
+      Description: !Ref PackageBuildQueueDescription
+      FarmId: !GetAtt farm.FarmId
+      JobAttachmentSettings:
+        S3BucketName: !Ref JobAttachmentsBucketName
+        RootPrefix: DeadlineCloudPkgBld
+      RoleArn: !GetAtt queueForPackageBuildIAMRole.Arn
+
+  queueForPackageBuildIAMRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub
+        - "PackageBuildQueue-${FarmId}"
+        - FarmId: !GetAtt farm.FarmId
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+              - !Sub 'deadline.${AWS::URLSuffix}'
+              - !Sub 'credentials.deadline.${AWS::URLSuffix}'
+            Action: "sts:AssumeRole"
+            Condition:
+              StringEquals:
+                aws:SourceAccount: !Sub '${AWS::AccountId}'
+              ArnEquals:
+                aws:SourceArn: !Ref farm
+      Policies:
+        - PolicyName: QueuePolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+            - Sid: JobAttachmentsReadWrite
+              Action:
+              - s3:GetObject
+              - s3:PutObject
+              - s3:ListBucket
+              - s3:GetBucketLocation
+              Effect: Allow
+              Resource:
+              - !Sub "arn:aws:s3:::${JobAttachmentsBucketName}"
+              - !Sub "arn:aws:s3:::${JobAttachmentsBucketName}/DeadlineCloudPkgBld/*"
+              Condition:
+                StringEquals:
+                  aws:ResourceAccount: !Sub '${AWS::AccountId}'
+            - Sid: CondaChannelReadWrite
+              Action:
+              - s3:GetObject
+              - s3:ListBucket
+              # These two are in addition to the ones in the non-package building role
+              - s3:PutObject
+              - s3:DeleteObject
+              Effect: Allow
+              Resource:
+              - !Sub "arn:aws:s3:::${JobAttachmentsBucketName}"
+              - !Sub "arn:aws:s3:::${JobAttachmentsBucketName}/Conda/*"
+              Condition:
+                StringEquals:
+                  aws:ResourceAccount: !Sub '${AWS::AccountId}'
+            - Sid: JobLogsReadOnly
+              Action:
+              - logs:GetLogEvents
+              Effect: Allow
+              Resource: !Sub
+                - "arn:aws:logs:us-west-2:${AWS::AccountId}:log-group:/aws/deadline/${FarmId}/*"
+                - FarmId: !GetAtt farm.FarmId
+            - Sid: DeadlineServiceManagedFleetSoftwareAccess
+              Action:
+              - s3:GetObject
+              - s3:ListBucket
+              Effect: Allow
+              Resource:
+              - "*"
+              Condition:
+                ArnLike:
+                  s3:DataAccessPointArn: "arn:aws:s3:*:*:accesspoint/deadline-software-*"
+                StringEquals:
+                  s3:AccessPointNetworkOrigin: VPC
+
+  deadlineFleetCUDALinux:
+    Type: AWS::Deadline::Fleet
+    Condition: HasCUDALinuxFleet
+    Properties:
+      DisplayName: !Ref CUDALinuxFleetName
+      FarmId: !GetAtt farm.FarmId
+      RoleArn: !GetAtt fleetRole.Arn
+      MinWorkerCount: 0
+      MaxWorkerCount: !Ref MaxCUDALinuxWorkerCount
+      Configuration:
+        ServiceManagedEc2:
+          InstanceCapabilities:
+            AcceleratorCapabilities:
+              Count:
+                Min: 1
+                Max: 1
+              Selections:
+                - Name: a10g
+                  Runtime: latest
+                - Name: l4
+                  Runtime: latest
+            VCpuCount:
+              Min: !Ref MinCUDALinuxVcpu
+              Max: !Ref MaxCUDALinuxVcpu
+            MemoryMiB:
+              Min: !Ref MinCUDALinuxRamMiB
+            RootEbsVolume:
+              SizeGiB: !Ref RootEbsVolumeSizeGiB
+              Iops: !Ref RootEbsVolumeIops
+              ThroughputMiB: !Ref RootEbsVolumeThroughputMiB
+            OsFamily: LINUX
+            CpuArchitectureType: x86_64
+          InstanceMarketOptions:
+            Type: !Ref CUDALinuxInstanceMarketType
+
+  deadlineFleetCPULinux:
+    Type: AWS::Deadline::Fleet
+    Condition: HasCPULinuxFleet
+    Properties:
+      DisplayName: !Ref CPULinuxFleetName
+      FarmId: !GetAtt farm.FarmId
+      RoleArn: !GetAtt fleetRole.Arn
+      MinWorkerCount: 0
+      MaxWorkerCount: !Ref MaxCPULinuxWorkerCount
+      Configuration:
+        ServiceManagedEc2:
+          InstanceCapabilities:
+            VCpuCount:
+              Min: !Ref MinCPULinuxVcpu
+              Max: !Ref MaxCPULinuxVcpu
+            MemoryMiB:
+              Min: !Ref MinCPULinuxRamMiB
+            RootEbsVolume:
+              SizeGiB: !Ref RootEbsVolumeSizeGiB
+              Iops: !Ref RootEbsVolumeIops
+              ThroughputMiB: !Ref RootEbsVolumeThroughputMiB
+            OsFamily: LINUX
+            CpuArchitectureType: x86_64
+          InstanceMarketOptions:
+            Type: !Ref CPULinuxInstanceMarketType
+
+  deadlineFleetCPUWindows:
+    Type: AWS::Deadline::Fleet
+    Condition: HasCPUWindowsFleet
+    Properties:
+      DisplayName: !Ref CPUWindowsFleetName
+      FarmId: !GetAtt farm.FarmId
+      RoleArn: !GetAtt fleetRole.Arn
+      MinWorkerCount: 0
+      MaxWorkerCount: !Ref MaxCPUWindowsWorkerCount
+      Configuration:
+        ServiceManagedEc2:
+          InstanceCapabilities:
+            VCpuCount:
+              Min: !Ref MinCPUWindowsVcpu
+              Max: !Ref MaxCPUWindowsVcpu
+            MemoryMiB:
+              Min: !Ref MinCPUWindowsRamMiB
+            RootEbsVolume:
+              SizeGiB: !Ref RootEbsVolumeSizeGiB
+              Iops: !Ref RootEbsVolumeIops
+              ThroughputMiB: !Ref RootEbsVolumeThroughputMiB
+            OsFamily: WINDOWS
+            CpuArchitectureType: x86_64
+          InstanceMarketOptions:
+            Type: !Ref CPUWindowsInstanceMarketType
+
+  deadlineProdQueueCPULinuxFleetAssociation:
+    Type: AWS::Deadline::QueueFleetAssociation
+    Condition: HasCPULinuxFleet
+    Properties:
+      FarmId: !GetAtt farm.FarmId
+      QueueId: !GetAtt queue.QueueId
+      FleetId: !GetAtt deadlineFleetCPULinux.FleetId
+
+  deadlineProdQueueCPUWindowsFleetAssociation:
+    Type: AWS::Deadline::QueueFleetAssociation
+    Condition: HasCPUWindowsFleet
+    Properties:
+      FarmId: !GetAtt farm.FarmId
+      QueueId: !GetAtt queue.QueueId
+      FleetId: !GetAtt deadlineFleetCPUWindows.FleetId
+
+  deadlineProdQueueCUDALinuxFleetAssociation:
+    Type: AWS::Deadline::QueueFleetAssociation
+    Condition: HasCUDALinuxFleet
+    Properties:
+      FarmId: !GetAtt farm.FarmId
+      QueueId: !GetAtt queue.QueueId
+      FleetId: !GetAtt deadlineFleetCUDALinux.FleetId
+
+  deadlinePackageBuildQueueCPULinuxFleetAssociation:
+    Type: AWS::Deadline::QueueFleetAssociation
+    Condition: HasCPULinuxFleet
+    Properties:
+      FarmId: !GetAtt farm.FarmId
+      QueueId: !GetAtt queueForPackageBuild.QueueId
+      FleetId: !GetAtt deadlineFleetCPULinux.FleetId
+
+  deadlinePackageBuildQueueCPUWindowsFleetAssociation:
+    Type: AWS::Deadline::QueueFleetAssociation
+    Condition: HasCPUWindowsFleet
+    Properties:
+      FarmId: !GetAtt farm.FarmId
+      QueueId: !GetAtt queueForPackageBuild.QueueId
+      FleetId: !GetAtt deadlineFleetCPUWindows.FleetId
+
+  deadlinePackageBuildQueueCUDALinuxFleetAssociation:
+    Type: AWS::Deadline::QueueFleetAssociation
+    Condition: HasCUDALinuxFleet
+    Properties:
+      FarmId: !GetAtt farm.FarmId
+      QueueId: !GetAtt queueForPackageBuild.QueueId
+      FleetId: !GetAtt deadlineFleetCUDALinux.FleetId
+
+  fleetRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub
+        - "Fleet-${FarmId}"
+        - FarmId: !GetAtt farm.FarmId
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - !Sub "credentials.deadline.${AWS::URLSuffix}"
+            Action:
+              - sts:AssumeRole
+            Condition:
+              StringEquals:
+                aws:SourceAccount: !Sub '${AWS::AccountId}'
+              ArnEquals:
+                aws:SourceArn: !Ref farm
+      Policies:
+        - PolicyName: FleetWorkerLogs
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+            - Effect: Allow
+              Action:
+              # Allow Deadline Cloud to create new log streams for the farm
+              - logs:CreateLogStream
+              Resource:
+              - !Sub
+                - arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:*:/aws/deadline/${FarmId}/*
+                - FarmId: !GetAtt farm.FarmId
+              Condition:
+                ForAnyValue:StringEquals:
+                  aws:CalledVia:
+                  - !Sub "deadline.${AWS::URLSuffix}"
+            - Effect: Allow
+              Action:
+              # Allow the Worker to put events to its Worker log and to Session logs for running Jobs
+              - logs:PutLogEvents
+              # Allow Deadline Cloud Monitor users to read Worker logs
+              - logs:GetLogEvents
+              Resource:
+              - !Sub
+                - arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:*:/aws/deadline/${FarmId}/*
+                - FarmId: !GetAtt farm.FarmId
+      ManagedPolicyArns:
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/AWSDeadlineCloud-FleetWorker'


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The instructions https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/configure-jobs-s3-channel.html for creating an AWS Deadline Cloud farm with package building capability require some manual steps to create a new queue and to adjust IAM policies. A CloudFormation template can make it simpler and more reliable to deploy farms following this pattern.

### What was the solution? (How)

Publish a CloudFormation template sample to deploy a starter AWS Deadline Cloud farm that includes both a production queue and a package build queue for building conda packages. The associated README includes step-by-step instructions for how to deploy, test, and use the farm.

### What is the impact of this change?

Customers have a CloudFormation template they can use to create their farm, or as a starting point to develop their own that deploys exactly what they need.

### How was this change tested?

Deployed the CloudFormation template in various configurations, and ran package build as well as sample jobs on the queues of the farm.

### Was this change documented?

Yes, it includes a README with step-by-step instructions.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*