### PR TITLE
feat: update and remove patch from openjd-adaptor-runtime conda recipe sample

### DIFF
--- a/conda_recipes/openjd-adaptor-runtime/recipe/meta.yaml
+++ b/conda_recipes/openjd-adaptor-runtime/recipe/meta.yaml
@@ -2,7 +2,7 @@
 # See recipe.yaml for the recipe in rattler-build format.
 
 {% set name = "openjd-adaptor-runtime" %}
-{% set version = "0.9.0" %}
+{% set version = "0.9.1" %}
 
 package:
   name: {{ name }}
@@ -11,9 +11,7 @@ package:
 # # This source reference uses the source archive published to PyPI
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/openjd_adaptor_runtime-{{ version }}.tar.gz
-  sha256: a2a117b23df4e7fa31360b4572528ecabeeed190f5a4c51177560d401df79704
-  patches:
-    - 0001-Remove-version-hook.patch
+  sha256: 8741388d40c07cf90c099105ef3bb899966d36b79295d916ce21864cf28ca223
 
 # This source reference uses git to retrieve the tag for the specified version. You can modify
 # the git_url and git_rev to point to a branch in your own fork of the project.

--- a/conda_recipes/openjd-adaptor-runtime/recipe/recipe.yaml
+++ b/conda_recipes/openjd-adaptor-runtime/recipe/recipe.yaml
@@ -2,7 +2,7 @@
 # See https://prefix-dev.github.io/rattler-build/latest/
 
 context:
-  version: "0.9.0"
+  version: "0.9.1"
 
 package:
   name: openjd-adaptor-runtime
@@ -10,9 +10,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/o/openjd-adaptor-runtime/openjd_adaptor_runtime-${{ version }}.tar.gz
-  sha256: a2a117b23df4e7fa31360b4572528ecabeeed190f5a4c51177560d401df79704
-  patches:
-    - 0001-Remove-version-hook.patch
+  sha256: 8741388d40c07cf90c099105ef3bb899966d36b79295d916ce21864cf28ca223
 
 build:
   number: 0


### PR DESCRIPTION
Follow-up to #106, openjd-adaptor-runtime was just released with the sdist fix

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*