### PR TITLE
chore: Updating the cinema4d-openjd conda recipe package version to t…

### DIFF
--- a/conda_recipes/cinema4d-openjd/recipe/meta.yaml
+++ b/conda_recipes/cinema4d-openjd/recipe/meta.yaml
@@ -4,7 +4,7 @@
 # https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/conda_recipes
 
 {% set name = "cinema4d-openjd" %}
-{% set version = "0.7.3" %}
+{% set version = "0.7.8" %}
 
 package:
   name: {{ name }}
@@ -12,7 +12,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/d/deadline-cloud-for-cinema-4d/deadline_cloud_for_cinema_4d-{{ version }}.tar.gz
-  sha256: 0aec84bc57a542393534fb5f76cab5051da49a5827ba97954f76d7b300601163
+  sha256: 0ec30804cce941f0a4a819086206121dbbd16633bf5567249d29a89685974023
   patches:
     - 0001-Remove-version-hook.patch
 

--- a/conda_recipes/cinema4d-openjd/recipe/recipe.yaml
+++ b/conda_recipes/cinema4d-openjd/recipe/recipe.yaml
@@ -6,7 +6,7 @@
 # https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/conda_recipes
 
 context:
-  version: "0.7.3"
+  version: "0.7.8"
 
 package:
   name: cinema4d-openjd
@@ -15,7 +15,7 @@ package:
 # This source reference uses the source archive published to PyPI
 source:
   url: https://pypi.io/packages/source/d/deadline-cloud-for-cinema-4d/deadline_cloud_for_cinema_4d-${{ version }}.tar.gz
-  sha256: 0aec84bc57a542393534fb5f76cab5051da49a5827ba97954f76d7b300601163
+  sha256: 0ec30804cce941f0a4a819086206121dbbd16633bf5567249d29a89685974023
   patches:
     - 0001-Remove-version-hook.patch
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The conda recipe for cinema4d-openjd did not have the latest package version.

### What was the solution? (How)
Update the version from 0.7.3 to 0.7.8.
Update the file hash (sha256).

### What is the impact of this change?
Customers will be able to get the latest changes for the conda recipe.

### How was this change tested?
Ran `python .\submit-package-job-script.py .\cinema4d-openjd\` and the job succeeded.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*