### PR TITLE
docs: Fleet configuration script to install 3dsMax

### DIFF
--- a/fleet_configuration_scripts/3ds_max_on_smf/3ds_max_installation.ps1
+++ b/fleet_configuration_scripts/3ds_max_on_smf/3ds_max_installation.ps1
@@ -1,0 +1,19 @@
+mkdir C:\3dsmax_setup
+
+Write-Host " --- Downloading from S3 --- "
+aws s3 cp --no-progress s3://<your-bucket-name>/resources/3ds_max_full.zip C:\3dsmax_setup\3dsmax.zip
+
+Write-Host " --- Expanding Archive --- "
+Expand-Archive C:\3dsmax_setup\3dsmax.zip C:\3dsmax_setup\
+
+Write-Host " --- Starting Install --- "
+Start-Process -FilePath "C:\3dsmax_setup\<3ds Max Version>\Setup.exe" -ArgumentList "-q" -Wait -PassThru
+
+Write-Host " --- Post install setup --- "
+[Environment]::SetEnvironmentVariable("Path", "C:\Program Files\Autodesk\<3ds Max Version>;" + [Environment]::GetEnvironmentVariable("Path", "Machine"), "Machine")
+
+& "C:\Program Files\Autodesk\<3ds Max Version>\Python\python.exe" -m ensurepip
+& "C:\Program Files\Autodesk\<3ds Max Version>\Python\python.exe" -m pip install deadline-cloud-for-3ds-max
+[Environment]::SetEnvironmentVariable("3DSMAX_EXECUTABLE", "C:\Program Files\Autodesk\<3ds Max Version>\3dsmaxbatch.exe", "Machine")
+[Environment]::SetEnvironmentVariable("PYTHONPATH", "C:\Program Files\Autodesk\<3ds Max Version>\Python;C:\Program Files\Autodesk\<3ds Max Version>\Python\Scripts", "Machine")
+[Environment]::SetEnvironmentVariable("Path", "C:\Program Files\Autodesk\<3ds Max Version>\Python;C:\Program Files\Autodesk\<3ds Max Version>\Python\Scripts;" + [Environment]::GetEnvironmentVariable("Path", "Machine"), "Machine")

--- a/fleet_configuration_scripts/3ds_max_on_smf/README.md
+++ b/fleet_configuration_scripts/3ds_max_on_smf/README.md
@@ -1,0 +1,11 @@
+# Installation script for 3ds Max
+
+This script takes care of installing 3ds Max, its required depenencies, and the 3ds Max adaptor.
+It also takes care of setting up some needed environment variables.
+
+The script makes the following assumptons:
+1. A 3ds Max installation package exists in a S3 bucket within the customer account.
+1. The IAM role of the fleet using the script has permissions to download the installation package.
+
+Please note that script contains placeholders for some path values. Please make sure to override the placeholders
+before using the script.

--- a/fleet_configuration_scripts/README.md
+++ b/fleet_configuration_scripts/README.md
@@ -1,0 +1,5 @@
+# Sample fleet configuration scripts
+
+This directory contains sample scripts used to configure service-managed fleets using administrative rights.
+
+See https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/smf-admin.html.


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We want to leverage the fleet configuration feature to enable 3dsMax on SMF.

### What was the solution? (How)
Share a sample powershell script to install 3dsMax.

### What is the impact of this change?
Customers can use 3dsMax on SMF.

### How was this change tested?
N/A

### Was this change documented?
Yes

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*