### PR TITLE
feat: Add Redshift 2025.4 for Maya Conda recipe

### DIFF
--- a/conda_recipes/maya-redshift-2025/README.md
+++ b/conda_recipes/maya-redshift-2025/README.md
@@ -1,0 +1,12 @@
+# Redshift for Maya conda build recipe
+
+## Download the installer file for Linux
+
+Download the redshift_2025.4.2_1782753868_linux_x64.run installer, or suitable alternate version from Maxon, and
+place it in the `conda_recipes/archive_files` directory in your git clone of the
+[https://github.com/aws-deadline/deadline-cloud-samples](deadline-cloud-samples) repository for
+submitting package build jobs.
+
+Please note that if the installer version used differs from "redshift_2025.4.2_1782753868_linux_x64.run", version
+and filename updates will need to be made to deadline-cloud.yaml and recipe/recipe.yaml
+

--- a/conda_recipes/maya-redshift-2025/deadline-cloud.yaml
+++ b/conda_recipes/maya-redshift-2025/deadline-cloud.yaml
@@ -1,0 +1,7 @@
+condaPlatforms:
+  - platform: linux-64
+    defaultSubmit: true
+    sourceArchiveFilename:
+    - redshift_2025.4.2_1782753868_linux_x64.run
+    sourceDownloadInstructions: 'Download the redshift_2025.4.2_1782753868_linux_x64.run file.'
+    buildTool: rattler-build

--- a/conda_recipes/maya-redshift-2025/recipe/build.sh
+++ b/conda_recipes/maya-redshift-2025/recipe/build.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+
+# Echo all the commands so debugging from log output is simpler
+set -x
+# Fail the script if any commands it runs fail
+set -euo pipefail
+
+# The version without the update number
+REDSHIFT_VERSION=${PKG_VERSION%.*}
+
+# Redshift supports the following maya versions 
+MAYA_VERSIONS="2022 2023 2024 2025 2026"
+
+INSTALLER_DIR="$SRC_DIR/installer"
+REDSHIFT_UNPACK_DIR="$INSTALLER_DIR/redshift_installer_artifacts"
+REDSHIFT_ROOT="usr/maxon/redshift_${REDSHIFT_VERSION}"
+
+# Extract the run file into its accompanying tarball and setup script
+chmod u+x "$INSTALLER_DIR"/redshift_"${REDSHIFT_VERSION}"*_linux_x64.run
+"$INSTALLER_DIR"/redshift_${REDSHIFT_VERSION}*_linux_x64.run --target "$REDSHIFT_UNPACK_DIR" --noexec
+
+# Skip superuser check by modifying the setup script in-place
+sed -i 's/\[ "$(id -u)" != "0" \]/false/' "$REDSHIFT_UNPACK_DIR/setup.sh"
+
+# Run the setup script
+cd "$REDSHIFT_UNPACK_DIR"
+./setup.sh --installpath "${PREFIX}/${REDSHIFT_ROOT}"
+
+# clear the installer artifacts
+rm setup.sh
+rm package.tar.gz
+
+# clean up unneeded DCC artifacts
+rm -r "${PREFIX}/${REDSHIFT_ROOT}"/redshift4blender
+rm -r "${PREFIX}/${REDSHIFT_ROOT}"/redshift4c4d
+rm -r "${PREFIX}/${REDSHIFT_ROOT}"/redshift4houdini
+rm -r "${PREFIX}/${REDSHIFT_ROOT}"/redshift4katana
+rm -r "${PREFIX}/${REDSHIFT_ROOT}"/redshift4solaris
+
+# Create the redshift4maya.mod file for multiple Maya versions
+#
+# The maya package has set the Maya module path to include virtual environment-equivalents of
+# the system module paths, so this is the usual installation location after the virtual environment
+# prefix.
+
+for MAYA_VERSION in $MAYA_VERSIONS; do
+  # Generate the .mod file for this specific version
+  mkdir -p "$PREFIX/usr/autodesk/modules/maya/$MAYA_VERSION"
+  cat <<EOF > "$PREFIX/usr/autodesk/modules/maya/$MAYA_VERSION/redshift4maya.mod"
++ redshift4maya any $PREFIX/$REDSHIFT_ROOT/redshift4maya
+scripts: common/scripts
+icons: common/icons
+plug-ins: $MAYA_VERSION
+REDSHIFT_COREDATAPATH = $PREFIX/$REDSHIFT_ROOT
+MAYA_CUSTOM_TEMPLATE_PATH +:= common/scripts/NETemplates
+MAYA_RENDER_DESC_PATH +:=  common/rendererDesc
+REDSHIFT_MAYAEXTENSIONSPATH +:= $MAYA_VERSION/extensions
+REDSHIFT_PROCEDURALSPATH += "\$REDSHIFT_COREDATAPATH/procedurals/usd/USD_24.08"
+REDSHIFT_PROCEDURALSPATH += "\$REDSHIFT_COREDATAPATH/procedurals/alembic"
+EOF
+
+done
+

--- a/conda_recipes/maya-redshift-2025/recipe/recipe.yaml
+++ b/conda_recipes/maya-redshift-2025/recipe/recipe.yaml
@@ -1,0 +1,36 @@
+# Recipe in rattler-build format.
+# See https://prefix-dev.github.io/rattler-build/latest/
+
+context:
+  version: "2025.4.2_1782753868"
+
+package:
+  name: maya-redshift
+  version: ${{ version }}
+
+source:
+  - url: file://archive_files/redshift_${{ version }}_linux_x64.run
+    sha256: 5ff7a02e7f94ce805cb219727e077a9e0bbe8550f8fce77f5e1f033061d6528a
+    target_directory: installer
+
+build:
+  number: 0
+  # These build options for repackaging an application
+  # https://prefix-dev.github.io/rattler-build/latest/build_options/#prefix-detection-replacement-options
+  prefix_detection:
+    ignore_binary_files: True
+  # https://prefix-dev.github.io/rattler-build/latest/build_options/#dynamic-linking-configuration
+  dynamic_linking:
+    binary_relocation: False
+    missing_dso_allowlist:
+    - "**"
+
+requirements:
+  run:
+    - maya >=2025, <2026
+
+
+about:
+  homepage: https://www.maxon.net/en/redshift
+  license: LicenseRef-MaxonEULA
+  summary: Redshift is a powerful 3D rendering software that helps visualize your 3D designs, models, animations, and scenes.


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
* There isn't a prior example of a conda recipe that can help install redshift for maya in this samples repository

### What was the solution? (How)
* Add this sample

### What is the impact of this change?
* This sample can be used to build the `maya-redshift` conda package in custom conda channels

### How was this change tested?
Test build with ./submit-package-job
```
./submit-package-job maya-redshift-2025 --queue 'Package Build Queue' -p linux-64
```

Used this conda package in a redshift for maya render.


### Was this change documented?

- Recipe directory contains a README.md

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*