### PR TITLE
chore: Update Cinema 4D open JD version recipe to 0.7.3

### DIFF
--- a/conda_recipes/cinema4d-openjd/recipe/meta.yaml
+++ b/conda_recipes/cinema4d-openjd/recipe/meta.yaml
@@ -4,7 +4,7 @@
 # https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/conda_recipes
 
 {% set name = "cinema4d-openjd" %}
-{% set version = "0.7.2" %}
+{% set version = "0.7.3" %}
 
 package:
   name: {{ name }}
@@ -12,7 +12,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/d/deadline-cloud-for-cinema-4d/deadline_cloud_for_cinema_4d-{{ version }}.tar.gz
-  sha256: 6a3cb214ad9b77e57a8ee94bd66d45bec8169bea0a5add9b49b8d03e9becc8c6
+  sha256: 0aec84bc57a542393534fb5f76cab5051da49a5827ba97954f76d7b300601163
   patches:
     - 0001-Remove-version-hook.patch
 

--- a/conda_recipes/cinema4d-openjd/recipe/meta.yaml
+++ b/conda_recipes/cinema4d-openjd/recipe/meta.yaml
@@ -40,7 +40,7 @@ requirements:
   run:
     # For the variant config file in deadline-cloud.yaml to work, python must not specify a version here.
     - python
-    - deadline >=0.49.7
+    - deadline >=0.49.7,<0.50
     - openjd-adaptor-runtime ==0.9.*
 
 test:

--- a/conda_recipes/cinema4d-openjd/recipe/meta.yaml
+++ b/conda_recipes/cinema4d-openjd/recipe/meta.yaml
@@ -4,7 +4,7 @@
 # https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/conda_recipes
 
 {% set name = "cinema4d-openjd" %}
-{% set version = "0.6.1" %}
+{% set version = "0.7.2" %}
 
 package:
   name: {{ name }}
@@ -12,7 +12,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/d/deadline-cloud-for-cinema-4d/deadline_cloud_for_cinema_4d-{{ version }}.tar.gz
-  sha256: e285197afa243ca2b54888d2ddee983723bbb724c6263f02f2fe4565cda9b502
+  sha256: 6a3cb214ad9b77e57a8ee94bd66d45bec8169bea0a5add9b49b8d03e9becc8c6
   patches:
     - 0001-Remove-version-hook.patch
 
@@ -40,7 +40,7 @@ requirements:
   run:
     # For the variant config file in deadline-cloud.yaml to work, python must not specify a version here.
     - python
-    - deadline ==0.49.*
+    - deadline >=0.49.7
     - openjd-adaptor-runtime ==0.9.*
 
 test:

--- a/conda_recipes/cinema4d-openjd/recipe/recipe.yaml
+++ b/conda_recipes/cinema4d-openjd/recipe/recipe.yaml
@@ -6,7 +6,7 @@
 # https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/conda_recipes
 
 context:
-  version: "0.6.1"
+  version: "0.7.2"
 
 package:
   name: cinema4d-openjd
@@ -15,7 +15,7 @@ package:
 # This source reference uses the source archive published to PyPI
 source:
   url: https://pypi.io/packages/source/d/deadline-cloud-for-cinema-4d/deadline_cloud_for_cinema_4d-${{ version }}.tar.gz
-  sha256: e285197afa243ca2b54888d2ddee983723bbb724c6263f02f2fe4565cda9b502
+  sha256: 6a3cb214ad9b77e57a8ee94bd66d45bec8169bea0a5add9b49b8d03e9becc8c6
   patches:
     - 0001-Remove-version-hook.patch
 
@@ -32,7 +32,7 @@ requirements:
     - pip
   run:
     - python
-    - deadline 0.49.*
+    - deadline >=0.49.7
     - openjd-adaptor-runtime 0.9.*
 
 tests:

--- a/conda_recipes/cinema4d-openjd/recipe/recipe.yaml
+++ b/conda_recipes/cinema4d-openjd/recipe/recipe.yaml
@@ -32,7 +32,7 @@ requirements:
     - pip
   run:
     - python
-    - deadline >=0.49.7
+    - deadline >=0.49.7,<0.50
     - openjd-adaptor-runtime 0.9.*
 
 tests:

--- a/conda_recipes/cinema4d-openjd/recipe/recipe.yaml
+++ b/conda_recipes/cinema4d-openjd/recipe/recipe.yaml
@@ -6,7 +6,7 @@
 # https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/conda_recipes
 
 context:
-  version: "0.7.2"
+  version: "0.7.3"
 
 package:
   name: cinema4d-openjd
@@ -15,7 +15,7 @@ package:
 # This source reference uses the source archive published to PyPI
 source:
   url: https://pypi.io/packages/source/d/deadline-cloud-for-cinema-4d/deadline_cloud_for_cinema_4d-${{ version }}.tar.gz
-  sha256: 6a3cb214ad9b77e57a8ee94bd66d45bec8169bea0a5add9b49b8d03e9becc8c6
+  sha256: 0aec84bc57a542393534fb5f76cab5051da49a5827ba97954f76d7b300601163
   patches:
     - 0001-Remove-version-hook.patch
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The conda recipe for Cinema 4D open JD was outdated. 

### What was the solution? (How)

Updated the hash and the version for the recipe. 

### What is the impact of this change?

Customers can now build and use the new conda packages. 

### How was this change tested?

Built the packages and ran renders on the built packages in Cinema 4D. 

<img width="1536" alt="image" src="https://github.com/user-attachments/assets/d352509a-eda1-471f-85f5-3e9af0f5b91f" />

### Was this change documented?

No

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*