### PR TITLE
feat: add Houdini 20.5 sample Conda package recipe

### DIFF
--- a/conda_recipes/houdini-20.5/README.md
+++ b/conda_recipes/houdini-20.5/README.md
@@ -1,0 +1,33 @@
+# Houdini 20.5 Conda Recipe
+
+## Download the archive file for Linux
+
+Download the houdini-20.5.654-linux_x86_64_gcc11.2.tar.gz file from SideFX.
+Place the file in the `conda_recipes/archive_files` directory in your git clone
+of the [https://github.com/aws-deadline/deadline-cloud-samples](deadline-cloud-samples)
+repository for submitting package build jobs.
+
+## Building the package
+
+Follow this [README](https://github.com/aws-deadline/deadline-cloud-samples/blob/mainline/conda_recipes/README.md) to get everything set
+up to submit pacakge build jobs.
+
+To submit a package build job for Houdini 20.5, enter the `conda_recipes` directory and run the following
+from your shell:
+
+```
+./submit-package-job houdini-20.5
+```
+
+## Instructions for Houdini plugin packages
+
+Plugins can be registered with Houdini following the standard process of creating
+and loading Houdini [package](https://www.sidefx.com/docs/houdini/ref/plugins.html)
+files. 
+
+## Adapting for other Houdini versions
+This recipe is written for Houdini 20.5.654, but should be able to be adapted
+for any 20.5 patch release or even modified to work with older Houdini versions
+such as 19.5 or 20.0. At minimum you would need to grab the specific installers
+for a different version and modify the `sourceArchiveFilename` in `deadline-cloud.yaml`
+and the version string and archive hash in `recipe.yaml`.

--- a/conda_recipes/houdini-20.5/deadline-cloud.yaml
+++ b/conda_recipes/houdini-20.5/deadline-cloud.yaml
@@ -1,0 +1,10 @@
+condaPlatforms:
+  - platform: linux-64
+    defaultSubmit: true
+    sourceArchiveFilename: houdini-20.5.654-linux_x86_64_gcc11.2.tar.gz
+    sourceDownloadInstructions: Download the installer archive from SideFX Houdini's downloads page.
+    buildTool: rattler-build
+jobParameters:
+  # conda-forge is used to get patchelf
+  - name: CondaChannels
+    value: conda-forge

--- a/conda_recipes/houdini-20.5/recipe/build.sh
+++ b/conda_recipes/houdini-20.5/recipe/build.sh
@@ -1,0 +1,83 @@
+#!/bin/sh
+set -xeuo pipefail
+
+mkdir -p $PREFIX/opt
+cd $PREFIX/opt
+
+
+# The Houdini installer expects `bc` to run, but does not fail when
+# it is missing. Ensure that it is installed before running the installer
+bc --help
+
+# Install Houdini
+INSTALLER=$SRC_DIR/installer/houdini.install
+# date of the EULA agreement, not the current date
+EULAdate=2021-10-13
+$INSTALLER \
+    --auto-install \
+    --accept-EULA $EULAdate \
+    --no-install-engine-maya \
+    --no-install-engine-unity \
+    --no-install-menus \
+    --no-install-bin-symlink \
+    --no-install-hfs-symlink \
+    --no-install-license \
+    --no-install-hqueue-server \
+    --no-root-check \
+    --make-dir $PREFIX/opt/houdini
+
+HOUDINI_DIR=$PREFIX/opt/houdini
+# The Houdini version without the build number
+HOUDINI_VERSION=${PKG_VERSION%.*}
+
+# Remove the documentation, it's not needed on the farm
+rm -r $HOUDINI_DIR/houdini/help
+# Remove the toolkit samples, they're not needed on the farm
+rm -r $HOUDINI_DIR/toolkit/samples
+
+# Create symlinks
+mkdir -p $PREFIX/bin
+for BINARY in houdini houdini-bin houdinicore houdinifx \
+    hscript husk hython hbatch karma karma_cc mantra mantra-bin \
+    vmantra vmantra-bin; do
+ln -r -s $HOUDINI_DIR/bin/$BINARY $PREFIX/bin/$BINARY
+done
+
+# Install Houdini dependencies from local package manager
+mkdir -p $SRC_DIR/download
+cd $SRC_DIR/download
+dnf download --resolve -y alsa-lib fontconfig libXScrnSaver
+
+
+for rpm_file in $(realpath $SRC_DIR/download/*.rpm); do
+    rpm2cpio "$rpm_file" | cpio -idm
+done
+
+# Add $ORIGIN as a RPATH to any .so's and copy into Houdini's installation
+for so_file in $(find . -iname "*.so.*"); do
+    patchelf --add-rpath '$ORIGIN' $so_file
+    cp $so_file $HOUDINI_DIR/dsolib/.
+done
+
+# Script to set environment variables during activation
+mkdir -p $PREFIX/etc/conda/activate.d
+cat <<EOF > $PREFIX/etc/conda/activate.d/houdini-$PKG_VERSION-vars.sh
+export "HOUDINI_LOCATION=\$CONDA_PREFIX/opt/houdini"
+export "HOUDINI_VERSION=$HOUDINI_VERSION"
+export "HOUDINI_BINARY_PATH=\$HOUDINI_LOCATION/bin"
+export "HOUDINI_HOUDINI_PATH=\$HOUDINI_LOCATION/houdini"
+export "HOUDINI_INCLUDE_PATH=\$HOUDINI_LOCATION/toolkit/include"
+export "HOUDINI_LIBRARY_PATH=\$HOUDINI_LOCATION/bin"
+
+EOF
+
+mkdir -p $PREFIX/etc/conda/deactivate.d
+cat <<EOF > $PREFIX/etc/conda/deactivate.d/houdini-$PKG_VERSION-vars.sh
+unset HOUDINI_LIBRARY_PATH
+unset HOUDINI_INCLUDE_PATH
+unset HOUDINI_HOUDINI_PATH
+unset HOUDINI_BINARY_PATH
+unset HOUDINI_VERSION
+unset HOUDINI_LOCATION
+
+EOF

--- a/conda_recipes/houdini-20.5/recipe/recipe.yaml
+++ b/conda_recipes/houdini-20.5/recipe/recipe.yaml
@@ -1,0 +1,42 @@
+# Recipe in rattler-build format.
+# See https://prefix-dev.github.io/rattler-build/latest/
+
+context:
+  version: "20.5.654"
+
+package:
+  name: houdini
+  version: ${{ version }}
+
+source:
+  - if: linux
+    then:
+      url: file://archive_files/houdini-{{ version }}-linux_x86_64_gcc11.2.tar.gz
+      sha256: 05e877c06216e102a040e11b6b7fd8364dc699ed01b9386fc407564ce722c454
+      target_directory: installer
+
+build:
+  number: 0
+  # These build options for repackaging an application
+  # https://prefix-dev.github.io/rattler-build/latest/build_options/#prefix-detection-replacement-options
+  prefix_detection:
+    ignore_binary_files: True
+  # https://prefix-dev.github.io/rattler-build/latest/build_options/#dynamic-linking-configuration
+  dynamic_linking:
+    binary_relocation: False
+
+requirements:
+  build:
+    - patchelf
+
+tests:
+  - script:
+    - houdini -h
+    - hython -h
+
+about:
+  homepage: https://www.sidefx.com/products/houdini/
+  license: LicenseRef-SideFXEULA
+  summary: >
+    Houdini is built from the ground up to be a procedural system that empowers artists to work freely,
+    create multiple iterations and rapidly share workflows with colleagues.


### PR DESCRIPTION
Fixes: #69 

### What was the problem/requirement? (What/Why)
We have sample recipes for many DCCs, but not Houdini yet.

### What was the solution? (How)
This PR builds on the work done in #76 to clean up a few things and get it merge ready since that PR seems to have stalled out. Thank you to @dzavada for the initial request and work to get a Houdini sample included. Main changes from #76:
* Removal of the use of LD_LIBRARY_PATH and instead add rpaths to $ORIGIN to any of the system libraries brought in by doing a dnf install
  * This was based on reading https://rattler.build/v0.35.6/internals/#making-packages-relocatable-with-rattler-build which notes that rpaths are added to $ORIGIN by rattler-build. When checking the dsolib folder in an extracted package I was seeing that most .so libraries had $ORIGIN as an rpath except for any that were copied over from the dnf downloads. 
* Swapped the build from conda-build to rattler-build which brought build times down from ~35min to ~7-8 minutes
* Removed some additional libraries from the dnf install command since they don't appear to be required for headless rendering
* Removed any setting of SESI_LMHOST from being in the package itself. This should be done as either a queue env or some other setup action not belonging to the package
* Added a sourceDownloadInstructions line
* I've also added a small README 

### What is the impact of this change?
Customers can build their Houdini Conda packages and configure them as desired. e.g. adding SideFXLabs into the package, changing to new versions, adding new system libraries.

### How was this change tested?

- Built the new package following the instructions in this package for setting up a build farm on Deadline Cloud and then did a submission `./submit-package-job houdini-20.5`. I verified that the package built and the tests passed.
- I did a real render using the package I built and the adaptor package from the deadline-cloud channel and verified the render succeeded, the output looked correct, and that my package was the one used.

### Was this change documented?
A small README is included

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*