### PR TITLE
docs: adding CFN template link to conda recipe README to make package build queue

### DIFF
--- a/conda_recipes/README.md
+++ b/conda_recipes/README.md
@@ -23,7 +23,7 @@ See the Deadline Cloud developer guide documentation
 for instructions on how to set up a Deadline Cloud farm for building packages into an Amazon S3 conda channel.
 Name your package build queue "Package Build Queue" for the job submission command to select it by default.
 
-To make this faster and simpler, you can use our provided starter farm CloudFormation template [here](https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/cloudformation/farm_templates/starter_farm) to deploy your Deadline infrastructure along with
+To make this process faster and simpler, you can use our provided starter farm CloudFormation template [here](https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/cloudformation/farm_templates/starter_farm) to deploy your Deadline infrastructure along with
 a configured package build queue as documented in the Deadline Cloud developer guide linked above. 
 
 To submit package build jobs, you will need the

--- a/conda_recipes/README.md
+++ b/conda_recipes/README.md
@@ -23,6 +23,9 @@ See the Deadline Cloud developer guide documentation
 for instructions on how to set up a Deadline Cloud farm for building packages into an Amazon S3 conda channel.
 Name your package build queue "Package Build Queue" for the job submission command to select it by default.
 
+To make this faster and simpler, you can use our provided starter farm CloudFormation template [here](https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/cloudformation/farm_templates/starter_farm) to deploy your Deadline infrastructure along with
+a configured package build queue as documented in the Deadline Cloud developer guide linked above. 
+
 To submit package build jobs, you will need the
 [Deadline Cloud CLI](https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/submit-jobs-how.html)
 installed on your workstation.


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
If a customer read the `conda_recipes` README, they wouldn't have known that there exists a starter farm CFN template does a lot of the Conda channel + package build queue set up already, thereby minimizing human error. They would just see the AWS documentation to manually set up Deadline resources in order to configure an S3 conda channel.

### What was the solution? (How)
Add a link to the README stating that a CFN template is available to deploy their package build queue setup.

### What is the impact of this change?
Easier for customer to follow along and start submitting their package build jobs to set up their custom S3 conda channel.

### How was this change tested?

No testing needed.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*