### PR TITLE
refactor: Apply fix in anticipation of deadline-cloud warning update

### DIFF
--- a/conda_recipes/submit-package-job-script.py
+++ b/conda_recipes/submit-package-job-script.py
@@ -26,8 +26,9 @@ try:
     from deadline.client.job_bundle import create_job_history_bundle_dir
 except ModuleNotFoundError:
     print("ERROR: The `deadline` library is not installed. Please install it with the following command:")
-    print(f" \"{sys.executable}\" -m pip install deadline")
+    print(f' "{sys.executable}" -m pip install deadline')
     sys.exit(1)
+
 
 def validate_recipe(recipe_dir):
     """Validate the conda build recipe directory with some basic sanity checks."""
@@ -370,13 +371,17 @@ def create_job_bundle(
     }
 
     (job_bundle_dir / "template.yaml").write_text(json.dumps(job_template, indent=1, sort_keys=False))
+
+    parameter_values_list = [{"name": name, "value": value} for name, value in parameter_values.items()]
     (job_bundle_dir / "parameter_values.yaml").write_text(
         json.dumps(
-            {"parameterValues": [{"name": name, "value": value} for name, value in parameter_values.items()]},
+            {"parameterValues": parameter_values_list},
             indent=1,
             sort_keys=False,
         )
     )
+
+    return parameter_values_list
 
 
 def progress_callback(op_name):
@@ -441,7 +446,7 @@ def main():
     if default_build_tool not in ["conda-build", "rattler-build"]:
         raise RuntimeError(f"Recipe provided an unsupported build tool {default_build_tool}")
 
-    create_job_bundle(
+    job_parameters = create_job_bundle(
         default_build_tool=default_build_tool,
         job_bundle_dir=job_bundle_dir,
         recipe_dir=recipe_dir,
@@ -453,9 +458,11 @@ def main():
         conda_platforms=conda_platforms,
     )
     print(f"Wrote job bundle:\n  '{job_bundle_dir}'")
+    print()
 
     create_job_from_job_bundle(
         job_bundle_dir,
+        job_parameters=job_parameters,
         print_function_callback=print,
         hashing_progress_callback=progress_callback("Hashing"),
         upload_progress_callback=progress_callback("Uploading"),


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

In https://github.com/aws-deadline/deadline-cloud/pull/673, we are changing some behaviors of the job attachments upload warnings. One detail is that the parameter_values.yaml/json file is not treated as known paths, while the parameter values passed directly to the function call are.

### What was the solution? (How)

This change passes the parameter values to create_job_from_job_bundle, so that it will continue to submit successfully after that deadline-cloud PR is merged.

Here's an example of what a submission looks like using the deadline-cloud PR code:

```
No channel URL was provided, using a default prefix on the queue's job attachments bucket
Building packages into channel s3://<BUCKET>/Conda/Default
Creating steps for conda platforms: linux-64
Wrote job bundle:
  'C:\Users\me\.deadline\job_history\me-us-west-2\2025-05\2025-05-27-07-CondaBuild-CondaBuild'

Submitting to Queue: Package Build Queue

Job submission contains 14 input files totaling 373.7 MB. All input files will be uploaded to S3 if they are not already present in the job attachments bucket.

Locations for upload:
  C:\Users\me\.deadline\job_history\me-us-west-2\2025-05\2025-05-27-07-CondaBuild-CondaBuild\scripts\ (8 files):
    build-package.py (1 file)
    enter-package-build-env.sh (1 file)
    enter-proxy-s3-conda-channels.sh (1 file)
    exit-proxy-s3-conda-channels.sh (1 file)
    openjd-vars-capture.py (1 file)
    openjd-vars-start.py (1 file)
    ... and 2 more
  C:\Dev\deadline-cloud-samples\conda_recipes\ (6 files):
    blender-4.4\ (5 files)
    archive_files\ (1 file)

Hashing: 100.0%
Hashing Summary:
    Processed 8 files totaling 33.88 KB.
    Skipped re-processing 6 files totaling 373.66 MB.
    Total processing time of 0.06216 seconds at 545.13 KB/s.

Uploading: 100.0%
Waiting for Job to be created...
Submitted job bundle:
   C:\Users\me\.deadline\job_history\me-us-west-2\2025-05\2025-05-27-07-CondaBuild-CondaBuild
Job creation completed successfully
job-123
```

### What is the impact of this change?

Users of this package build script can update their git repo for submission to continue working when they update deadline-cloud later.

### How was this change tested?

Confirmed that job submission was failing with a message about unknown paths before the change, then confirmed that it submits successfully after the change.

### Was this change documented?

No.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*