### PR TITLE
docs: Add README files for the CloudFormation samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 This repository contains a set of samples to use with [AWS Deadline Cloud](https://aws.amazon.com/deadline-cloud/).
 
+## CloudFormation template samples
+
+The [cloudformation](cloudformation) directory contains sample CloudFormation templates you can use to
+deploy a Deadline Cloud farm or other infrastructure to work with your farm. The [starter_farm sample](cloudformation/farm_templates/starter_farm/)
+is a good place to start. Other samples include event notification and health checks for customer-managed fleets.
+
 ## Job bundle samples
 
 The [job_bundles](job_bundles) directory contains sample jobs that you can submit to your Deadline Cloud queue. You can use the
@@ -47,11 +53,11 @@ you can attach to your Deadline Cloud queue, to provide software applications to
 
 ## Security
 
-We take all security reports seriously. When we receive such reports, we will 
-investigate and subsequently address any potential vulnerabilities as quickly 
-as possible. If you discover a potential security issue in this project, please 
+We take all security reports seriously. When we receive such reports, we will
+investigate and subsequently address any potential vulnerabilities as quickly
+as possible. If you discover a potential security issue in this project, please
 notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/)
-or directly via email to [AWS Security](aws-security@amazon.com). Please do not 
+or directly via email to [AWS Security](aws-security@amazon.com). Please do not
 create a public GitHub issue in this project.
 
 ## License

--- a/cloudformation/README.md
+++ b/cloudformation/README.md
@@ -1,0 +1,24 @@
+# AWS Deadline Cloud sample CloudFormation templates
+
+With [AWS CloudFormation](https://aws.amazon.com/cloudformation/), you can use infrastructure as code to deploy infrastructure
+such as a Deadline Cloud farm to your AWS account. Use the samples provided here directly or as a starting point
+to create your own custom templates.
+
+## Starter farm
+
+The [starter_farm](farm_templates/starter_farm/) sample CloudFormation template deploys a Deadline Cloud farm you can use to run jobs that render images,
+reconstruct 3D scenes, or transform your data in custom ways. Sample jobs to submit are available in the deadline-cloud-samples on GitHub, Deadline Cloud
+provides many integrated submitter plugins for applications, and you can build your own jobs. The deployed farm includes the ability to
+[build custom conda packages](../conda_recipes/README.md) for providing additional application support.
+
+## Budget events notification
+
+The [budget_events_notification](notification_templates/budget_events_notification/) CloudFormation template sets up an integration
+to receive notifications via email and Slack when a budget threshold is reached in the aws.deadline service. It creates an SNS topic,
+an EventBridge rule, and a Chatbot configuration to send the notifications.
+
+## Customer-managed fleet health checks
+
+The [cmf_templates](farm_templates/cmf_templates/) collection includes a fleet health check CloudFormation template that sets up
+continuous health check monitoring for a single Deadline Cloud customer-managed fleet with autoscaling. It creates a Lambda function,
+an EventBridge rule, and a CloudWatch alarm that can be configured with an SNS topic.

--- a/cloudformation/farm_templates/cmf_templates/README.md
+++ b/cloudformation/farm_templates/cmf_templates/README.md
@@ -1,7 +1,8 @@
 # Deploying Deadline Cloud fleet health check
 
 ## Introduction
-This CloudFormation template sets up continuous health check monitoring for a single Deadline Cloud fleet with autoscaling. It creates a Lambda function, an EventBridge rule, and a CloudWatch alarm that can be configured with an SNS topic.
+This CloudFormation template sets up continuous health check monitoring for a single Deadline Cloud customer-managed fleet
+with autoscaling. It creates a Lambda function, an EventBridge rule, and a CloudWatch alarm that can be configured with an SNS topic.
 
 ## Prerequisites
 Before deploying this CloudFormation template, check that you have the following resources created in your AWS Account.
@@ -29,7 +30,7 @@ Before deploying this CloudFormation template, check that you have the following
 1. Download the `deadline-fleet-health-check.yaml` CloudFormation template.
 2. From the [CloudFormation management console](https://console.aws.amazon.com/cloudformation/), navigate to __Create Stack > With new resources (standard)__.
 3. Upload the `deadline-fleet-health-check.yaml` CloudFormation template.
-4. Specify the name of the stack and parameters you copied from the Prerequisites section. 
+4. Specify the name of the stack and parameters you copied from the Prerequisites section.
 5. Follow the CloudFormation console steps to complete stack creation.
 
 ### Using the CLI

--- a/cloudformation/farm_templates/starter_farm/README.md
+++ b/cloudformation/farm_templates/starter_farm/README.md
@@ -36,7 +36,7 @@ your AWS Account. The AWS region should be the same as the one you use to deploy
    [AWS Deadline Cloud management console](https://console.aws.amazon.com/deadlinecloud/home),
    select the "Go to Monitor setup" option and follow the steps to enter a name for your monitor URL,
    enable IAM Identity Center, and then create a user login account to access the monitor. Your
-   monitor URL will look similar to `https://<ENTERED_MONITOR_NAME>.<AWS_REGION>.deadlinecloud.amazonaws.com/`,
+   monitor URL will look similar to `https://<ENTERED_MONITOR_NAME>.<AWS_REGION>.deadlinecloud.amazonaws.com/`.
    You will need this URL to log in with the Deadline Cloud monitor desktop application.
 
 ## Setup Instructions


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The CloudFormation template samples don't have a section in the top-level README, and lack an index
in a README that covers all the templates.

### What was the solution? (How)

* Add a section in the top-level README linking to the CloudFormation template samples.
* Add a README for the cloudformation directory.
* Apply minor updates to the READMES in the cloudformation subdirectories.

### What is the impact of this change?

Customers can more easily discover the CloudFormation template samples.

### How was this change tested?

N/A

### Was this change documented?

The change is to the documentation.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*