### PR TITLE
chore: Update Cinema4D openjd version to 0.6.1

### DIFF
--- a/conda_recipes/cinema4d-openjd/recipe/meta.yaml
+++ b/conda_recipes/cinema4d-openjd/recipe/meta.yaml
@@ -4,7 +4,7 @@
 # https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/conda_recipes
 
 {% set name = "cinema4d-openjd" %}
-{% set version = "0.6.0" %}
+{% set version = "0.6.1" %}
 
 package:
   name: {{ name }}
@@ -12,7 +12,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/d/deadline-cloud-for-cinema-4d/deadline_cloud_for_cinema_4d-{{ version }}.tar.gz
-  sha256: c35166730d274da0c1c753835efabd358bb07b496173258ee03e194ef541c1ac
+  sha256: e285197afa243ca2b54888d2ddee983723bbb724c6263f02f2fe4565cda9b502
   patches:
     - 0001-Remove-version-hook.patch
 

--- a/conda_recipes/cinema4d-openjd/recipe/recipe.yaml
+++ b/conda_recipes/cinema4d-openjd/recipe/recipe.yaml
@@ -6,7 +6,7 @@
 # https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/conda_recipes
 
 context:
-  version: "0.6.0"
+  version: "0.6.1"
 
 package:
   name: cinema4d-openjd
@@ -15,7 +15,7 @@ package:
 # This source reference uses the source archive published to PyPI
 source:
   url: https://pypi.io/packages/source/d/deadline-cloud-for-cinema-4d/deadline_cloud_for_cinema_4d-${{ version }}.tar.gz
-  sha256: c35166730d274da0c1c753835efabd358bb07b496173258ee03e194ef541c1ac
+  sha256: e285197afa243ca2b54888d2ddee983723bbb724c6263f02f2fe4565cda9b502
   patches:
     - 0001-Remove-version-hook.patch
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

There was a new release of Cinema 4D OpenJD package i.e. `0.6.1` which contains [important customer fixes](https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/pull/146).   

### What was the solution? (How)

Updating the hashes and version to `0.6.1` so that customers have the latest fixes. 

### What is the impact of this change?

Customers can use the latest version of Cinema 4D OpenJD that have important fixes. 

### How was this change tested?

I submitted builds to my personal farm and confirmed that the recipes work as expected. Below is last part of the logs where the conda package was uploaded to my S3 bucket. 

```
2025/01/13 12:22:41-06:00 Package cinema4d-openjd-0.6.1-py_0.conda is 38967 bytes
2025/01/13 12:22:41-06:00 openjd_status: Uploading the package cinema4d-openjd-0.6.1-py_0.conda to s3://<my-s3-bucket>/noarch/cinema4d-openjd-0.6.1-py_0.conda...
2025/01/13 12:22:42-06:00 Process pid 2436 exited with code: 0 (unsigned) / 0x0 (hex)
```

I have also confirmed that the jobs using the newly built package works as expected. 

```
2025/01/13 13:15:08-06:00     cinema4d-2025.1.1          |                0       824.6 MB  s3://my-s3-bucket/Conda/Default
2025/01/13 13:15:08-06:00     cinema4d-openjd-0.6.1      |             py_0          38 KB  s3://my-s3-bucket/Conda/Default
...
2025/01/13 13:18:16-06:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 97.5
2025/01/13 13:18:16-06:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 97.9167
2025/01/13 13:18:16-06:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 98.75
2025/01/13 13:18:16-06:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 99.1667
2025/01/13 13:18:16-06:00 ADAPTOR_OUTPUT: STDOUT: ALF_PROGRESS 99.5833
2025/01/13 13:18:16-06:00 ADAPTOR_OUTPUT: STDOUT: Finished Rendering
```


---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*