### PR TITLE
fix: CFN template hardcoded region, package job script bug

### DIFF
--- a/cloudformation/farm_templates/starter_farm/deadline-cloud-starter-farm-template.yaml
+++ b/cloudformation/farm_templates/starter_farm/deadline-cloud-starter-farm-template.yaml
@@ -728,7 +728,7 @@ Resources:
               - logs:GetLogEvents
               Effect: Allow
               Resource: !Sub
-                - "arn:aws:logs:us-west-2:${AWS::AccountId}:log-group:/aws/deadline/${FarmId}/*"
+                - "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/deadline/${FarmId}/*"
                 - FarmId: !GetAtt farm.FarmId
             - Sid: DeadlineServiceManagedFleetSoftwareAccess
               Action:
@@ -811,7 +811,7 @@ Resources:
               - logs:GetLogEvents
               Effect: Allow
               Resource: !Sub
-                - "arn:aws:logs:us-west-2:${AWS::AccountId}:log-group:/aws/deadline/${FarmId}/*"
+                - "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/deadline/${FarmId}/*"
                 - FarmId: !GetAtt farm.FarmId
             - Sid: DeadlineServiceManagedFleetSoftwareAccess
               Action:

--- a/conda_recipes/submit-package-job
+++ b/conda_recipes/submit-package-job
@@ -5,15 +5,20 @@
 
 set -euo pipefail
 
+# Find the path to the 'deadline' executable
+DEADLINE_PATH="$(which deadline)"
 
-DEADLINE_PATH=$(which deadline)
-if [ $(basename $(dirname $DEADLINE_PATH)) = Scripts ]; then
+if [ "$(basename "$(dirname "$DEADLINE_PATH")")" = Scripts ]; then
     # Windows Python installation with Scripts directory
-    DEADLINE_PYTHON=$(dirname $(dirname $DEADLINE_PATH))/Python.exe
+    DEADLINE_PYTHON="$(dirname "$(dirname "$DEADLINE_PATH")")/Python.exe"
+
+    # Run the Python script submitter with the same Python
+    "$DEADLINE_PYTHON" "$0-script.py" "$@"
 else
     # Take the #! from the script
-    DEADLINE_PYTHON=$(head -1 $DEADLINE_PATH | cut -c 3-)
-fi
+    DEADLINE_PYTHON=$(head -1 "$DEADLINE_PATH" | cut -c 3-)
 
-# Run the Python script submitter with the same Python
-$DEADLINE_PYTHON $0-script.py "$@"
+    # Run the Python script submitter with the same Python.
+    # Not quoting the command for cases like `#!/usr/bin/env python`
+    $DEADLINE_PYTHON "$0-script.py" "$@"
+fi


### PR DESCRIPTION
### What was the problem/requirement/solution? (What/Why/How)

* The starter_farm CloudFormation template included us-west-2 in two IAM policies, this is changed to be the deployment region.
* The conda_recipes/submit-package-job did not work with spaces in paths, this adds quotes where necessary to support them.

### What is the impact of this change?

Fewer errors when people try the samples.

### How was this change tested?

- Deployed CFN template, confirmed success.
- Submitted package build jobs with the updated script.

### Was this change documented?

N/A

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*