### PR TITLE
feat: Add VTK sample

### DIFF
--- a/job_bundles/vtk-latest/README.md
+++ b/job_bundles/vtk-latest/README.md
@@ -1,0 +1,62 @@
+# VTK Visualization Job Template
+
+This OpenJD job template allows users to run VTK (Visualization Toolkit) Python scripts using AWS Deadline Cloud.
+
+## Overview
+
+This job template is designed to be generalizable for any VTK-based Python script that:
+1. Accepts command-line parameters for output path, width, and height
+2. Saves visualization output to a specified location
+
+The template accepts a user-provided Python script, runs it with the specified parameters, and saves the visualization output to the designated location.
+
+## Parameters
+
+### Input Parameters
+- **InputDir**: Directory containing the VTK script and any additional required files
+- **InputScript**: Name of the Python script to run (must be in the input directory)
+
+### Output Parameters
+- **OutputDir**: Directory where the visualization output will be saved
+- **OutputFilename**: Name of the output image file
+
+### Render Parameters
+- **Width**: Width of the output image in pixels (default: "1280")
+- **Height**: Height of the output image in pixels (default: "720")
+
+### Software Parameters
+- **CondaPackages**: Conda packages to install (default: "vtk numpy"). These packages must be available in the Conda Channels configured in the queue environment
+
+### Additional Parameters
+- **ExtraParams**: Additional parameters to pass to the script (format: '--param1 value1 --param2 value2')
+
+## Usage
+
+1. Prepare a VTK Python script that includes command-line arguments for:
+   - `--output`: Output file path
+   - `--width`: Image width
+   - `--height`: Image height
+
+2. Submit the job with:
+   - **InputDir**: Directory containing your VTK script
+   - **InputScript**: Filename of your script
+   - **OutputDir**: Where to save the visualization
+   - **OutputFilename**: Name for the output file
+   - Any other parameters your script requires via ExtraParams
+
+## Script Requirements
+
+Your VTK script should:
+1. Accept the parameters `--output`, `--width`, and `--height`
+2. Save output to the location specified by `--output`
+3. Use VTK for visualization
+
+## Sample Script
+
+A sample VTK script (`flow_simulation_visualization.py`) is provided in the `sample` directory that demonstrates:
+- Creating a 3D airfoil geometry
+- Generating a flow field
+- Calculating pressure distribution
+- Visualizing the simulation with streamlines
+- Saving the output as an image file
+This script is sourced from [here](https://github.com/djeada/Vtk-Examples/blob/main/src/02_advanced_shapes/flow_simulation_visualization.py#L4) and is licensed under the MIT license.

--- a/job_bundles/vtk-latest/sample/flow_simulation_visualization.py
+++ b/job_bundles/vtk-latest/sample/flow_simulation_visualization.py
@@ -1,0 +1,287 @@
+import numpy as np
+import vtk
+import argparse
+import os
+from vtkmodules.util.numpy_support import numpy_to_vtk, vtk_to_numpy
+
+
+def create_airfoil_geometry():
+    """
+    Create a basic airfoil geometry using an elliptical cross-section.
+
+    Returns:
+        vtk.vtkPolyData: The airfoil geometry as a VTK PolyData object.
+    """
+    # Parameters for the ellipse (airfoil cross-section)
+    radius_x, radius_y = 1.0, 0.2  # Major and minor radii of the ellipse
+    num_points = 100  # Number of points to define the ellipse
+
+    # Create points for an ellipse
+    ellipse_points = vtk.vtkPoints()
+    for i in range(num_points):
+        angle = 2.0 * np.pi * i / num_points
+        x = radius_x * np.cos(angle)
+        y = radius_y * np.sin(angle)
+        ellipse_points.InsertNextPoint(x, y, 0)
+
+    # Create a polygon that represents the ellipse
+    polygon = vtk.vtkPolygon()
+    polygon.GetPointIds().SetNumberOfIds(num_points)
+    for i in range(num_points):
+        polygon.GetPointIds().SetId(i, i)
+
+    # Create a PolyData object
+    polydata = vtk.vtkPolyData()
+    polydata.SetPoints(ellipse_points)
+
+    # Create a cell array to store the polygon
+    cells = vtk.vtkCellArray()
+    cells.InsertNextCell(polygon)
+    polydata.SetPolys(cells)
+
+    # Extrude the polygon to create a 3D airfoil shape
+    extrude = vtk.vtkLinearExtrusionFilter()
+    extrude.SetInputData(polydata)
+    extrude.SetExtrusionTypeToNormalExtrusion()
+    extrude.SetVector(0.0, 0.0, 1.0)
+    extrude.SetScaleFactor(5.0)  # Length of the airfoil
+
+    # Convert the extruded shape to PolyData
+    extrude.Update()
+    airfoil_geometry = extrude.GetOutput()
+
+    return airfoil_geometry
+
+
+def generate_flow_field(airfoil_geometry):
+    """
+    Generate a vector field representing airflow around the airfoil.
+
+    Args:
+        airfoil_geometry (vtk.vtkPolyData): The airfoil geometry.
+
+    Returns:
+        vtk.vtkStructuredGrid: A structured grid representing the vector field.
+    """
+    # Define the bounds and resolution of the flow field
+    bounds = airfoil_geometry.GetBounds()
+    grid_resolution = 20  # Adjust for finer or coarser grid
+
+    # Create a mesh grid for vector field
+    x = np.linspace(bounds[0] - 1, bounds[1] + 1, grid_resolution)
+    y = np.linspace(bounds[2] - 1, bounds[3] + 1, grid_resolution)
+    z = np.linspace(bounds[4] - 1, bounds[5] + 1, grid_resolution)
+    x, y, z = np.meshgrid(x, y, z, indexing="ij")
+
+    # Initialize the vector field (flow primarily along x-axis)
+    flow_vectors = np.zeros((grid_resolution, grid_resolution, grid_resolution, 3))
+    flow_vectors[..., 0] = (
+        1  # Setting x-component of vectors to simulate horizontal flow
+    )
+
+    # This is a simple approximation and can be improved for more realistic simulations
+    for i in range(grid_resolution):
+        for j in range(grid_resolution):
+            for k in range(grid_resolution):
+                # Check if the point is close to the airfoil and modify the flow vector accordingly
+                if (
+                    np.sqrt((x[i, j, k] - 0) ** 2 + (y[i, j, k] - 0) ** 2) < 1.0
+                ):  # Example condition
+                    flow_vectors[i, j, k, 1] += 0.5  # Modify y-component as an example
+
+    # Convert numpy array to VTK structured grid
+    vectors_flat = flow_vectors.ravel()
+    vtk_vectors = numpy_to_vtk(vectors_flat, deep=True, array_type=vtk.VTK_FLOAT)
+    vtk_vectors.SetNumberOfComponents(3)
+
+    structured_grid = vtk.vtkStructuredGrid()
+    structured_grid.SetDimensions(grid_resolution, grid_resolution, grid_resolution)
+
+    points = vtk.vtkPoints()
+    for i in range(grid_resolution):
+        for j in range(grid_resolution):
+            for k in range(grid_resolution):
+                points.InsertNextPoint(x[i, j, k], y[i, j, k], z[i, j, k])
+
+    structured_grid.SetPoints(points)
+    structured_grid.GetPointData().SetVectors(vtk_vectors)
+
+    return structured_grid
+
+
+def calculate_pressure_distribution(airfoil_geometry, flow_field):
+    """
+    Approximate the pressure distribution on the airfoil based on the flow field.
+
+    Args:
+        airfoil_geometry (vtk.vtkPolyData): The airfoil geometry.
+        flow_field (vtk.vtkStructuredGrid): The flow field around the airfoil.
+
+    Returns:
+        np.ndarray: An array representing the pressure distribution on the airfoil's surface.
+    """
+    # Assume air density (rho) in kg/m^3 (1.225 kg/m^3 at sea level, 15 degrees Celsius)
+    rho = 1.225
+    # Assume free stream speed (V_inf) in m/s
+    V_inf = 1.0
+    # Assume free stream pressure (P_inf) in Pascals
+    P_inf = 101325  # Standard atmospheric pressure at sea level
+
+    # Extract the flow vectors from the flow field
+    vtk_vectors = flow_field.GetPointData().GetVectors()
+    vectors = vtk_to_numpy(vtk_vectors)
+
+    # Calculate the speed at each point in the flow field
+    speeds = np.linalg.norm(vectors, axis=1)
+
+    # Calculate pressure at each point using Bernoulli's equation
+    # P = P_inf - 0.5 * rho * (V^2 - V_inf^2)
+    pressures = P_inf - 0.5 * rho * (speeds**2 - V_inf**2)
+
+    # Ensure no negative pressures (optional, depending on your application)
+    pressures = np.maximum(pressures, 0)
+
+    # Pressure distribution along the airfoil surface
+    # For a more accurate pressure distribution, you would project the pressures onto the airfoil surface
+    # This may involve finding the nearest points on the airfoil to the flow field points and interpolating the pressures
+
+    # Here we provide a simplified mapping assuming the pressures array aligns with the airfoil geometry points
+    # In a real CFD application, you would perform an interpolation based on the airfoil's surface projection
+
+    return pressures
+
+
+def visualize_simulation(airfoil_geometry, flow_field, pressure_distribution, output_path=None, width=800, height=600):
+    """
+    Use VTK to visualize the airfoil, the flow field, and the pressure distribution.
+
+    Args:
+        airfoil_geometry (vtk.vtkPolyData): The airfoil geometry.
+        flow_field (vtk.vtkStructuredGrid): The flow field around the airfoil.
+        pressure_distribution (np.ndarray): The pressure distribution on the airfoil's surface.
+        output_path (str, optional): Path to save the visualization image. If None, display interactively.
+        width (int): Width of the output image in pixels.
+        height (int): Height of the output image in pixels.
+    """
+    # Create a mapper and actor for the airfoil
+    airfoil_mapper = vtk.vtkPolyDataMapper()
+    airfoil_mapper.SetInputData(airfoil_geometry)
+
+    airfoil_actor = vtk.vtkActor()
+    airfoil_actor.SetMapper(airfoil_mapper)
+
+    # Apply a color map to the airfoil based on the pressure distribution
+    pressure_colors = vtk.vtkFloatArray()
+    pressure_colors.SetName("Pressure")
+    for pressure in pressure_distribution:
+        pressure_colors.InsertNextValue(pressure)
+    airfoil_geometry.GetPointData().SetScalars(pressure_colors)
+    airfoil_mapper.SetScalarRange(
+        np.min(pressure_distribution), np.max(pressure_distribution)
+    )
+
+    # Increase the number of seed points and adjust their placement
+    seeds = vtk.vtkPointSource()
+    seeds.SetNumberOfPoints(100)  # Increase the number of seed points
+    seeds.SetRadius(5)  # Adjust the radius as needed
+    seeds.SetCenter(0, 0, 0)  # Place the seed points in an area with significant flow
+
+    # Streamline tracer setup with adjusted parameters
+    streamer = vtk.vtkStreamTracer()
+    streamer.SetInputData(flow_field)
+    streamer.SetSourceConnection(seeds.GetOutputPort())
+    streamer.SetMaximumPropagation(200)  # Increase the propagation length
+    streamer.SetIntegrationStepUnit(vtk.vtkStreamTracer.LENGTH_UNIT)
+    streamer.SetInitialIntegrationStep(0.1)
+    streamer.SetIntegrationDirectionToBoth()
+    streamer.SetComputeVorticity(False)
+
+    # Streamline visualization
+    mapper = vtk.vtkPolyDataMapper()
+    mapper.SetInputConnection(streamer.GetOutputPort())
+
+    streamline_actor = vtk.vtkActor()
+    streamline_actor.SetMapper(mapper)
+    streamline_actor.GetProperty().SetColor(1, 0, 0)  # Set a visible color
+
+    # Renderer and Render Window setup
+    renderer = vtk.vtkRenderer()
+    render_window = vtk.vtkRenderWindow()
+    render_window.AddRenderer(renderer)
+    
+    # Set window size
+    render_window.SetSize(width, height)
+    
+    # Add actors to the renderer
+    renderer.AddActor(airfoil_actor)
+    renderer.AddActor(streamline_actor)  # Add streamline actor
+
+    # Set background color and reset camera
+    renderer.SetBackground(0.1, 0.2, 0.3)
+    renderer.ResetCamera()
+
+    # If output path is provided, save to file
+    if output_path:
+        render_window.SetOffScreenRendering(1)
+        render_window.Render()
+        
+        # Create a window to image filter
+        window_to_image_filter = vtk.vtkWindowToImageFilter()
+        window_to_image_filter.SetInput(render_window)
+        window_to_image_filter.SetInputBufferTypeToRGBA()
+        window_to_image_filter.ReadFrontBufferOff()
+        window_to_image_filter.Update()
+
+        # Create an image writer
+        writer = None
+        extension = os.path.splitext(output_path)[1].lower()
+        
+        if extension == '.jpg' or extension == '.jpeg':
+            writer = vtk.vtkJPEGWriter()
+        elif extension == '.png':
+            writer = vtk.vtkPNGWriter()
+        elif extension == '.tif' or extension == '.tiff':
+            writer = vtk.vtkTIFFWriter()
+        else:
+            # Default to JPG if extension is not recognized
+            writer = vtk.vtkJPEGWriter()
+            
+        if writer:
+            writer.SetFileName(output_path)
+            writer.SetInputConnection(window_to_image_filter.GetOutputPort())
+            writer.Write()
+            print(f"Visualization saved to {output_path}")
+    else:
+        # Interactive mode
+        interactor = vtk.vtkRenderWindowInteractor()
+        interactor.SetRenderWindow(render_window)
+        render_window.Render()
+        interactor.Start()
+
+
+def main():
+    parser = argparse.ArgumentParser(description='VTK Flow Simulation Visualization')
+    parser.add_argument('--output', type=str, help='Output file path for the visualization')
+    parser.add_argument('--width', type=int, default=800, help='Width of the output image')
+    parser.add_argument('--height', type=int, default=600, help='Height of the output image')
+    
+    args = parser.parse_args()
+    
+    airfoil_geometry = create_airfoil_geometry()
+    flow_field = generate_flow_field(airfoil_geometry)
+    pressure_distribution = calculate_pressure_distribution(
+        airfoil_geometry, flow_field
+    )
+    
+    visualize_simulation(
+        airfoil_geometry, 
+        flow_field, 
+        pressure_distribution,
+        output_path=args.output,
+        width=args.width,
+        height=args.height
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/job_bundles/vtk-latest/template.yaml
+++ b/job_bundles/vtk-latest/template.yaml
@@ -1,0 +1,142 @@
+specificationVersion: 'jobtemplate-2023-09'
+name: VTK Visualization
+
+parameterDefinitions:
+
+# Input Parameters
+- name: InputDir
+  type: PATH
+  objectType: DIRECTORY
+  dataFlow: IN
+  userInterface:
+    control: CHOOSE_DIRECTORY
+    label: Input Directory
+    groupLabel: Input Parameters
+  default: "./sample"
+  description: >
+    Directory containing the VTK script and any additional required files.
+
+- name: InputScript
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Input Script Filename
+    groupLabel: Input Parameters
+  default: "flow_simulation_visualization.py"
+  description: >
+    Name of the Python script to run (must be in the input directory).
+
+# Output Parameters
+- name: OutputDir
+  type: PATH
+  objectType: DIRECTORY
+  dataFlow: OUT
+  userInterface:
+    control: CHOOSE_DIRECTORY
+    label: Output Directory
+    groupLabel: Output Parameters
+  default: "./output"
+  description: >
+    Directory where the visualization output will be saved.
+
+- name: OutputFilename
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Output Filename
+    groupLabel: Output Parameters
+  default: "visualization.jpg"
+  description: >
+    Name of the output image file.
+
+# Render Parameters
+- name: Width
+  type: INT
+  userInterface:
+    control: SPIN_BOX
+    label: Image Width (pixels)
+    groupLabel: Render Parameters
+  default: 1280
+  description: >
+    Width of the output image in pixels.
+
+- name: Height
+  type: INT
+  userInterface:
+    control: SPIN_BOX
+    label: Image Height (pixels)
+    groupLabel: Render Parameters
+  default: 720
+  description: >
+    Height of the output image in pixels.
+
+# Software Parameters
+- name: CondaPackages
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Conda Packages
+    groupLabel: Software Parameters
+  default: "vtk numpy"
+  description: >
+    Conda packages to install for the environment. Add any additional packages your script requires.
+    These packages must be available in a channel made available by a Queue Environment. vtk and numpy are available in CondaForge
+
+# Additional Script Parameters
+- name: ExtraParams
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Additional Parameters
+    groupLabel: Script Parameters
+  default: ""
+  description: >
+    Additional parameters to pass to the script (in format: '--param1 value1 --param2 value2').
+
+steps:
+- name: RenderVTKVisualization
+  script:
+    actions:
+      onRun:
+        command: bash
+        args: ['{{Task.File.Run}}']
+    embeddedFiles:
+      - name: Run
+        type: TEXT
+        data: |
+          #!/bin/bash
+          set -xeuo pipefail
+          
+          # Display environment information
+          echo "Current directory: $(pwd)"
+          echo "Listing input directory content:"
+          ls -la "{{Param.InputDir}}"
+          
+          # Make sure output directory exists
+          mkdir -p "{{Param.OutputDir}}"
+          
+          # Check if the input script exists
+          if [ ! -f "{{Param.InputDir}}/{{Param.InputScript}}" ]; then
+            echo "ERROR: Script {{Param.InputScript}} not found in the input directory!"
+            exit 1
+          fi
+          
+          # Run the VTK visualization script
+          echo "Running VTK visualization script: {{Param.InputScript}}"
+          
+          python "{{Param.InputDir}}/{{Param.InputScript}}" \
+            --output "{{Param.OutputDir}}/{{Param.OutputFilename}}" \
+            --width {{Param.Width}} \
+            --height {{Param.Height}} \
+            {{Param.ExtraParams}}
+          
+          echo "Visualization complete. Results saved to {{Param.OutputDir}}/{{Param.OutputFilename}}"
+          ls -la "{{Param.OutputDir}}"
+          
+          # Check if the output file was created
+          if [ ! -f "{{Param.OutputDir}}/{{Param.OutputFilename}}" ]; then
+            echo "WARNING: Output file {{Param.OutputFilename}} was not found in the output directory!"
+            echo "This might be expected if your script saves output with a different name or format."
+          else
+            echo "Output file successfully created: {{Param.OutputDir}}/{{Param.OutputFilename}}"
+          fi


### PR DESCRIPTION
Fixes: N/A

### What was the problem/requirement? (What/Why)
The Visualization Toolkit (VTK) is open source software for manipulating and displaying scientific data. It comes with state-of-the-art tools for 3D rendering, a suite of widgets for 3D interaction, and extensive 2D plotting capability.

Adding a sample of software like this expands the usefulness of our samples repo

### What was the solution? (How)
Included is a sample job template that installs VTK and numpy from Conda Forge, runs a script that outputs a jpeg file.

### What is the impact of this change?
Users wanting to render VTK imagery using Deadline Cloud have an example to use

### How was this change tested?

I submitted this sample with no arguments to my personal farm with the default conda queue environment and received the expected output.

![flow_visualization](https://github.com/user-attachments/assets/87d8275d-70aa-4c94-8a81-915a2a19836d)

### Was this change documented?

The sample includes a README
---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
yes, the provided sample comes from the vtk samples repo which is MIT licensed