### PR TITLE
feat: Create new After Effects plugin bundle sample package recipe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ conda_recipes/archive_files/vraystd_*
 **/*.exe
 **/*.run
 **/*.pyc
+**/*.aex
+**/*.conda

--- a/conda_recipes/aftereffects-plugin-bundle/README.md
+++ b/conda_recipes/aftereffects-plugin-bundle/README.md
@@ -1,0 +1,129 @@
+# Conda build recipe for a bundle of After Effects plugins
+
+## About
+
+This package build recipe creates a conda package that bundles together all the After Effects plugins
+you provide in an input folder. Note that if your plugins require network licenses, you will have to
+handle that separately.
+
+To understand how After Effects plugins work in a conda package, see the instructions for plugin
+packages in the [After Effects recipe README](../aftereffects-25.1/README.md).
+
+## Building the package for Windows
+
+First copy all the Windows `.aex` plugin files that you want to include into
+the [`conda_recipes/archive_files/aftereffects-plugin-bundle/win-64`](../archive_files/aftereffects-plugin-bundle/win-64/)
+directory. You can find the plugins you're using locally in the After Effects installation
+directory like `C:\Program Files\Adobe\Adobe After Effects <version>\Support Files\Plug-ins`.
+
+### Build the package locally
+
+To build locally on Windows, you can follow the linked installation instructions for either
+[rattler-build](https://rattler.build/) or [conda-build](https://docs.conda.io/projects/conda-build).
+
+IMPORTANT: Conda packages have a build number that you need to update to a new number each time you
+build and publish the package for the same version number. Edit the meta.yaml and recipe.yaml files
+in the `build` section from `number: 0` to a bigger number each time you follow these instructions.
+
+From the `conda_recipes` directory, run one of the following build commands:
+
+```
+C:\Dev\deadline-cloud-samples\conda_recipes>rattler-build build -r aftereffects-plugin-bundle/recipe
+
+ ╭─ Finding outputs from recipe
+ │ Found 1 variants
+ ...
+ ╭─ Build summary
+ │
+ │ ╭─ Build summary for recipe: aftereffects-plugin-bundle-1.0-h9490d1a_1
+ │ │ Artifact: C:\Dev\deadline-cloud-samples\conda_recipes\output\win-64\aftereffects-plugin-bundle-1.0-h9490d1a_1.conda (253.17 KiB)
+ │ │ Variant configuration (hash: h9490d1a_1):
+ │ │ ╭─────────────────┬──────────╮
+ │ │ │ target_platform ┆ "win-64" │
+ │ │ ╰─────────────────┴──────────╯
+ │ │
+ │ │ Run dependencies:
+ │ │ ╭──────────────────┬──────────╮
+ │ │ │ Name             ┆ Spec     │
+ │ │ ╞══════════════════╪══════════╡
+ │ │ │ Run dependencies ┆          │
+ │ │ │ aftereffects     ┆ >=25,<26 │
+ │ │ ╰──────────────────┴──────────╯
+ │ │
+ │ │
+ │ ╰─────────────────── (took 0 seconds)
+ │
+ ╰─────────────────── (took 0 seconds)
+```
+
+or
+
+```
+C:\Dev\deadline-cloud-samples\conda_recipes>conda build aftereffects-plugin-bundle/recipe --no-test
+Adding in variants from internal_defaults
+...
+####################################################################################
+Source and build intermediates have been left in C:\...\conda-bld.
+There are currently 1 accumulated.
+To remove them, you can run the ```conda build purge``` command
+
+C:\Dev\deadline-cloud-samples\conda_recipes>dir C:\...\conda-bld\win-64
+...
+04/10/2025  02:21 PM           232,806 aftereffects-plugin-bundle-1.0-0.conda
+...
+```
+
+### Publish the locally built package to an S3 conda channel
+
+To publish your package to an S3 conda channel, two things need to happen:
+
+1. Copy the Windows package into the `win-64` subdirectory of the channel.
+2. Update the channel index (`repodata.json` and some other files) so that they
+   include metadata about the new package.
+
+You can accomplish this with the AWS CLI to synchronize S3 data and the `conda index`
+command that is available when you install [conda-build](https://docs.conda.io/projects/conda-build).
+
+Here's an example of doing this for the package that was built by rattler-build:
+
+1. Synchronize the `win-64` subdirectory of the channel locally.
+    ```
+    C:\Dev\deadline-cloud-samples\conda_recipes>set CHANNEL_BUCKET=<MY_S3_CHANNEL_BUCKET>
+
+    C:\Dev\deadline-cloud-samples\conda_recipes>aws s3 sync s3://%CHANNEL_BUCKET%/Conda/Default/win-64 ./temp-local-channel/win-64
+    ...
+    ```
+2. Copy the package you built into the `win-64` subdirectory.
+    ```
+    C:\Dev\deadline-cloud-samples\conda_recipes>copy output\win-64\aftereffects-plugin-bundle-1.0-h9490d1a_0.conda temp-local-channel\win-64
+            1 file(s) copied.
+    ...
+    ```
+3. Update the channel index with the new package.
+    ```
+    C:\Dev\deadline-cloud-samples\conda_recipes>conda index --subdir win-64 --zst ./temp-local-channel
+    Indexing ['win-64'] does not include 'noarch'
+    ...
+    ```
+4. Synchronize the local copy of the `win-64` subdirectory back to S3.
+    ```
+    C:\Dev\deadline-cloud-samples\conda_recipes>aws s3 sync ./temp-local-channel/win-64 s3://%CHANNEL_BUCKET%/Conda/Default/win-64
+    upload: temp-local-channel\win-64\repodata.json to s3://<MY_S3_CHANNEL_BUCKET>/Conda/Default/win-64/repodata.json
+    ...
+    ```
+
+### Build the package on Deadline Cloud
+
+If you create a package build queue as described in the Deadline Cloud developer guide page
+[Create a conda channel using S3](https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/configure-jobs-s3-channel.html),
+you can submit the package to build on your farm.
+
+Note that this approach automatically determines a new build number each time you run
+the package build job, you do not have to handle that yourself like when building locally.
+
+```
+C:\Dev\deadline-cloud-samples\conda_recipes>submit-package-job aftereffects-plugin-bundle
+No channel URL was provided, using a default prefix on the queue's job attachments bucket
+Building packages into channel s3://<MY_S3_CHANNEL_BUCKET>/Conda/Default
+...
+```

--- a/conda_recipes/aftereffects-plugin-bundle/deadline-cloud.yaml
+++ b/conda_recipes/aftereffects-plugin-bundle/deadline-cloud.yaml
@@ -1,0 +1,5 @@
+condaPlatforms:
+  - platform: win-64
+    defaultSubmit: true
+    sourceArchiveDirectory: aftereffects-plugin-bundle/win-64/
+    buildTool: conda-build

--- a/conda_recipes/aftereffects-plugin-bundle/recipe/bld.bat
+++ b/conda_recipes/aftereffects-plugin-bundle/recipe/bld.bat
@@ -1,0 +1,20 @@
+
+REM The package build recipe for After Effects installs into %PREFIX%\aftereffects.
+set "AE_PLUGINS_DIRECTORY=%PREFIX%\aftereffects\Plug-ins"
+mkdir "%AE_PLUGINS_DIRECTORY%"
+
+REM In order to keep this recipe as easy and simple to build as possible, we directly
+REM use that value here. Alternatively, we could add a build dependency to aftereffects
+REM and use %AE_LOCATION% value defined by the After Effects package.
+
+REM Copy all .aex plugin files.
+copy "%SRC_DIR%\*.aex" "%AE_PLUGINS_DIRECTORY%"
+
+REM Verify that at least one .aex file was copied
+if exist "%AE_PLUGINS_DIRECTORY%\*.aex" (
+    exit /b 0
+) else (
+    echo No *.aex plugin files were copied into the After Effects %AE_PLUGINS_DIRECTORY%
+    echo Check that the input directory for plugins contains at least one .aex file.
+    exit /b 1
+)

--- a/conda_recipes/aftereffects-plugin-bundle/recipe/meta.yaml
+++ b/conda_recipes/aftereffects-plugin-bundle/recipe/meta.yaml
@@ -1,0 +1,24 @@
+
+package:
+  name: aftereffects-plugin-bundle
+  version: "1.0"
+
+source:
+- path: ../../archive_files/aftereffects-plugin-bundle/win-64 # [win64]
+
+build:
+  number: 0
+  # These build options for repackaging an application
+  # https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html
+  binary_relocation: False
+  detect_binary_files_with_prefix: False
+  missing_dso_whitelist:
+  - "**"
+
+requirements:
+  run:
+    - aftereffects >=25,<26
+
+about:
+  license: LicenseRef-Multiple
+  summary: This package contains all the After Effects plugins provided to the recipe in a directory.

--- a/conda_recipes/aftereffects-plugin-bundle/recipe/recipe.yaml
+++ b/conda_recipes/aftereffects-plugin-bundle/recipe/recipe.yaml
@@ -1,0 +1,38 @@
+# Recipe in rattler-build format.
+# See https://prefix-dev.github.io/rattler-build/latest/
+
+context:
+  version: "1.0"
+
+package:
+  name: aftereffects-plugin-bundle
+  version: ${{ version }}
+
+source:
+  - if: win
+    then:
+      path: ../../archive_files/aftereffects-plugin-bundle/win-64
+
+build:
+  script:
+  - if: win
+    then:
+      - bld.bat
+
+  number: 0
+  # These build options for repackaging an application
+  # https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html
+  prefix_detection:
+    ignore_binary_files: True
+  dynamic_linking:
+    binary_relocation: False
+    missing_dso_allowlist:
+    - "**"
+
+requirements:
+  run:
+    - aftereffects >=25,<26
+
+about:
+  license: LicenseRef-Multiple
+  summary: This package contains all the After Effects plugins provided to the recipe in a directory.

--- a/conda_recipes/archive_files/aftereffects-plugin-bundle/win-64/README.md
+++ b/conda_recipes/archive_files/aftereffects-plugin-bundle/win-64/README.md
@@ -1,0 +1,4 @@
+# Directory for Windows After Effects Plugins
+
+Copy any .aex Windows plugin files into this directory for them to get built
+into the sample aftereffects-plugin-bundle sample.

--- a/conda_recipes/conda_build_linux_package/scripts/build-package.py
+++ b/conda_recipes/conda_build_linux_package/scripts/build-package.py
@@ -107,6 +107,7 @@ def main():
     parser.add_argument("--override-prefix-length")
     parser.add_argument("--override-source-archive1")
     parser.add_argument("--override-source-archive2")
+    parser.add_argument("--override-source-dir")
     parser.add_argument("--variant-config-file")
     args = parser.parse_args()
 
@@ -219,33 +220,40 @@ def main():
         if not os.path.isfile(args.override_source_archive2):
             print(f"ERROR: Override source archive 2 does not exist: {args.override_source_archive2}")
             sys.exit(1)
+    if args.override_source_dir:
+        if not os.path.isdir(args.override_source_dir):
+            print(f"ERROR: Override source dir does not exist: {args.override_source_dir}")
+            sys.exit(1)
 
     # Substitute the override archives into the recipe
     if "source" in rendered_recipe:
         updated_recipe["source"] = rendered_recipe["source"]
-        if isinstance(rendered_recipe["source"], dict):
-            if args.override_source_archive1:
-                if args.build_tool == "conda-build":
-                    updated_recipe["source"]["url"] = args.override_source_archive1
-                else:
-                    updated_recipe["source"].pop("url", None)
-                    updated_recipe["source"]["path"] = args.override_source_archive1
-        elif isinstance(rendered_recipe["source"], list):
-            if args.override_source_archive1 or args.override_source_archive2:
-                if args.override_source_archive1:
-                    if args.build_tool == "conda-build":
-                        updated_recipe["source"][0]["url"] = args.override_source_archive1
-                    else:
-                        updated_recipe["source"][0].pop("url", None)
-                        updated_recipe["source"][0]["path"] = args.override_source_archive1
-                if args.override_source_archive2:
-                    if args.build_tool == "conda-build":
-                        updated_recipe["source"][1]["url"] = args.override_source_archive2
-                    else:
-                        updated_recipe["source"][1].pop("url", None)
-                        updated_recipe["source"][1]["path"] = args.override_source_archive2
-        else:
+        # If the source is not in list form, turn it into a list
+        if isinstance(updated_recipe["source"], dict):
+            updated_recipe["source"] = [updated_recipe["source"]]
+
+        if not isinstance(updated_recipe["source"], list):
             raise RuntimeError("The rendered recipe's source field was not a string or a list.")
+
+        # Put the source archives in a list to help process sequentially
+        override_source_archives = []
+        if args.override_source_archive1:
+            override_source_archives.append(args.override_source_archive1)
+        if args.override_source_archive2:
+            override_source_archives.append(args.override_source_archive2)
+        override_source_dir = args.override_source_dir
+
+        # Iterate through the source entries and update either the directory path or URL
+        # based on the input override parameters.
+        for source_entry in updated_recipe["source"]:
+            if "path" in source_entry:
+                if override_source_dir:
+                    source_entry["path"] = override_source_dir
+            elif "url" in source_entry:
+                if override_source_archives:
+                    source_entry["url"] = override_source_archives.pop(0)
+                    if args.build_tool != "conda-build":
+                        source_entry["path"] = source_entry.pop("url")
 
     # Save the rendered recipe with modifications
     if args.build_tool == "conda-build":

--- a/conda_recipes/conda_build_linux_package/template.yaml
+++ b/conda_recipes/conda_build_linux_package/template.yaml
@@ -61,6 +61,18 @@ parameterDefinitions:
   objectType: FILE
   dataFlow: IN
   default: ""
+- name: OverrideSourceDir
+  description: |
+    If the source includes a local directory, this replaces the recipe's source directory with this directory. Use "" or leave the
+    parameter out to use the recipe's source directory.
+  userInterface:
+    control: CHOOSE_DIRECTORY
+    label: Override Source Dir
+    groupLabel: Conda Package Recipe
+  type: PATH
+  objectType: DIRECTORY
+  dataFlow: IN
+  default: ""
 - name: OverridePackageName
   description: If provided, overrides the package name in the recipe's meta.yaml file.
   type: STRING
@@ -199,6 +211,7 @@ steps:
       - BuildTool
       - OverrideSourceArchive1
       - OverrideSourceArchive2
+      - OverrideSourceDir
       - CondaPlatform
       - VariantConfigFile
 
@@ -245,6 +258,7 @@ steps:
             --override-package-name '{{Param.OverridePackageName}}' \
             --override-source-archive1 '{{Param.OverrideSourceArchive1}}' \
             --override-source-archive2 '{{Param.OverrideSourceArchive2}}' \
+            --override-source-dir '{{Param.OverrideSourceDir}}' \
             --variant-config-file '{{Param.VariantConfigFile}}'
 
   hostRequirements:

--- a/conda_recipes/submit-package-job-script.py
+++ b/conda_recipes/submit-package-job-script.py
@@ -287,6 +287,14 @@ def create_job_bundle(
                 print(f"    {platform_meta['sourceDownloadInstructions']}")
                 sys.exit(1)
 
+        source_archive_directory = platform_meta.get("sourceArchiveDirectory")
+        if source_archive_directory:
+            parameter_values[f"OverrideSourceDir_{step_name_suffix}"] = str(archive_file_dir / source_archive_directory)
+            if not (archive_file_dir / source_archive_directory).is_dir():
+                print(f"ERROR: Directory {source_archive_directory} not found in {archive_file_dir}.")
+                print(f"To submit the {recipe_dir.name} package build, you need this directory.")
+                sys.exit(1)
+
         # Rename the platform-specific parameter values
         per_step_parameters = set(platform_template["meta"]["perStepParameters"])
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

In many cases, installing After Effects plugins is as easy as copying the .aex files into the After Effects Plug-ins directory. It would be great to have a sample conda package recipe that works this way. Additionally, if you could build the package locally or use a package build queue, it would be easier to get started.

### What was the solution? (How)

* For the sample, have tried to make it as simple as possible to build the package locally or on a package build farm. You just need to copy your .aex plugin files into a specific directory, and then you can build the package locally or submit it.
* To support using a directory as input, this required modifications to the package build job and the job submission script. It now supports an override source dir in addition to the override source archive files.

### What is the impact of this change?

Customers can more easily create a conda package that bundles their Windows After Effects plugins and publish it to an S3 conda channel.

### How was this change tested?

* Built the package locally, both with conda-build and rattler-build.
* Tested the S3 conda channel update commands that the README documents.
* Submitted an After Effects job that uses a plugin with and without the package in the CondaPackages parameter. Confirmed that the render prints a warning message without it, and succeeds with it.
* Submitted a variety of different package build jobs to verify the package build job bundle and submit script work after modification.

### Was this change documented?

Wrote a README for the new sample.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*