### PR TITLE
refactor: Env clean ups, add openjd CLI command to job_dev README

### DIFF
--- a/cloudformation/farm_templates/apply-conda-queue-env.py
+++ b/cloudformation/farm_templates/apply-conda-queue-env.py
@@ -58,7 +58,7 @@ def main():
         result_cfn_template.append(line)
         if start_delim in line:
             prefix = line.split(start_delim, 1)[0]
-            result_cfn_template.extend(prefix + qe_line for qe_line in queue_env)
+            result_cfn_template.extend((prefix + qe_line).rstrip() for qe_line in queue_env)
             skipping_content = True
     result_cfn_template.append("")
 

--- a/cloudformation/farm_templates/starter_farm/deadline-cloud-starter-farm-template.yaml
+++ b/cloudformation/farm_templates/starter_farm/deadline-cloud-starter-farm-template.yaml
@@ -334,8 +334,8 @@ Resources:
           type: STRING
           description: >
             This is a space-separated list of Conda package match specifications to
-            install for the job. E.g. "blender=3.6" for a job that renders frames in
-            Blender 3.6.
+            install for the job. E.g. "blender=4.3" for a job that renders frames in
+            Blender 4.3.
           default: ""
           userInterface:
             control: LINE_EDIT
@@ -491,133 +491,131 @@ Resources:
                 # Initialize/activate the Conda virtual environment
                 if [ -n "$NAMED_CONDA_ENV" ] && conda env list | grep -q "^$NAMED_CONDA_ENV "; then
                     echo "Reusing the existing named Conda environment $NAMED_CONDA_ENV."
+                    echo ""
 
-                    # Activate the Conda environment
+                    # Capture environment variables set by activation
                     python '{{Env.File.OpenJDVarsStart}}' .vars
-                    set +u
-                    conda activate "$NAMED_CONDA_ENV"
-                    set -u
-                    python '{{Env.File.OpenJDVarsCapture}}' .vars
+                    conda run -n "$NAMED_CONDA_ENV" python '{{Env.File.OpenJDVarsCapture}}' .vars
+                    ENV_DIR=$(conda run -n "$NAMED_CONDA_ENV" bash -c 'echo $CONDA_PREFIX')
 
                     CUR_TIMESTAMP="$(date +%s)"
-                    TIMESTAMP_FILE="$CONDA_PREFIX/var/log/conda_queue_env_update_timestamp"
+                    TIMESTAMP_FILE="$ENV_DIR/var/log/conda_queue_env_update_timestamp"
+                    UPDATE_AFTER='{{Param.NamedCondaEnvUpdateAfterMinutes}}'
                     if [ -f "$TIMESTAMP_FILE" ]; then
                         PREV_UPDATE_TIMESTAMP="$(cat "$TIMESTAMP_FILE")"
-                        MINUTES_SINCE_UPDATE="$(( ( $CUR_TIMESTAMP - $PREV_UPDATE_TIMESTAMP ) / 60 ))"
+                        MINUTES_SINCE_UPDATE="$(python -c "print(($CUR_TIMESTAMP - $PREV_UPDATE_TIMESTAMP) // 60)")"
                     else
                         echo "The file recording the previous timestamp was not found"
-                        MINUTES_SINCE_UPDATE=0
+                        MINUTES_SINCE_UPDATE="$UPDATE_AFTER"
                     fi
                     echo "Minutes elapsed since last update of this named Conda environment: $MINUTES_SINCE_UPDATE"
 
-                    if [ $MINUTES_SINCE_UPDATE -ge {{Param.NamedCondaEnvUpdateAfterMinutes}} ]; then
-                        echo "Elapsed time greater than or equal to {{Param.NamedCondaEnvUpdateAfterMinutes}} minutes, updating the environment packages to the latest"
-                        set +u
-                        conda install --yes \
-                            --update-all \
+                    if [ $MINUTES_SINCE_UPDATE -ge $UPDATE_AFTER ]; then
+                        echo "Elapsed time greater than or equal to $UPDATE_AFTER minutes, updating the environment packages to the latest"
+                        conda install -n "$NAMED_CONDA_ENV" --yes --quiet \
                             $CONDA_PACKAGES \
                             $CHANNEL_OPTS
-                        set -u
 
                         # Save the channels and packages used in the environment, to help out debugging
-                        LOGFILE="$CONDA_PREFIX/var/log/conda_queue_env.log"
+                        LOGFILE="$ENV_DIR/var/log/conda_queue_env.log"
                         echo "Updated $NAMED_CONDA_ENV env at $(date --iso-8601=minutes)" >> "$LOGFILE"
                         echo '  CondaChannels: {{Param.CondaChannels}}' >> "$LOGFILE"
                         echo '  CondaPackages: {{Param.CondaPackages}}' >> "$LOGFILE"
 
                         # Save a timestamp of when we updated
-                        echo "$CUR_TIMESTAMP" > "$CONDA_PREFIX/var/log/conda_queue_env_update_timestamp"
+                        echo "$CUR_TIMESTAMP" > "$ENV_DIR/var/log/conda_queue_env_update_timestamp"
                     else
-                        echo "Elapsed time less than {{Param.NamedCondaEnvUpdateAfterMinutes}} minutes, skipping updates"
+                        echo "Elapsed time less than $UPDATE_AFTER minutes, skipping updates"
                     fi
+
+                    echo ""
+                    conda list -n "$NAMED_CONDA_ENV"
                 elif [ -n "$NAMED_CONDA_ENV" ]; then
                     echo "Named Conda environment $NAMED_CONDA_ENV not found, creating it."
 
-                    # Make sure there's no incomplete environment hanging around
+                    # Remove incomplete environments
                     remove_named_env "$NAMED_CONDA_ENV"
 
-                    # Create the virtual environment
-                    conda create --yes \
+                    conda create --yes --quiet \
                         --name "$NAMED_CONDA_ENV" \
                         $CONDA_PACKAGES \
                         $CHANNEL_OPTS
 
-                    # Activate the Conda environment
+                    # Capture environment variables set by activation
                     python '{{Env.File.OpenJDVarsStart}}' .vars
-                    set +u
-                    conda activate "$NAMED_CONDA_ENV"
-                    set -u
-                    python '{{Env.File.OpenJDVarsCapture}}' .vars
+                    conda run -n "$NAMED_CONDA_ENV" python '{{Env.File.OpenJDVarsCapture}}' .vars
+                    ENV_DIR=$(conda run -n $NAMED_CONDA_ENV bash -c 'echo $CONDA_PREFIX')
 
-                    # Save the channels and packages used in the environment, to help out debugging
-                    LOGFILE="$CONDA_PREFIX/var/log/conda_queue_env.log"
+                    # Save the channels and packages used in the environment, to help debugging
+                    LOGFILE="$ENV_DIR/var/log/conda_queue_env.log"
                     mkdir -p "$(dirname $LOGFILE)"
                     echo "Created $NAMED_CONDA_ENV env at $(date --iso-8601=minutes)" >> "$LOGFILE"
                     echo '  CondaChannels: {{Param.CondaChannels}}' >> "$LOGFILE"
                     echo '  CondaPackages: {{Param.CondaPackages}}' >> "$LOGFILE"
 
                     # Save a timestamp of when we updated
-                    date +%s > "$CONDA_PREFIX/var/log/conda_queue_env_update_timestamp"
+                    date +%s > "$ENV_DIR/var/log/conda_queue_env_update_timestamp"
                 else
                     echo "Creating temporary Conda environment in the session directory..."
 
-                    # Create the virtual environment
-                    conda create --yes \
-                        -p '{{Session.WorkingDirectory}}/.env' \
+                    ENV_DIR="$(mktemp -d '{{Session.WorkingDirectory}}/.env-XXXXX')"
+                    conda create --yes --quiet \
+                        -p "$ENV_DIR" \
                         $CONDA_PACKAGES \
                         $CHANNEL_OPTS
 
-                    # Activate the Conda environment
+                    # Capture environment variables set by activation
                     python '{{Env.File.OpenJDVarsStart}}' .vars
-                    set +u
-                    conda activate '{{Session.WorkingDirectory}}/.env'
-                    set -u
-                    python '{{Env.File.OpenJDVarsCapture}}' .vars
+                    conda run -p "$ENV_DIR" python '{{Env.File.OpenJDVarsCapture}}' .vars
                 fi
 
-                # Print information about the environment
-                conda info
+                conda run -p "$ENV_DIR" conda info
             - name: Exit
               filename: conda-queue-env-exit.sh
               type: TEXT
               data: |
                 set -euo pipefail
 
-                # When using this queue environment on long-lived worker hosts, such as on premises,
-                # automatically named conda environments can accumulate. This code removes them after
-                # 96 hours of unuse. 96 hours was chosen so the caches stick around for a long weekend.
+                # When using this queue environment on long-lived worker hosts, such as on premises, the
+                # automatically named conda environments can accumulate. This code cleans up these environments
+                # after they haven't been used for 96 hours, a length of time chosen so that when a farm is idle
+                # for a long weekend it doesn't clear all these environment caches.
 
-                DELETE_AFTER_HOURS=96
+                # Deactivate the environment so we can delete it if necessary
+                set +u
+                eval "$(conda shell.bash deactivate)"
+                set -u
 
-                echo "Cleaning up automatically-named conda environments not updated within $DELETE_AFTER_HOURS hours."
+                ENV_DELETE_AFTER_HOURS=96
 
-                AUTO_CONDA_ENVS="$(conda env list | grep "^hashname_" | cut -d " " -f 1)"
+                echo "Cleaning up any automatically-named conda environments that weren't updated within $ENV_DELETE_AFTER_HOURS hours."
+
+                AUTO_CONDA_ENVS="$(conda env list | { grep "^hashname_" || true; } | cut -d " " -f 1)"
                 REMOVED_ENV=0
 
                 CUR_TIMESTAMP="$(date +%s)"
                 for ENV_NAME in $AUTO_CONDA_ENVS; do
                     echo "Checking environment $ENV_NAME"
+                    ENV_DIR=$(conda run -n $ENV_NAME bash -c 'echo $CONDA_PREFIX')
 
-                    set +u
-                    conda activate $ENV_NAME
-                    set -u
-
-                    LOGFILE="$CONDA_PREFIX/var/log/conda_queue_env.log"
+                    LOGFILE="$ENV_DIR/var/log/conda_queue_env.log"
                     if [ -f "$LOGFILE" ]; then
                         # Creation and each update outputs 3 lines to the log, so print the last 3
                         tail -3 "$LOGFILE"
                     fi
 
-                    PREV_UPDATE_TIMESTAMP="$(cat "$CONDA_PREFIX/var/log/conda_queue_env_update_timestamp")"
-                    HOURS_SINCE_UPDATE="$(( ( $CUR_TIMESTAMP - $PREV_UPDATE_TIMESTAMP ) / 1440 ))"
+                    TIMESTAMP_FILE="$ENV_DIR/var/log/conda_queue_env_update_timestamp"
+                    if [ -f "$TIMESTAMP_FILE" ]; then
+                        PREV_UPDATE_TIMESTAMP="$(cat "$TIMESTAMP_FILE")"
+                    else
+                        echo "The file recording the previous timestamp was not found"
+                        PREV_UPDATE_TIMESTAMP=0
+                    fi
+                    HOURS_SINCE_UPDATE="$(python -c print"(($CUR_TIMESTAMP - $PREV_UPDATE_TIMESTAMP) // 3600)")"
                     echo "Environment was last updated $HOURS_SINCE_UPDATE hours ago."
 
-                    set +u
-                    conda deactivate
-                    set -u
-
-                    if [ $HOURS_SINCE_UPDATE -gt $DELETE_AFTER_HOURS ]; then
-                        echo "Elapsed time $HOURS_SINCE_UPDATE is greater than $DELETE_AFTER_HOURS hours, removing the environment."
+                    if [ $HOURS_SINCE_UPDATE -gt $ENV_DELETE_AFTER_HOURS ]; then
+                        echo "Elapsed time $HOURS_SINCE_UPDATE is greater than $ENV_DELETE_AFTER_HOURS hours, removing the environment."
                         conda env remove --yes -q -n $ENV_NAME
                         REMOVED_ENV=1
                     fi
@@ -626,8 +624,6 @@ Resources:
                 if [ "$REMOVED_ENV" = "1" ]; then
                     echo "Cleaning the conda cache to reclaim disk space."
                     conda clean --yes --all
-                else
-                    echo "Nothing to clean up."
                 fi
 
             - name: OpenJDVarsStart

--- a/job_bundles/job_dev_progression/README.md
+++ b/job_bundles/job_dev_progression/README.md
@@ -12,3 +12,57 @@ and unit tests.
 
 While this example is built around Python, the ideas are not Python-specific.
 Feel free to adapt them to your language toolchain of choice.
+
+## Running jobs on Deadline Cloud
+
+To run these jobs on Deadline Cloud, you need a farm in your AWS account.
+The [quickstart in the Deadline Cloud console](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/getting-started.html)
+or the [starter_farm sample CloudFormation template](https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/cloudformation/farm_templates/starter_farm#readme)
+are two ways to deploy one. In both cases, the farm will include a queue environment that can
+provide a conda virtual environment for the jobs.
+
+With the Deadline Cloud CLI installed locally, e.g. from `pip install deadline`,
+the following command will submit the first stage to your farm:
+
+```bash
+$ deadline bundle submit stage_1_self_contained_template
+```
+
+You can view your job and its log output from [Deadline Cloud monitor](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/working-with-deadline-monitor.html).
+
+## Running jobs locally
+
+You can run jobs locally for development or as a way to use one code base locally and on your farm.
+Use the [Open Job Description CLI](https://github.com/OpenJobDescription/openjd-cli#readme),
+available to install from `pip install openjd-cli`.
+
+In each job template, you'll find two parameters defined that specify the software
+environment it expects to run in. You can either provide the necessary applications by
+installing them yourself, or you can use an environment template to provide the conda packages.
+See the [sample environment templates](https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/queue_environments#readme),
+and note that you will need conda installed in order for them to work.
+
+If you have set up all the required software in the `PATH` environment variable, you can run
+the job directly. If `polars` is not installed, the job will fail with an error in the log
+like `ModuleNotFoundError: No module named 'polars'`.
+
+```bash
+$ openjd run stage_1_self_contained_template/template.yaml
+```
+
+If you run the jobs with the [conda_queue_env_console_equivalent](https://github.com/aws-deadline/deadline-cloud-samples/blob/mainline/queue_environments/conda_queue_env_console_equivalent.yaml)
+sample, it will create a conda virtual environment within the job's session directory.
+This creates a fresh conda environment every time you run the job.
+
+```bash
+$ openjd run --environment ../../queue_environments/conda_queue_env_console_equivalent.yaml stage_1_self_contained_template/template.yaml
+```
+
+If you run the jobs with the [conda_queue_env_improved_caching](https://github.com/aws-deadline/deadline-cloud-samples/blob/mainline/queue_environments/conda_queue_env_improved_caching.yaml)
+sample, it will take the hash of requested channels and packages, and use a named channel based on that hash. When
+the named channel already exists, it will reuse it directly. After a configurable delay, it will refresh the packages,
+and after a longer delay, it will remove the environment.
+
+```bash
+$ openjd run --environment ../../queue_environments/conda_queue_env_improved_caching.yaml stage_1_self_contained_template/template.yaml
+```

--- a/job_bundles/job_dev_progression/stage_1_self_contained_template/template.yaml
+++ b/job_bundles/job_dev_progression/stage_1_self_contained_template/template.yaml
@@ -58,7 +58,7 @@ steps:
         cd '{{Param.WorkspacePath}}'
 
         # Copy the input CSV files
-        mkdir csv
+        mkdir -p csv
         cp '{{Param.InputCsvFile}}' csv/dataset.csv
 
 - name: ProcessWithPython

--- a/job_bundles/job_dev_progression/stage_2_bundled_scripts/scripts/initialize.sh
+++ b/job_bundles/job_dev_progression/stage_2_bundled_scripts/scripts/initialize.sh
@@ -13,5 +13,5 @@ mkdir -p "$2"
 cd "$2"
 
 # Copy the input CSV file
-mkdir csv
+mkdir -p csv
 cp "$1" csv/dataset.csv

--- a/queue_environments/conda_queue_env_console_equivalent.yaml
+++ b/queue_environments/conda_queue_env_console_equivalent.yaml
@@ -4,8 +4,8 @@ parameterDefinitions:
   type: STRING
   description: >
     This is a space-separated list of Conda package match specifications to
-    install for the job. E.g. "blender=3.6" for a job that renders frames in
-    Blender 3.6.
+    install for the job. E.g. "blender=4.3" for a job that renders frames in
+    Blender 4.3.
   default: ""
   userInterface:
     control: LINE_EDIT
@@ -62,20 +62,18 @@ environment:
         echo "Creating a Conda environment in the session directory..."
 
         # Create the virtual environment
-        conda create --yes \
-            -p '{{Session.WorkingDirectory}}/.env' \
+        ENV_DIR="$(mktemp -d '{{Session.WorkingDirectory}}/.env-XXXXX')"
+        conda create --yes --quiet \
+            -p "$ENV_DIR" \
             $CONDA_PACKAGES \
             $CHANNEL_OPTS
 
-        # Activate the Conda environment, capturing the environment variables for the session to use
+        # Capture the environment variables set by activation
         python '{{Env.File.OpenJDVarsStart}}' .vars
-        set +u
-        conda activate '{{Session.WorkingDirectory}}/.env'
-        set -u
-        python '{{Env.File.OpenJDVarsCapture}}' .vars
+        conda run -p "$ENV_DIR" python '{{Env.File.OpenJDVarsCapture}}' .vars
 
         # Print information about the activated Conda environment
-        conda info
+        conda run -p "$ENV_DIR" conda info
     - name: OpenJDVarsStart
       filename: openjd-vars-start.py
       type: TEXT

--- a/queue_environments/conda_queue_env_from_console.yaml
+++ b/queue_environments/conda_queue_env_from_console.yaml
@@ -4,8 +4,8 @@ parameterDefinitions:
   type: STRING
   description: >
     This is a space-separated list of Conda package match specifications to
-    install for the job. E.g. "blender=3.6" for a job that renders frames in
-    Blender 3.6.
+    install for the job. E.g. "blender=4.3" for a job that renders frames in
+    Blender 4.3.
   default: ""
   userInterface:
     control: LINE_EDIT

--- a/queue_environments/conda_queue_env_improved_caching.yaml
+++ b/queue_environments/conda_queue_env_improved_caching.yaml
@@ -5,8 +5,8 @@ parameterDefinitions:
   type: STRING
   description: >
     This is a space-separated list of Conda package match specifications to
-    install for the job. E.g. "blender=3.6" for a job that renders frames in
-    Blender 3.6.
+    install for the job. E.g. "blender=4.3" for a job that renders frames in
+    Blender 4.3.
   default: ""
   userInterface:
     control: LINE_EDIT
@@ -116,6 +116,19 @@ environment:
         }
         trap 'conda_clean_on_error $?' EXIT
 
+        function remove_named_env {
+            for ENVS_DIR in $(conda info --json | python -c "import json, sys; v = json.load(sys.stdin); print('\n'.join(v['envs_dirs']))"); do
+                if [ -d $ENVS_DIR/$1 ]; then
+                    echo "Removing directory $ENVS_DIR/$1 for the environment"
+                    rm -rf $ENVS_DIR/$1
+                    if [ -d $ENVS_DIR/$1 ]; then
+                        echo "ERROR: Could not remove the directory. Possibly a permissions error or a process holding a lock."
+                        exit 1
+                    fi
+                fi
+            done
+        }
+
         NAMED_CONDA_ENV='{{Param.NamedCondaEnv}}'
 
         # If the special name 'AUTOMATIC' is provided, use the hash of the CondaChannels and CondaPackages
@@ -132,16 +145,7 @@ environment:
         # If we're not reusing the Conda env, clean up any prior ones
         if [ '{{Param.NamedCondaEnvAction}}' = 'REMOVE_AND_CREATE' ] && [ -n "$NAMED_CONDA_ENV" ]; then
             echo "NamedCondaEnvAction parameter is set to REMOVE_AND_CREATE, removing the virtual environment..."
-            for ENVS_DIR in $(conda info --json | python -c "import json, sys; v = json.load(sys.stdin); print('\n'.join(v['envs_dirs']))"); do
-                if [ -d $ENVS_DIR/$NAMED_CONDA_ENV ]; then
-                    echo "Removing directory $ENVS_DIR/$NAMED_CONDA_ENV for the environment"
-                    rm -rf $ENVS_DIR/$NAMED_CONDA_ENV
-                    if [ -d $ENVS_DIR/$NAMED_CONDA_ENV ]; then
-                        echo "ERROR: Could not remove the directory. Possibly a permissions error or a process holding a lock."
-                        exit 1
-                    fi
-                fi
-            done
+            remove_named_env "$NAMED_CONDA_ENV"
         fi
 
         # If requested, clean the Conda package cache
@@ -158,101 +162,85 @@ environment:
         # Initialize/activate the Conda virtual environment
         if [ -n "$NAMED_CONDA_ENV" ] && conda env list | grep -q "^$NAMED_CONDA_ENV "; then
             echo "Reusing the existing named Conda environment $NAMED_CONDA_ENV."
+            echo ""
 
-            # Activate the Conda environment
+            # Capture environment variables set by activation
             python '{{Env.File.OpenJDVarsStart}}' .vars
-            set +u
-            conda activate "$NAMED_CONDA_ENV"
-            set -u
-            python '{{Env.File.OpenJDVarsCapture}}' .vars
+            conda run -n "$NAMED_CONDA_ENV" python '{{Env.File.OpenJDVarsCapture}}' .vars
+            ENV_DIR=$(conda run -n "$NAMED_CONDA_ENV" bash -c 'echo $CONDA_PREFIX')
 
-            CURRENT_TIMESTAMP="$(date +%s)"
-            TIMESTAMP_FILE="$CONDA_PREFIX/var/log/conda_queue_env_update_timestamp"
+            CUR_TIMESTAMP="$(date +%s)"
+            TIMESTAMP_FILE="$ENV_DIR/var/log/conda_queue_env_update_timestamp"
+            UPDATE_AFTER='{{Param.NamedCondaEnvUpdateAfterMinutes}}'
             if [ -f "$TIMESTAMP_FILE" ]; then
-                PREVIOUS_UPDATE_TIMESTAMP="$(cat "$TIMESTAMP_FILE")"
-                MINUTES_SINCE_UPDATE="$(( ( $CURRENT_TIMESTAMP - $PREVIOUS_UPDATE_TIMESTAMP ) / 60 ))"
+                PREV_UPDATE_TIMESTAMP="$(cat "$TIMESTAMP_FILE")"
+                MINUTES_SINCE_UPDATE="$(python -c "print(($CUR_TIMESTAMP - $PREV_UPDATE_TIMESTAMP) // 60)")"
             else
                 echo "The file recording the previous timestamp was not found"
-                MINUTES_SINCE_UPDATE=0
+                MINUTES_SINCE_UPDATE="$UPDATE_AFTER"
             fi
             echo "Minutes elapsed since last update of this named Conda environment: $MINUTES_SINCE_UPDATE"
 
-            if [ $MINUTES_SINCE_UPDATE -ge {{Param.NamedCondaEnvUpdateAfterMinutes}} ]; then
-                echo "Elapsed time greater than or equal to {{Param.NamedCondaEnvUpdateAfterMinutes}} minutes, updating the environment packages to the latest"
-                set +u
-                conda install --yes \
-                    --update-all \
+            if [ $MINUTES_SINCE_UPDATE -ge $UPDATE_AFTER ]; then
+                echo "Elapsed time greater than or equal to $UPDATE_AFTER minutes, updating the environment packages to the latest"
+                conda install -n "$NAMED_CONDA_ENV" --yes --quiet \
                     $CONDA_PACKAGES \
                     $CHANNEL_OPTS
-                set -u
 
                 # Save the channels and packages used in the environment, to help out debugging
-                LOGFILE="$CONDA_PREFIX/var/log/conda_queue_env.log"
+                LOGFILE="$ENV_DIR/var/log/conda_queue_env.log"
                 echo "Updated $NAMED_CONDA_ENV env at $(date --iso-8601=minutes)" >> "$LOGFILE"
                 echo '  CondaChannels: {{Param.CondaChannels}}' >> "$LOGFILE"
                 echo '  CondaPackages: {{Param.CondaPackages}}' >> "$LOGFILE"
 
                 # Save a timestamp of when we updated
-                echo "$CURRENT_TIMESTAMP" > "$CONDA_PREFIX/var/log/conda_queue_env_update_timestamp"
+                echo "$CUR_TIMESTAMP" > "$ENV_DIR/var/log/conda_queue_env_update_timestamp"
             else
-                echo "Elapsed time less than {{Param.NamedCondaEnvUpdateAfterMinutes}} minutes, skipping updates"
+                echo "Elapsed time less than $UPDATE_AFTER minutes, skipping updates"
             fi
+
+            echo ""
+            conda list -n "$NAMED_CONDA_ENV"
         elif [ -n "$NAMED_CONDA_ENV" ]; then
             echo "Named Conda environment $NAMED_CONDA_ENV not found, creating it."
 
-            # Make sure there's no incomplete environment hanging around
-            for ENVS_DIR in $(conda info --json | python -c "import json, sys; v = json.load(sys.stdin); print('\n'.join(v['envs_dirs']))"); do
-                if [ -d $ENVS_DIR/$NAMED_CONDA_ENV ]; then
-                    echo "Removing directory $ENVS_DIR/$NAMED_CONDA_ENV for the environment"
-                    rm -rf $ENVS_DIR/$NAMED_CONDA_ENV
-                    if [ -d $ENVS_DIR/$NAMED_CONDA_ENV ]; then
-                        echo "ERROR: Could not remove the directory. Possibly a permissions error or a process holding a lock."
-                        exit 1
-                    fi
-                fi
-            done
+            # Remove incomplete environments
+            remove_named_env "$NAMED_CONDA_ENV"
 
-            # Create the virtual environment
-            conda create --yes \
+            conda create --yes --quiet \
                 --name "$NAMED_CONDA_ENV" \
                 $CONDA_PACKAGES \
                 $CHANNEL_OPTS
 
-            # Activate the Conda environment
+            # Capture environment variables set by activation
             python '{{Env.File.OpenJDVarsStart}}' .vars
-            set +u
-            conda activate "$NAMED_CONDA_ENV"
-            set -u
-            python '{{Env.File.OpenJDVarsCapture}}' .vars
+            conda run -n "$NAMED_CONDA_ENV" python '{{Env.File.OpenJDVarsCapture}}' .vars
+            ENV_DIR=$(conda run -n $NAMED_CONDA_ENV bash -c 'echo $CONDA_PREFIX')
 
-            # Save the channels and packages used in the environment, to help out debugging
-            LOGFILE="$CONDA_PREFIX/var/log/conda_queue_env.log"
+            # Save the channels and packages used in the environment, to help debugging
+            LOGFILE="$ENV_DIR/var/log/conda_queue_env.log"
             mkdir -p "$(dirname $LOGFILE)"
             echo "Created $NAMED_CONDA_ENV env at $(date --iso-8601=minutes)" >> "$LOGFILE"
             echo '  CondaChannels: {{Param.CondaChannels}}' >> "$LOGFILE"
             echo '  CondaPackages: {{Param.CondaPackages}}' >> "$LOGFILE"
 
             # Save a timestamp of when we updated
-            date +%s > "$CONDA_PREFIX/var/log/conda_queue_env_update_timestamp"
+            date +%s > "$ENV_DIR/var/log/conda_queue_env_update_timestamp"
         else
             echo "Creating temporary Conda environment in the session directory..."
 
-            # Create the virtual environment
-            conda create --yes \
-                -p '{{Session.WorkingDirectory}}/.env' \
+            ENV_DIR="$(mktemp -d '{{Session.WorkingDirectory}}/.env-XXXXX')"
+            conda create --yes --quiet \
+                -p "$ENV_DIR" \
                 $CONDA_PACKAGES \
                 $CHANNEL_OPTS
 
-            # Activate the Conda environment
+            # Capture environment variables set by activation
             python '{{Env.File.OpenJDVarsStart}}' .vars
-            set +u
-            conda activate '{{Session.WorkingDirectory}}/.env'
-            set -u
-            python '{{Env.File.OpenJDVarsCapture}}' .vars
+            conda run -p "$ENV_DIR" python '{{Env.File.OpenJDVarsCapture}}' .vars
         fi
 
-        # Print information about the environment
-        conda info
+        conda run -p "$ENV_DIR" conda info
     - name: Exit
       filename: conda-queue-env-exit.sh
       type: TEXT
@@ -264,34 +252,38 @@ environment:
         # after they haven't been used for 96 hours, a length of time chosen so that when a farm is idle
         # for a long weekend it doesn't clear all these environment caches.
 
+        # Deactivate the environment so we can delete it if necessary
+        set +u
+        eval "$(conda shell.bash deactivate)"
+        set -u
+
         ENV_DELETE_AFTER_HOURS=96
 
         echo "Cleaning up any automatically-named conda environments that weren't updated within $ENV_DELETE_AFTER_HOURS hours."
 
-        AUTO_CONDA_ENVS="$(conda env list | grep "^hashname_" | cut -d " " -f 1)"
+        AUTO_CONDA_ENVS="$(conda env list | { grep "^hashname_" || true; } | cut -d " " -f 1)"
         REMOVED_ENV=0
 
-        CURRENT_TIMESTAMP="$(date +%s)"
+        CUR_TIMESTAMP="$(date +%s)"
         for ENV_NAME in $AUTO_CONDA_ENVS; do
             echo "Checking environment $ENV_NAME"
+            ENV_DIR=$(conda run -n $ENV_NAME bash -c 'echo $CONDA_PREFIX')
 
-            set +u
-            conda activate $ENV_NAME
-            set -u
-
-            LOGFILE="$CONDA_PREFIX/var/log/conda_queue_env.log"
+            LOGFILE="$ENV_DIR/var/log/conda_queue_env.log"
             if [ -f "$LOGFILE" ]; then
                 # Creation and each update outputs 3 lines to the log, so print the last 3
                 tail -3 "$LOGFILE"
             fi
 
-            PREVIOUS_UPDATE_TIMESTAMP="$(cat "$CONDA_PREFIX/var/log/conda_queue_env_update_timestamp")"
-            HOURS_SINCE_UPDATE="$(( ( $CURRENT_TIMESTAMP - $PREVIOUS_UPDATE_TIMESTAMP ) / 1440 ))"
+            TIMESTAMP_FILE="$ENV_DIR/var/log/conda_queue_env_update_timestamp"
+            if [ -f "$TIMESTAMP_FILE" ]; then
+                PREV_UPDATE_TIMESTAMP="$(cat "$TIMESTAMP_FILE")"
+            else
+                echo "The file recording the previous timestamp was not found"
+                PREV_UPDATE_TIMESTAMP=0
+            fi
+            HOURS_SINCE_UPDATE="$(python -c print"(($CUR_TIMESTAMP - $PREV_UPDATE_TIMESTAMP) // 3600)")"
             echo "Environment was last updated $HOURS_SINCE_UPDATE hours ago."
-
-            set +u
-            conda deactivate
-            set -u
 
             if [ $HOURS_SINCE_UPDATE -gt $ENV_DELETE_AFTER_HOURS ]; then
                 echo "Elapsed time $HOURS_SINCE_UPDATE is greater than $ENV_DELETE_AFTER_HOURS hours, removing the environment."
@@ -303,8 +295,6 @@ environment:
         if [ "$REMOVED_ENV" = "1" ]; then
             echo "Cleaning the conda cache to reclaim disk space."
             conda clean --yes --all
-        else
-            echo "Nothing to clean up."
         fi
 
     - name: OpenJDVarsStart


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

We've identified improvements to make in the sample conda queue environments, based on usage in practice. The progress output of environment creation makes the log hard to work with, and when reusing an environment it's hard to trace down what packages were actually in the environment if something is failing in the task. The environment exit was sometimes failing.

In https://github.com/OpenJobDescription/openjd-cli/releases/tag/0.7.0, the OpenJD CLI `--environment` got a bugfix for running jobs together with an external environment like the sample conda queue environments. The job_dev_progression is a nice sample for demonstrating this usage to run it either locally or on Deadline Cloud.

### What was the solution? (How)

* Update apply-conda-queue-env.py to remove trailing whitespace.
* Clean up conda queue environment samples.
    * Create virtual environments in directories with names randomized by `mktemp`.
    * Capture the environment activation by using `conda run` instead of `conda activate`. Deactivate by calling eval "$(conda shell.bash deactivate)". These changes let the environment work without `conda init` changes working in non-interactive contexts.
    * Use Python instead of bash $(()) expressions for math.
    * Add `--quiet` option to `conda create` and `conda install` commands, to remove incremental progress updates from the log.
    * Add a `conda list` call to the 'improved_caching' env enter when it is reusing an environment, so that it is easy to look at the contents of the virtual environment from each job's log view.
    * Fixed a failing case in the 'improved_caching' env exit, due to grep return exit code 1 when no cached environments exist.
* Update the job_dev_progression README to include specific instructions for both running the job on Deadline Cloud and running the job locally with the Open Job Description CLI.
* Update the job dev progression code to use `mkdir -p` so that repeated runs on the same workspace succeed.

### What is the impact of this change?

The sample conda queue environments are more friendly to work with. The job_dev_progression sample has more useful info on ways to get started and run the jobs.

### How was this change tested?

Deployed the starter_farm CloudFormation template with the updated conda queue environment. Verified running a variety of different jobs on it.

Ran sample jobs locally with the openjd CLI and all the different sample conda queue environments.

### Was this change documented?

The README for the job_dev_progression was updated.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*