### PR TITLE
chore: update cinema4d 2025 recipe to 2025.1.2

### DIFF
--- a/conda_recipes/cinema4d-2025/README.md
+++ b/conda_recipes/cinema4d-2025/README.md
@@ -35,7 +35,7 @@ for use by the conda build recipe.
         2. User name: `Administrator`
     5. Enter the password you set for Administrator after you created the instance. You should now have a remote desktop session to your instance.
 3. Install Cinema 4D 2025 on the instance.
-    1. Download the Cinema 4D 2025 installer for Windows from Maxon (https://www.maxon.net/en/downloads/cinema-4d-2025-downloads). For example, the files `Cinema4D_2025_2025.1.1_Win.exe`.
+    1. Download the Cinema 4D 2025 installer for Windows from Maxon (https://www.maxon.net/en/downloads/cinema-4d-2025-downloads). For example, the files `Cinema4D_2025_2025.1.2_Win.exe`.
        If you have placed them on S3, you can use a PowerShell command like `Read-S3Object -BucketName MY_BUCKET_NAME -Key MY_UPLOADED_KEY_NAME -File MY_FILE_NAME`.
     2. Run the installer. Accept the prompts to continue.
     3. The Cinema 4D installer will launch. Proceed to install as normal with the components you want included.
@@ -43,9 +43,9 @@ for use by the conda build recipe.
     5. Log in with a PowerShell window again, either from the EC2 management console session manager or reconnecting to RDP.
     5. Run the following commands to create the archive.
         1. `cd 'C:\Program Files\'`
-        2. `Compress-Archive -Path '.\Maxon Cinema 4D 2025\' -DestinationPath Cinema4D_2025_2025.1.1_Win.zip`
-        3. `(Get-FileHash -Path .\Cinema4D_2025_2025.1.1_Win.zip -Algorithm SHA256).Hash.ToLower()`
+        2. `Compress-Archive -Path '.\Maxon Cinema 4D 2025\' -DestinationPath Cinema4D_2025_2025.1.2_Win.zip`
+        3. `(Get-FileHash -Path .\Cinema4D_2025_2025.1.2_Win.zip -Algorithm SHA256).Hash.ToLower()`
     6. Record the file sha256 hash, and upload the archive to your private S3 bucket. You can use a PowerShell command like
-       `Write-S3Object -BucketName MY_BUCKET_NAME -Key Cinema4D_2025_2025.1.1_Win.zip -File Cinema4D_2025_2025.1.1_Win.zip`.
+       `Write-S3Object -BucketName MY_BUCKET_NAME -Key Cinema4D_2025_2025.1.2_Win.zip -File Cinema4D_2025_2025.1.2_Win.zip`.
 4. From the AWS EC2 management console, select the instance you used and terminate it.
 5. Download the zip file to the `conda_recipes/archive_files` directory in your git clone of the [deadline-cloud-samples](https://github.com/aws-deadline/deadline-cloud-samples) repository for submitting package build jobs, and update the Windows source artifact hash in the Cinema 4D-2025 conda build recipe meta.yaml.

--- a/conda_recipes/cinema4d-2025/deadline-cloud.yaml
+++ b/conda_recipes/cinema4d-2025/deadline-cloud.yaml
@@ -1,6 +1,6 @@
 condaPlatforms:
   - platform: win-64
     defaultSubmit: true
-    sourceArchiveFilename: Cinema4D_2025_2025.1.1_Win.zip
+    sourceArchiveFilename: Cinema4D_2025_2025.1.2_Win.zip
     sourceDownloadInstructions: 'Follow the instructions from README in this folder on how to make this file.'
     buildTool: conda-build

--- a/conda_recipes/cinema4d-2025/recipe/meta.yaml
+++ b/conda_recipes/cinema4d-2025/recipe/meta.yaml
@@ -2,7 +2,7 @@
 {% set display_name = "Cinema4D" %}
 {% set version_major = "2025" %}
 {% set version_minor = "1" %}
-{% set version_patch = "1" %}
+{% set version_patch = "2" %}
 {% set version = version_major + "." + version_minor + "." + version_patch %}
 
 package:
@@ -11,7 +11,7 @@ package:
 
 source:
   url: archive_files/{{ display_name }}_{{ version_major }}_{{ version }}_Win.zip # [win64]
-  sha256: e7de8b07187e2d054d4c0ea16b9510448987992dc70ae7eb71e0d7f6659d9115
+  sha256: 7fa63576db7eca3b4c8b62f192e8e9e612dd9c59ad365fcc5faba20c0fd06069
   folder: cinema4d
 
 build:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Cinema 4D 2025.1.2 was released! Updated the sample Conda recipes accordingly.

### What is the impact of this change?
Customers will be able to use the latest Cinema 4D version.

### How was this change tested?
Re-ran the sample conda recipe and confirmed that I was able to render with it.

### Was this change documented?
No, N/A

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*