### PR TITLE
feat: update maya-openjd and cinama4d-openjd and remove patches since sdist fix is released

### DIFF
--- a/conda_recipes/cinema4d-openjd/recipe/meta.yaml
+++ b/conda_recipes/cinema4d-openjd/recipe/meta.yaml
@@ -4,7 +4,7 @@
 # https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/conda_recipes
 
 {% set name = "cinema4d-openjd" %}
-{% set version = "0.7.8" %}
+{% set version = "0.7.10" %}
 
 package:
   name: {{ name }}
@@ -12,9 +12,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/d/deadline-cloud-for-cinema-4d/deadline_cloud_for_cinema_4d-{{ version }}.tar.gz
-  sha256: 0ec30804cce941f0a4a819086206121dbbd16633bf5567249d29a89685974023
-  patches:
-    - 0001-Remove-version-hook.patch
+  sha256: 8382f7772550a5330bc5c41d4cd657569f03d0fb7e9fcafce996c9c9195f9980
 
 # Here's an alternative source definition to build a package from a development branch on github. Replace
 # the username and git branch as appropriate for your case.

--- a/conda_recipes/cinema4d-openjd/recipe/recipe.yaml
+++ b/conda_recipes/cinema4d-openjd/recipe/recipe.yaml
@@ -6,7 +6,7 @@
 # https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/conda_recipes
 
 context:
-  version: "0.7.8"
+  version: "0.7.10"
 
 package:
   name: cinema4d-openjd
@@ -15,9 +15,7 @@ package:
 # This source reference uses the source archive published to PyPI
 source:
   url: https://pypi.io/packages/source/d/deadline-cloud-for-cinema-4d/deadline_cloud_for_cinema_4d-${{ version }}.tar.gz
-  sha256: 0ec30804cce941f0a4a819086206121dbbd16633bf5567249d29a89685974023
-  patches:
-    - 0001-Remove-version-hook.patch
+  sha256: 8382f7772550a5330bc5c41d4cd657569f03d0fb7e9fcafce996c9c9195f9980
 
 build:
   number: 0

--- a/conda_recipes/maya-openjd/recipe/meta.yaml
+++ b/conda_recipes/maya-openjd/recipe/meta.yaml
@@ -2,7 +2,7 @@
 # See recipe.yaml for the recipe in rattler-build format.
 
 {% set name = "maya-openjd" %}
-{% set version = "0.14.4" %}
+{% set version = "0.15.7" %}
 
 package:
   name: {{ name }}
@@ -11,9 +11,7 @@ package:
 # This source reference uses the source archive published to PyPI
 source:
  url: https://pypi.io/packages/source/d/deadline-cloud-for-maya/deadline_cloud_for_maya-{{ version }}.tar.gz
- sha256: 9b86a6c02df800ed3e69a3094c0f7d2aaa8b07304af34068fc41e2e14313268e
- patches:
-   - 0001-Remove-version-hook.patch
+ sha256: ed7c230d7dc45e3c0b8dc1914a2894f779622179e4e645ea5e8259af20967f50
 
 # # This source reference uses git to retrieve the tag for the specified version. You can modify
 # # the git_url and git_rev to point to a branch in your own fork of the project.

--- a/conda_recipes/maya-openjd/recipe/recipe.yaml
+++ b/conda_recipes/maya-openjd/recipe/recipe.yaml
@@ -2,7 +2,7 @@
 # See https://prefix-dev.github.io/rattler-build/latest/
 
 context:
-  version: "0.14.4"
+  version: "0.15.7"
 
 package:
   name: maya-openjd
@@ -11,9 +11,7 @@ package:
 # This source reference uses the source archive published to PyPI
 source:
   url: https://pypi.io/packages/source/d/deadline-cloud-for-maya/deadline_cloud_for_maya-${{ version }}.tar.gz
-  sha256: 9b86a6c02df800ed3e69a3094c0f7d2aaa8b07304af34068fc41e2e14313268e
-  patches:
-    - 0001-Remove-version-hook.patch
+  sha256: ed7c230d7dc45e3c0b8dc1914a2894f779622179e4e645ea5e8259af20967f50
 
 build:
   number: 0


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

We had patches because the sdist of the packages were broken. They are now (mostly) fixed/released.

Openjd-adaptor-runtime-for-python has not been released yet with the fix.

### What was the solution? (How)

updated version, sha256, and remove patch

### What is the impact of this change?

Simpler recipes!

### How was this change tested?

_:)_ I have not - if someone is able to verify they build/work properly that'd be great.

### Was this change documented?

N/A

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*