### PR TITLE
feat: adding After Effects plugin recipe for Saber

### DIFF
--- a/conda_recipes/aftereffects-saber/README.md
+++ b/conda_recipes/aftereffects-saber/README.md
@@ -1,0 +1,48 @@
+# Saber plug-in conda build recipe for After Effects
+
+## About
+This recipe installs the Saber.aex plug-in file to the AE plugin directory located under `$PREFIX/opt/aftereffects/Plug-ins` in the Conda environment. To write conda recipes to add more plug-ins to your After Effects Deadline Cloud setup, use this recipe as a template to guide your development.
+
+## Creating an archive file for Windows
+
+Follow these instructions to install Adobe After Effects 25 on a freshly created EC2 instance as Administrator, then install the AE Saber plug-in, then create an archive file of the Saber plugin and use it with the conda build recipe. If you have a Windows workstation, you can also do step 3 and 5 without starting an EC2 instance.
+
+1. Launch a fresh Windows Server 2022 instance.
+   1. From the AWS EC2 management console, select the option to Launch instance.
+   2. Enter instance name "Create Windows AE archive".
+   3. Select "Microsoft Windows Server 2022 Base" for the AMI.
+   4. Select an instance type with enough vCPUs and RAM, for example c5.4xlarge has 8 vCPUs and 16 GiB RAM.
+   5. Select "Proceed without a key pair" for the "Key pair (login)" option.
+   6. Make sure that "Allow RDP traffic" is unchecked. We will use SSM port forwarding to avoid sending RDP
+      protocol traffic directly over the internet.
+   7. Set the storage to at least 64 GiB. Adjust other settings as you like, e.g. if you want an encrypted volume of type gp3.
+   8. Select "Launch instance."
+   9. If it asks, select "Proceed without key pair" and proceed with the launch.
+   10. Once it launched, navigate to the instance detail page. Select "Connect," and with "Session manager" selected, again select "Connect."
+       If it says "SSM Agent is not online," you may have to wait a few minutes for it to initialize.
+   11. Create a secure password for the Administrator account. From the Administrator powershell window that session manager,
+       enter the following command with your secure password substituted to change the password.
+       1. `net user Administrator MY_SECURE_PASSWORD`
+2. Connect to the instance with SSM port forwarding and RDP.
+   1. Install or update the AWS CLI v2 from https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html.
+   2. Install or update the Session Manager plugin from https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html.
+   3. Run the following command, using AWS credentials that have suitable permissions, to start the SSM port forwarding. Replace INSTANCE_ID with the one you launched.
+      1. `aws ssm start-session --document-name AWS-StartPortForwardingSession --parameters "localPortNumber=33389,portNumber=3389" --target INSTANCE_ID`
+   4. Open RDP, and enter the following connection details:
+      1. Computer: `localhost:33389`
+      2. User name: `Administrator`
+   5. Enter the password you set for Administrator after you created the instance. You should now have a remote desktop session to your instance.
+3. Install Adobe After Effects 25 on the instance.
+   1. Download Adobe Creative Cloud after logging into your Adobe account.
+   2. Download Adobe After Effects 25 from Creative Cloud App.
+   3. The After Effects installer will launch. Proceed to install as normal with the components you want included.
+4. Install Saber plug-in
+   1. Download Saber plug-in from here: https://www.videocopilot.net/blog/2016/03/new-plug-in-saber-now-available-100-free
+   2. Log in with a powershell window again, either from the EC2 management console session manager or reconnecting to RDP.
+   3. Run the following commands to create the archive.
+      1. `Compress-Archive -Path 'C:\Program Files\Adobe\Adobe After Effects 2025\Support Files\Plug-ins\VideoCopilot\Saber.aex' -DestinationPath Saber_1_0_40_Windows_installation.zip`
+      2. `(Get-FileHash -Path "Saber_1_0_40_Windows_installation.zip" -Algorithm SHA256).Hash.ToLower()`
+   4. Record the file sha256 hash, and upload the archive to your private S3 bucket. You can use a PowerShell command like
+      `Write-S3Object -BucketName MY_BUCKET_NAME -Key Saber_1_0_40_Windows_installation.zip -File Saber_1_0_40_Windows_installation.zip`.
+4. From the AWS EC2 management console, select the instance you used and terminate it.
+5. Download the zip file to the `conda_recipes/archive_files` directory in your git clone of the [deadline-cloud-samples](https://github.com/aws-deadline/deadline-cloud-samples) repository for submitting package build jobs, and update the Windows source artifact hash in the saber conda build recipe meta.yaml.

--- a/conda_recipes/aftereffects-saber/README.md
+++ b/conda_recipes/aftereffects-saber/README.md
@@ -1,11 +1,11 @@
 # Saber plug-in conda build recipe for After Effects
 
 ## About
-This recipe installs the Saber.aex plug-in file to the AE plugin directory located under `$PREFIX/opt/aftereffects/Plug-ins` in the Conda environment. To write conda recipes to add more plug-ins to your After Effects Deadline Cloud setup, use this recipe as a template to guide your development.
+This recipe installs the Saber.aex plug-in file to the AE plugin directory located under `$PREFIX/opt/aftereffects/Plug-ins` in the Conda environment. To write conda recipes to add more plug-ins to your After Effects (AE) Deadline Cloud setup, use this recipe as a template to guide your development.
 
 ## Creating an archive file for Windows
 
-Follow these instructions to install Adobe After Effects 25 on a freshly created EC2 instance as Administrator, then install the AE Saber plug-in, then create an archive file of the Saber plugin and use it with the conda build recipe. If you have a Windows workstation, you can also do step 3 and 5 without starting an EC2 instance.
+Follow these instructions to install AE 25 on a freshly created EC2 instance as Administrator, then install the AE Saber plug-in, then create an archive file of the Saber plugin and use it with the conda build recipe. If you have a Windows workstation, you can also do step 3 and 5 without starting an EC2 instance.
 
 1. Launch a fresh Windows Server 2022 instance.
    1. From the AWS EC2 management console, select the option to Launch instance.
@@ -32,10 +32,10 @@ Follow these instructions to install Adobe After Effects 25 on a freshly created
       1. Computer: `localhost:33389`
       2. User name: `Administrator`
    5. Enter the password you set for Administrator after you created the instance. You should now have a remote desktop session to your instance.
-3. Install Adobe After Effects 25 on the instance.
+3. Install Adobe AE 25 on the instance.
    1. Download Adobe Creative Cloud after logging into your Adobe account.
-   2. Download Adobe After Effects 25 from Creative Cloud App.
-   3. The After Effects installer will launch. Proceed to install as normal with the components you want included.
+   2. Download Adobe AE 25 from Creative Cloud App.
+   3. The AE installer will launch. Proceed to install as normal with the components you want included.
 4. Install Saber plug-in
    1. Download Saber plug-in from here: https://www.videocopilot.net/blog/2016/03/new-plug-in-saber-now-available-100-free
    2. Log in with a powershell window again, either from the EC2 management console session manager or reconnecting to RDP.

--- a/conda_recipes/aftereffects-saber/README.md
+++ b/conda_recipes/aftereffects-saber/README.md
@@ -1,7 +1,7 @@
 # Saber plug-in conda build recipe for After Effects
 
 ## About
-This recipe installs the Saber.aex plug-in file to the AE plugin directory located under `$PREFIX/opt/aftereffects/Plug-ins` in the Conda environment. To write conda recipes to add more plug-ins to your After Effects (AE) Deadline Cloud setup, use this recipe as a template to guide your development.
+This recipe installs the Saber.aex plug-in file to the After Effects (AE) plugin directory located under `$PREFIX/opt/aftereffects/Plug-ins` in the Conda environment. To write conda recipes to add more plug-ins to your AE Deadline Cloud setup, use this recipe as a template to guide your development.
 
 ## Creating an archive file for Windows
 

--- a/conda_recipes/aftereffects-saber/README.md
+++ b/conda_recipes/aftereffects-saber/README.md
@@ -46,3 +46,4 @@ Follow these instructions to install Adobe After Effects 25 on a freshly created
       `Write-S3Object -BucketName MY_BUCKET_NAME -Key Saber_1_0_40_Windows_installation.zip -File Saber_1_0_40_Windows_installation.zip`.
 4. From the AWS EC2 management console, select the instance you used and terminate it.
 5. Download the zip file to the `conda_recipes/archive_files` directory in your git clone of the [deadline-cloud-samples](https://github.com/aws-deadline/deadline-cloud-samples) repository for submitting package build jobs, and update the Windows source artifact hash in the saber conda build recipe meta.yaml.
+6. Follow the instructions [here](https://github.com/aws-deadline/deadline-cloud-samples/blob/mainline/conda_recipes/README.md) to build the conda recipe into your custom conda channel.

--- a/conda_recipes/aftereffects-saber/deadline-cloud.yaml
+++ b/conda_recipes/aftereffects-saber/deadline-cloud.yaml
@@ -1,0 +1,10 @@
+condaPlatforms:
+  - platform: win-64
+    defaultSubmit: true
+    sourceArchiveFilename:
+    - Saber_1_0_40_Windows_installation.zip
+    sourceDownloadInstructions: 'Follow the instructions in README.md to construct the archive zip file.'
+    buildTool: conda-build
+jobParameters:
+  - name: CondaChannels
+    value: conda-forge

--- a/conda_recipes/aftereffects-saber/recipe/bld.bat
+++ b/conda_recipes/aftereffects-saber/recipe/bld.bat
@@ -1,0 +1,2 @@
+bash %RECIPE_DIR%/build_win.sh
+if errorlevel 1 exit 1

--- a/conda_recipes/aftereffects-saber/recipe/build_win.sh
+++ b/conda_recipes/aftereffects-saber/recipe/build_win.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+set -xeuo pipefail
+
+mkdir -p $PREFIX/opt
+
+AE_LOCATION="$PREFIX/opt/aftereffects"
+AE_PLUGINS_DIRECTORY="$AE_LOCATION/Plug-ins"
+
+mkdir -p $AE_PLUGINS_DIRECTORY
+cp -r $SRC_DIR/saber $AE_PLUGINS_DIRECTORY
+
+# Version without update number
+SABER_VERSION=${PKG_VERSION%.*}
+
+
+# See https://docs.conda.io/projects/conda/en/latest/dev-guide/deep-dives/activation.html
+# for details on activation. The Deadline Cloud sample queue environments use bash
+# to activate environments on Windows, so we recommend always producing both .bat and .sh files.
+mkdir -p "$PREFIX/etc/conda/activate.d"
+mkdir -p "$PREFIX/etc/conda/deactivate.d"
+
+
+cat <<EOF > "$PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.bat"
+set "SABER_VERSION=$SABER_VERSION"
+EOF
+cat "$PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.bat"
+
+
+cat <<EOF > "$PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.sh"
+export "SABER_VERSION=$SABER_VERSION"
+EOF
+cat "$PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.sh"
+
+
+cat <<EOF > "$PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.bat"
+set SABER_VERSION=
+EOF
+cat "$PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.bat"
+
+
+cat <<EOF > "$PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.sh"
+unset SABER_VERSION
+EOF
+cat "$PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.sh"

--- a/conda_recipes/aftereffects-saber/recipe/meta.yaml
+++ b/conda_recipes/aftereffects-saber/recipe/meta.yaml
@@ -1,0 +1,34 @@
+{% set name = "saber" %}
+{% set version_partial = "1" %}
+{% set version_minor = "0" %}
+{% set version_patch = "40" %}
+{% set version = version_partial + "." + version_minor + "." + version_patch %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+- url: archive_files/Saber_{{ version.replace(".", "_") }}_Windows_installation.zip # [win64]
+  sha256: f5551f4cf0a149c48defe324be9d97a12b434cbdfd869f5996f1af5a66cb7bc3 # [win64]
+  folder: saber
+
+build:
+  number: 0
+  # These build options for repackaging an application
+  # https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html
+  binary_relocation: False
+  detect_binary_files_with_prefix: False
+  missing_dso_whitelist:
+  - "**"
+
+requirements:
+  build:
+    - aftereffects
+  run:
+    - aftereffects
+
+about:
+  home: https://www.adobe.com/products/aftereffects.html
+  license: Commercial
+  summary: The Saber plugin, a free offering from Video Copilot, is a powerful tool for Adobe After Effects that allows users to create a variety of energy-based effects, including beams, lightsabers, lasers, portals, neon lights, and more.

--- a/conda_recipes/aftereffects-saber/recipe/meta.yaml
+++ b/conda_recipes/aftereffects-saber/recipe/meta.yaml
@@ -29,6 +29,6 @@ requirements:
     - aftereffects
 
 about:
-  home: https://www.adobe.com/products/aftereffects.html
+  home: https://www.videocopilot.net/blog/2016/03/new-plug-in-saber-now-available-100-free/
   license: Commercial
   summary: The Saber plugin, a free offering from Video Copilot, is a powerful tool for Adobe After Effects that allows users to create a variety of energy-based effects, including beams, lightsabers, lasers, portals, neon lights, and more.


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
It was unclear how to properly add AE plugin support for rendering on Deadline Cloud fleet workers

### What was the solution? (How)
Using a free AE plugin called Saber, I wrote a basic Conda recipe that copies that plugin into the Plug-ins directory of AfterEffects on the worker. That way when After Effects renders a job, it has access to use that plug-in. Saber requires no licensing so this works out of the box.

### What is the impact of this change?
Customers now have an idea of how to bring their AE plugins to Deadline Cloud. This conda recipe is based off the conda recipe for AE in this samples package.

### How was this change tested?
Wrote this plugin, built it into my custom conda channel, then submitted a render job that uses Saber and it worked!
<img width="1414" alt="Screenshot 2025-03-27 at 2 19 03 PM" src="https://github.com/user-attachments/assets/ea2ee257-d526-4745-943b-91fba37e75c0" />


### Was this change documented?
A README.md is attached in the `aftereffects-saber` folder for how customers can do it themselves.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*