### PR TITLE
chore: Update openjd-adaptor-runtime version in conda recipes.

### DIFF
--- a/conda_recipes/cinema4d-2024/recipe/build_win.sh
+++ b/conda_recipes/cinema4d-2024/recipe/build_win.sh
@@ -31,27 +31,27 @@ mkdir -p "$PREFIX/etc/conda/deactivate.d"
 cat <<EOF > "$PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.sh"
 export C4D_VERSION=$CINEMA_4D_VERSION
 export C4D_LOCATION="$PREFIX\\cinema4d"
-export CINEMA4D_ADAPTOR_COMMANDLINE_EXE="$PREFIX\\cinema4d\\Commandline.exe"
+export C4D_COMMANDLINE_EXECUTABLE="$PREFIX\\cinema4d\\Commandline.exe"
 EOF
 cat "$PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.sh"
 
 cat <<EOF > "$PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.bat"
 set "C4D_VERSION=$CINEMA_4D_VERSION"
 set "C4D_LOCATION=$PREFIX\cinema4d"
-set "CINEMA4D_ADAPTOR_COMMANDLINE_EXE=$PREFIX\cinema4d\Commandline.exe"
+set "C4D_COMMANDLINE_EXECUTABLE=$PREFIX\cinema4d\Commandline.exe"
 EOF
 cat "$PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.bat"
 
 cat <<EOF > "$PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.sh"
 unset C4D_VERSION
 unset C4D_LOCATION
-unset CINEMA4D_ADAPTOR_COMMANDLINE_EXE
+unset C4D_COMMANDLINE_EXECUTABLE
 EOF
 cat "$PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.sh"
 
 cat <<EOF > "$PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.bat"
 set C4D_VERSION=
 set C4D_LOCATION=
-set CINEMA4D_ADAPTOR_COMMANDLINE_EXE=
+set C4D_COMMANDLINE_EXECUTABLE=
 EOF
 cat "$PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.bat"

--- a/conda_recipes/cinema4d-2025/README.md
+++ b/conda_recipes/cinema4d-2025/README.md
@@ -35,7 +35,7 @@ for use by the conda build recipe.
         2. User name: `Administrator`
     5. Enter the password you set for Administrator after you created the instance. You should now have a remote desktop session to your instance.
 3. Install Cinema 4D 2025 on the instance.
-    1. Download the Cinema 4D 2025 installer for Windows from Maxon (https://www.maxon.net/en/downloads/cinema-4d-2025-downloads). For example, the files `Cinema4D_2025_2025.0.2_Win.exe`.
+    1. Download the Cinema 4D 2025 installer for Windows from Maxon (https://www.maxon.net/en/downloads/cinema-4d-2025-downloads). For example, the files `Cinema4D_2025_2025.1.1_Win.exe`.
        If you have placed them on S3, you can use a PowerShell command like `Read-S3Object -BucketName MY_BUCKET_NAME -Key MY_UPLOADED_KEY_NAME -File MY_FILE_NAME`.
     2. Run the installer. Accept the prompts to continue.
     3. The Cinema 4D installer will launch. Proceed to install as normal with the components you want included.
@@ -43,9 +43,9 @@ for use by the conda build recipe.
     5. Log in with a PowerShell window again, either from the EC2 management console session manager or reconnecting to RDP.
     5. Run the following commands to create the archive.
         1. `cd 'C:\Program Files\'`
-        2. `Compress-Archive -Path '.\Maxon Cinema 4D 2025\' -DestinationPath Cinema4D_2025_2025.0.2_Win.zip`
-        3. `(Get-FileHash -Path .\Cinema4D_2025_2025.0.2_Win.zip -Algorithm SHA256).Hash.ToLower()`
+        2. `Compress-Archive -Path '.\Maxon Cinema 4D 2025\' -DestinationPath Cinema4D_2025_2025.1.1_Win.zip`
+        3. `(Get-FileHash -Path .\Cinema4D_2025_2025.1.1_Win.zip -Algorithm SHA256).Hash.ToLower()`
     6. Record the file sha256 hash, and upload the archive to your private S3 bucket. You can use a PowerShell command like
-       `Write-S3Object -BucketName MY_BUCKET_NAME -Key Cinema4D_2025_2025.0.2_Win.zip -File Cinema4D_2025_2025.0.2_Win.zip`.
+       `Write-S3Object -BucketName MY_BUCKET_NAME -Key Cinema4D_2025_2025.1.1_Win.zip -File Cinema4D_2025_2025.1.1_Win.zip`.
 4. From the AWS EC2 management console, select the instance you used and terminate it.
 5. Download the zip file to the `conda_recipes/archive_files` directory in your git clone of the [deadline-cloud-samples](https://github.com/aws-deadline/deadline-cloud-samples) repository for submitting package build jobs, and update the Windows source artifact hash in the Cinema 4D-2025 conda build recipe meta.yaml.

--- a/conda_recipes/cinema4d-2025/deadline-cloud.yaml
+++ b/conda_recipes/cinema4d-2025/deadline-cloud.yaml
@@ -1,6 +1,6 @@
 condaPlatforms:
   - platform: win-64
     defaultSubmit: true
-    sourceArchiveFilename: Cinema4D_2025_2025.0.2_Win.zip
+    sourceArchiveFilename: Cinema4D_2025_2025.1.1_Win.zip
     sourceDownloadInstructions: 'Follow the instructions from README in this folder on how to make this file.'
     buildTool: conda-build

--- a/conda_recipes/cinema4d-2025/recipe/build_win.sh
+++ b/conda_recipes/cinema4d-2025/recipe/build_win.sh
@@ -31,27 +31,27 @@ mkdir -p "$PREFIX/etc/conda/deactivate.d"
 cat <<EOF > "$PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.sh"
 export C4D_VERSION=$CINEMA_4D_VERSION
 export C4D_LOCATION="$PREFIX\\cinema4d"
-export CINEMA4D_ADAPTOR_COMMANDLINE_EXE="$PREFIX\\cinema4d\\Commandline.exe"
+export C4D_COMMANDLINE_EXECUTABLE="$PREFIX\\cinema4d\\Commandline.exe"
 EOF
 cat "$PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.sh"
 
 cat <<EOF > "$PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.bat"
 set "C4D_VERSION=$CINEMA_4D_VERSION"
 set "C4D_LOCATION=$PREFIX\cinema4d"
-set "CINEMA4D_ADAPTOR_COMMANDLINE_EXE=$PREFIX\cinema4d\Commandline.exe"
+set "C4D_COMMANDLINE_EXECUTABLE=$PREFIX\cinema4d\Commandline.exe"
 EOF
 cat "$PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.bat"
 
 cat <<EOF > "$PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.sh"
 unset C4D_VERSION
 unset C4D_LOCATION
-unset CINEMA4D_ADAPTOR_COMMANDLINE_EXE
+unset C4D_COMMANDLINE_EXECUTABLE
 EOF
 cat "$PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.sh"
 
 cat <<EOF > "$PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.bat"
 set C4D_VERSION=
 set C4D_LOCATION=
-set CINEMA4D_ADAPTOR_COMMANDLINE_EXE=
+set C4D_COMMANDLINE_EXECUTABLE=
 EOF
 cat "$PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.bat"

--- a/conda_recipes/cinema4d-2025/recipe/meta.yaml
+++ b/conda_recipes/cinema4d-2025/recipe/meta.yaml
@@ -1,8 +1,8 @@
 {% set name = "cinema4d" %}
 {% set display_name = "Cinema4D" %}
 {% set version_major = "2025" %}
-{% set version_minor = "0" %}
-{% set version_patch = "2" %}
+{% set version_minor = "1" %}
+{% set version_patch = "1" %}
 {% set version = version_major + "." + version_minor + "." + version_patch %}
 
 package:
@@ -11,7 +11,7 @@ package:
 
 source:
   url: archive_files/{{ display_name }}_{{ version_major }}_{{ version }}_Win.zip # [win64]
-  sha256: 7cefab01e5b02e6c43b74e658f4f4484f8dc978cd801ede6de466a662ef4914b
+  sha256: e7de8b07187e2d054d4c0ea16b9510448987992dc70ae7eb71e0d7f6659d9115
   folder: cinema4d
 
 build:

--- a/conda_recipes/cinema4d-openjd/recipe/meta.yaml
+++ b/conda_recipes/cinema4d-openjd/recipe/meta.yaml
@@ -4,7 +4,7 @@
 # https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/conda_recipes
 
 {% set name = "cinema4d-openjd" %}
-{% set version = "0.5.4" %}
+{% set version = "0.6.0" %}
 
 package:
   name: {{ name }}
@@ -12,7 +12,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/d/deadline-cloud-for-cinema-4d/deadline_cloud_for_cinema_4d-{{ version }}.tar.gz
-  sha256: 314ea9fadc658b4e25b3616aa36a1d2ee9f24863f7c0bb39a26c512b9f976ea8
+  sha256: c35166730d274da0c1c753835efabd358bb07b496173258ee03e194ef541c1ac
   patches:
     - 0001-Remove-version-hook.patch
 
@@ -20,7 +20,7 @@ source:
 # the username and git branch as appropriate for your case.
 # source:
 #   git_url: https://github.com/aws-deadline/deadline-cloud-for-cinema-4d.git
-#   git_rev: region-render
+#   git_rev: {{ version }}
 
 build:
   entry_points:
@@ -41,7 +41,7 @@ requirements:
     # For the variant config file in deadline-cloud.yaml to work, python must not specify a version here.
     - python
     - deadline ==0.49.*
-    - openjd-adaptor-runtime ==0.8.*
+    - openjd-adaptor-runtime ==0.9.*
 
 test:
   imports:

--- a/conda_recipes/cinema4d-openjd/recipe/recipe.yaml
+++ b/conda_recipes/cinema4d-openjd/recipe/recipe.yaml
@@ -6,7 +6,7 @@
 # https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/conda_recipes
 
 context:
-  version: "0.5.4"
+  version: "0.6.0"
 
 package:
   name: cinema4d-openjd
@@ -15,7 +15,7 @@ package:
 # This source reference uses the source archive published to PyPI
 source:
   url: https://pypi.io/packages/source/d/deadline-cloud-for-cinema-4d/deadline_cloud_for_cinema_4d-${{ version }}.tar.gz
-  sha256: 314ea9fadc658b4e25b3616aa36a1d2ee9f24863f7c0bb39a26c512b9f976ea8
+  sha256: c35166730d274da0c1c753835efabd358bb07b496173258ee03e194ef541c1ac
   patches:
     - 0001-Remove-version-hook.patch
 
@@ -33,7 +33,7 @@ requirements:
   run:
     - python
     - deadline 0.49.*
-    - openjd-adaptor-runtime 0.8.*
+    - openjd-adaptor-runtime 0.9.*
 
 tests:
 - python:

--- a/conda_recipes/openjd-adaptor-runtime/recipe/meta.yaml
+++ b/conda_recipes/openjd-adaptor-runtime/recipe/meta.yaml
@@ -2,24 +2,24 @@
 # See recipe.yaml for the recipe in rattler-build format.
 
 {% set name = "openjd-adaptor-runtime" %}
-{% set version = "0.8.2" %}
+{% set version = "0.9.0" %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
 # # This source reference uses the source archive published to PyPI
-# source:
-#   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/openjd_adaptor_runtime-{{ version }}.tar.gz
-#   sha256: 9230002d9d73e5120d211535bb9fff7fe1d9fea0c6e0f301ff0fe731cbd62747
-#   patches:
-#     - 0001-Remove-version-hook.patch
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/openjd_adaptor_runtime-{{ version }}.tar.gz
+  sha256: a2a117b23df4e7fa31360b4572528ecabeeed190f5a4c51177560d401df79704
+  patches:
+    - 0001-Remove-version-hook.patch
 
 # This source reference uses git to retrieve the tag for the specified version. You can modify
 # the git_url and git_rev to point to a branch in your own fork of the project.
-source:
-  git_url: https://github.com/OpenJobDescription/openjd-adaptor-runtime-for-python.git
-  git_rev: "{{ version }}"
+# source:
+#   git_url: https://github.com/OpenJobDescription/openjd-adaptor-runtime-for-python.git
+#   git_rev: "{{ version }}"
 
 build:
   skip: true  # [py<39]

--- a/conda_recipes/openjd-adaptor-runtime/recipe/recipe.yaml
+++ b/conda_recipes/openjd-adaptor-runtime/recipe/recipe.yaml
@@ -2,7 +2,7 @@
 # See https://prefix-dev.github.io/rattler-build/latest/
 
 context:
-  version: "0.8.2"
+  version: "0.9.0"
 
 package:
   name: openjd-adaptor-runtime
@@ -10,7 +10,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/o/openjd-adaptor-runtime/openjd_adaptor_runtime-${{ version }}.tar.gz
-  sha256: 9402ab555ad60ca81c4669fb634c569abaca794e2eefafac1dada89fdb300c2a
+  sha256: a2a117b23df4e7fa31360b4572528ecabeeed190f5a4c51177560d401df79704
   patches:
     - 0001-Remove-version-hook.patch
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

There was a new OpenJD adaptor runtime release (latest is now 0.9.0).

Additionally, Cinema 4D and Cinema 4D open JD packages also had new releases. 

### What was the solution? (How)

Hence, updating the conda recipes according to the changes. 

### What is the impact of this change?

Customers can use the latest conda packages. 

### How was this change tested?

To ensure the change works as expected, I submitted the conda recipe to build on my farm. 

Once the builds were successful, I submitted few Cinema 4D jobs to confirm that they worked as expected. 


Here's a sample session log for a Cinema 4D job. 

```
...
2025/01/03 16:32:55-06:00   added / updated specs:
2025/01/03 16:32:55-06:00     - cinema4d
2025/01/03 16:32:55-06:00     - cinema4d-openjd
2025/01/03 16:32:55-06:00  
2025/01/03 16:32:55-06:00  
2025/01/03 16:32:55-06:00 The following packages will be downloaded:
2025/01/03 16:32:55-06:00  
2025/01/03 16:32:55-06:00     package                    |            build
2025/01/03 16:32:55-06:00     ---------------------------|-----------------
...
2025/01/03 16:32:55-06:00     cinema4d-2025.1.1          |                0       824.6 MB  s3://<my-bucket-name>/Conda/Default
2025/01/03 16:32:55-06:00     cinema4d-openjd-0.6.0      |             py_0          38 KB  s3://<my-bucket-name>/Conda/Default
2025/01/03 16:32:55-06:00     deadline-0.49.3            |          py312_0         470 KB  s3://<my-bucket-name>/Conda/Default
...
25/01/03 16:32:55-06:00     openjd-adaptor-runtime-0.9.0|          py312_0         158 KB  s3://<my-bucket-name>/Conda/Default
...

2025/01/03 16:37:21-06:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 93
2025/01/03 16:37:21-06:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 95
2025/01/03 16:37:21-06:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 96
2025/01/03 16:37:21-06:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 98
2025/01/03 16:37:21-06:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 100
2025/01/03 16:37:21-06:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 100
2025/01/03 16:37:21-06:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 100
2025/01/03 16:37:21-06:00 ADAPTOR_OUTPUT: STDOUT: Finished Rendering
2025/01/03 16:37:21-06:00 INFO: Done Cinema4DAdaptor main
```

### Was this change documented?
No
---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*