### PR TITLE
docs: Clarify that the starter_farm S3 bucket must already exist

### DIFF
--- a/cloudformation/farm_templates/starter_farm/deadline-cloud-starter-farm-template.yaml
+++ b/cloudformation/farm_templates/starter_farm/deadline-cloud-starter-farm-template.yaml
@@ -9,7 +9,7 @@ Description: >
 Parameters:
   JobAttachmentsBucketName:
     Type: String
-    Description: The S3 bucket to use for job attachments and the default S3 conda channel.
+    Description: An existing S3 bucket to use for job attachments and the default S3 conda channel.
     MinLength: 1
 
   # Deadline Cloud farm
@@ -223,7 +223,7 @@ Metadata:
 
     ParameterLabels:
       JobAttachmentsBucketName:
-        default: "Job Attachments S3 Bucket"
+        default: "Existing S3 Bucket For Job Attachments"
       FarmName:
         default: "Farm Name"
       FarmDescription:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

If someone starts deploying the starter_farm bucket without stepping through the README, they
can miss that the S3 bucket should exist before they deploy the template.

### What was the solution? (How)

* Updated the description and GUI metadata for the JobAttachmentsBucketName to be more clear that its for an existing bucket.

### What is the impact of this change?

It should be more obvious from the label of the parameter and the description of it, that the bucket should exist already.

### How was this change tested?

Confirmed that the adjusted label and description display when deploying the template from the AWS console.

### Was this change documented?

N/A

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*