### PR TITLE
chore: Update Blender conda recipes to latest

### DIFF
--- a/conda_recipes/blender-4.2/deadline-cloud.yaml
+++ b/conda_recipes/blender-4.2/deadline-cloud.yaml
@@ -1,11 +1,11 @@
 condaPlatforms:
   - platform: linux-64
     defaultSubmit: true
-    sourceArchiveFilename: blender-4.2.8-linux-x64.tar.xz
-    sourceDownloadInstructions: 'Run "curl -LO https://download.blender.org/release/Blender4.2/blender-4.2.8-linux-x64.tar.xz --output-dir archive_files"'
+    sourceArchiveFilename: blender-4.2.9-linux-x64.tar.xz
+    sourceDownloadInstructions: 'Run "curl -LO https://download.blender.org/release/Blender4.2/blender-4.2.9-linux-x64.tar.xz --output-dir archive_files"'
     buildTool: rattler-build
   - platform: win-64
     defaultSubmit: false
-    sourceArchiveFilename: blender-4.2.8-windows-x64.zip
-    sourceDownloadInstructions: 'Run "curl -LO https://download.blender.org/release/Blender4.2/blender-4.2.8-windows-x64.zip --output-dir archive_files"'
+    sourceArchiveFilename: blender-4.2.9-windows-x64.zip
+    sourceDownloadInstructions: 'Run "curl -LO https://download.blender.org/release/Blender4.2/blender-4.2.9-windows-x64.zip --output-dir archive_files"'
     buildTool: conda-build

--- a/conda_recipes/blender-4.2/recipe/meta.yaml
+++ b/conda_recipes/blender-4.2/recipe/meta.yaml
@@ -1,7 +1,7 @@
 # Recipe in conda-build format.
 # This recipe is only for Windows, see recipe.yaml for the Linux recipe in rattler-build format.
 
-{% set version = "4.2.8" %}
+{% set version = "4.2.9" %}
 {% set major_minor_version = ".".join(version.split(".")[:2]) %}
 
 package:
@@ -10,7 +10,7 @@ package:
 
 source:
   url: https://download.blender.org/release/Blender{{major_minor_version}}/blender-{{version}}-windows-x64.zip # [win64]
-  sha256: 01b3b6e5791d02e6fc1dede624fed1784ff4716301e419817d5fc4f768c384ea # [win64]
+  sha256: 223cd22afc5cab3f8cb43006574f1c962ff9bb9e07418c3f4f2542b7c34899cb # [win64]
   folder: blender
 
 build:

--- a/conda_recipes/blender-4.2/recipe/recipe.yaml
+++ b/conda_recipes/blender-4.2/recipe/recipe.yaml
@@ -2,7 +2,7 @@
 # See https://prefix-dev.github.io/rattler-build/latest/
 
 context:
-  version: "4.2.8"
+  version: "4.2.9"
   major_minor_version: "4.2"
 
 package:
@@ -13,12 +13,12 @@ source:
   - if: linux
     then:
       url: https://download.blender.org/release/Blender${{ major_minor_version }}/blender-${{ version }}-linux-x64.tar.xz
-      sha256: 238812c5be9ac53e69c833eaf8b6d78990a6d6b1e50a5300db20782581015167
+      sha256: dfbc127a7d28f9c2175b23bf9d6701b2855f31eedfb391f9a6e60adb24572846
       target_directory: blender
   - if: win
     then:
       url: https://download.blender.org/release/Blender${{ major_minor_version }}/blender-${{ version }}-windows-x64.zip
-      sha256: 01b3b6e5791d02e6fc1dede624fed1784ff4716301e419817d5fc4f768c384ea
+      sha256: 223cd22afc5cab3f8cb43006574f1c962ff9bb9e07418c3f4f2542b7c34899cb
       target_directory: blender
 
 build:

--- a/conda_recipes/blender-4.4/deadline-cloud.yaml
+++ b/conda_recipes/blender-4.4/deadline-cloud.yaml
@@ -1,11 +1,11 @@
 condaPlatforms:
   - platform: linux-64
     defaultSubmit: true
-    sourceArchiveFilename: blender-4.4.0-linux-x64.tar.xz
-    sourceDownloadInstructions: 'Run "curl -LO https://download.blender.org/release/Blender4.4/blender-4.4.0-linux-x64.tar.xz --output-dir archive_files"'
+    sourceArchiveFilename: blender-4.4.3-linux-x64.tar.xz
+    sourceDownloadInstructions: 'Run "curl -LO https://download.blender.org/release/Blender4.4/blender-4.4.3-linux-x64.tar.xz --output-dir archive_files"'
     buildTool: rattler-build
   - platform: win-64
     defaultSubmit: false
-    sourceArchiveFilename: blender-4.4.0-windows-x64.zip
-    sourceDownloadInstructions: 'Run "curl -LO https://download.blender.org/release/Blender4.4/blender-4.4.0-windows-x64.zip --output-dir archive_files"'
+    sourceArchiveFilename: blender-4.4.3-windows-x64.zip
+    sourceDownloadInstructions: 'Run "curl -LO https://download.blender.org/release/Blender4.4/blender-4.4.3-windows-x64.zip --output-dir archive_files"'
     buildTool: conda-build

--- a/conda_recipes/blender-4.4/recipe/meta.yaml
+++ b/conda_recipes/blender-4.4/recipe/meta.yaml
@@ -1,7 +1,7 @@
 # Recipe in conda-build format.
 # This recipe is only for Windows, see recipe.yaml for the Linux recipe in rattler-build format.
 
-{% set version = "4.4.0" %}
+{% set version = "4.4.3" %}
 {% set major_minor_version = ".".join(version.split(".")[:2]) %}
 
 package:
@@ -10,7 +10,7 @@ package:
 
 source:
   url: https://download.blender.org/release/Blender{{major_minor_version}}/blender-{{version}}-windows-x64.zip # [win64]
-  sha256: 1a603c06d67ef5ae4fae2e5991742a183af525e2f4162e0e5a8c5d010ba0119e # [win64]
+  sha256: 60a9703b07f2cf42509f699ccdec4f5ede71c1932f6c14329f0e14c023e27d5c # [win64]
   folder: blender
 
 build:

--- a/conda_recipes/blender-4.4/recipe/recipe.yaml
+++ b/conda_recipes/blender-4.4/recipe/recipe.yaml
@@ -2,7 +2,7 @@
 # See https://prefix-dev.github.io/rattler-build/latest/
 
 context:
-  version: "4.4.0"
+  version: "4.4.3"
   major_minor_version: "4.4"
 
 package:
@@ -13,12 +13,12 @@ source:
   - if: linux
     then:
       url: https://download.blender.org/release/Blender${{ major_minor_version }}/blender-${{ version }}-linux-x64.tar.xz
-      sha256: b4a74463677618d09621332ddbd62baa1a3ed06a11818714f6c5f1c7f31a15c6
+      sha256: 8d3be07d2bc412b502c6bfe3cfe3e22195a4164076867da987ce148d73c27946
       target_directory: blender
   - if: win
     then:
       url: https://download.blender.org/release/Blender${{ major_minor_version }}/blender-${{ version }}-windows-x64.zip
-      sha256: 1a603c06d67ef5ae4fae2e5991742a183af525e2f4162e0e5a8c5d010ba0119e
+      sha256: 60a9703b07f2cf42509f699ccdec4f5ede71c1932f6c14329f0e14c023e27d5c
       target_directory: blender
 
 build:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The Blender conda recipe samples for Blender 4.2 and Blender 4.4 are out of date.

### What was the solution? (How)

* Update from 4.2.8 to 4.2.9
* Update from 4.4.0 to 4.4.3

### What is the impact of this change?

Using the conda samples gets the latest updates of Blender.

### How was this change tested?

Built the package on Windows & Linux for 4.2 and 4.4. Ran a blender_render job for all 4 combinations, confirmed the output.

### Was this change documented?

No

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*