### PR TITLE
fix: On Windows, submit-package-job fails in some installations

### DIFF
--- a/conda_recipes/submit-package-job-script.py
+++ b/conda_recipes/submit-package-job-script.py
@@ -18,11 +18,16 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 import yaml
-from deadline.client.api import create_job_from_job_bundle, get_boto3_client, list_queues
-from deadline.client.config import get_setting, set_setting
-from deadline.client.config.config_file import read_config
-from deadline.client.job_bundle import create_job_history_bundle_dir
 
+try:
+    from deadline.client.api import create_job_from_job_bundle, get_boto3_client, list_queues
+    from deadline.client.config import get_setting, set_setting
+    from deadline.client.config.config_file import read_config
+    from deadline.client.job_bundle import create_job_history_bundle_dir
+except ModuleNotFoundError:
+    print("ERROR: The `deadline` library is not installed. Please install it with the following command:")
+    print(f" \"{sys.executable}\" -m pip install deadline")
+    sys.exit(1)
 
 def validate_recipe(recipe_dir):
     """Validate the conda build recipe directory with some basic sanity checks."""

--- a/conda_recipes/submit-package-job.bat
+++ b/conda_recipes/submit-package-job.bat
@@ -2,8 +2,24 @@
 
 REM This script finds the Python that is used by the Deadline Cloud CLI,
 REM and then runs submit-package-job-script.py with that Python.
+REM If the Deadline Cloud CLI doesn't have an associated Python.exe,
+REM it will fall back to the bare "python" command.
 
 for /f "delims=" %%F in ('where deadline') do set DEADLINE_DIR=%%~dF%%~pF
 set SCRIPT_PATH=%~d0%~p0%~n0-script.py
+for %%a in (%DEADLINE_DIR:~0,-1%) do set "DEADLINE_PARENT_DIR=%%~dpa"
 
-"%DEADLINE_DIR%..\Python.exe" "%SCRIPT_PATH%" %*
+set "PYTHON=%DEADLINE_PARENT_DIR%Python.exe"
+where "%PYTHON%" > nul 2> nul
+if %ERRORLEVEL% NEQ 0 set PYTHON=python
+
+where "%PYTHON%" > nul 2> nul
+if %ERRORLEVEL% NEQ 0 goto nopython
+
+"%PYTHON%" "%SCRIPT_PATH%" %*
+
+exit /b 0
+
+:nopython
+echo No Python interpreter was found to run submit-package-job-script.py.
+exit /b 1


### PR DESCRIPTION

Fixes: https://github.com/aws-deadline/deadline-cloud-samples/issues/58

### What was the problem/requirement? (What/Why)

On Windows, if the Deadline Cloud CLI has no associated Python, the .bat to help submit package jobs fails. When this happens, it should instead fall back to the default Python available.

### What was the solution? (How)

* The Deadline Cloud submitter installer installs the Deadline Cloud CLI without an associated Python interpreter. Updated submit-package-job.bat to detect this case and fall back to just "python".
* Updated submit-package-job-script.py to print installation instructions if the 'deadline' library is not installed.

### What is the impact of this change?

Customers using our submitter installer and this package build submit script on Windows can use them as expected.

### How was this change tested?

Tested the command on Windows with/without Python in the PATH, and with/without the deadline library installed.

### Was this change documented?

N/A

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*