### PR TITLE
feat: add houdini redshift sample Conda recipe

### DIFF
--- a/conda_recipes/houdini-20.5/README.md
+++ b/conda_recipes/houdini-20.5/README.md
@@ -21,9 +21,12 @@ from your shell:
 
 ## Instructions for Houdini plugin packages
 
-Plugins can be registered with Houdini following the standard process of creating
-and loading Houdini [package](https://www.sidefx.com/docs/houdini/ref/plugins.html)
-files. 
+When creating a plugin package for Houdini, place its package file in the following
+location so that Houdini loads the plugin at startup. Refer to the Houdini
+[plugins documentation](https://www.sidefx.com/docs/houdini/ref/plugins.html) page
+for more details on creating package files.
+
+* `$PREFIX/opt/houdini/packages`
 
 ## Adapting for other Houdini versions
 This recipe is written for Houdini 20.5.654, but should be able to be adapted

--- a/conda_recipes/houdini-20.5/recipe/build.sh
+++ b/conda_recipes/houdini-20.5/recipe/build.sh
@@ -27,8 +27,6 @@ $INSTALLER \
     --make-dir $PREFIX/opt/houdini
 
 HOUDINI_DIR=$PREFIX/opt/houdini
-# The Houdini version without the build number
-HOUDINI_VERSION=${PKG_VERSION%.*}
 
 # Remove the documentation, it's not needed on the farm
 rm -r $HOUDINI_DIR/houdini/help
@@ -63,7 +61,7 @@ done
 mkdir -p $PREFIX/etc/conda/activate.d
 cat <<EOF > $PREFIX/etc/conda/activate.d/houdini-$PKG_VERSION-vars.sh
 export "HOUDINI_LOCATION=\$CONDA_PREFIX/opt/houdini"
-export "HOUDINI_VERSION=$HOUDINI_VERSION"
+export "HOUDINI_VERSION=$PKG_VERSION"
 export "HOUDINI_BINARY_PATH=\$HOUDINI_LOCATION/bin"
 export "HOUDINI_HOUDINI_PATH=\$HOUDINI_LOCATION/houdini"
 export "HOUDINI_INCLUDE_PATH=\$HOUDINI_LOCATION/toolkit/include"

--- a/conda_recipes/houdini-redshift-2025/README.md
+++ b/conda_recipes/houdini-redshift-2025/README.md
@@ -1,0 +1,43 @@
+# Redshift for Houdini Conda Recipe
+
+## Download the installer for Linux
+
+Download the Redshift installer `redshift_2025.6.0_1924545106_linux_x64.run` from Maxon.
+Place the file in the `conda_recipes/archive_files` directory in your git clone
+of the [https://github.com/aws-deadline/deadline-cloud-samples](deadline-cloud-samples)
+repository for submitting package build jobs.
+
+## Building the package
+
+Follow this [README](https://github.com/aws-deadline/deadline-cloud-samples/blob/mainline/conda_recipes/README.md) to get everything set
+up to submit package build jobs.
+
+To submit a package build job for Redshift for Houdini, enter the `conda_recipes` directory and run the following
+from your shell:
+
+```
+./submit-package-job houdini-redshift-2025
+```
+
+## Integration with Houdini
+
+This package is designed to work with the [Houdini conda package](../houdini-20.5/README.md). It automatically detects the
+installed Houdini version by calling `houdini --version` and configures the appropriate Redshift plugin version. 
+
+Redshift plugins for Houdini are versioned to the exact patch release of Houdini. Using a Redshift plugin version that
+isn't for the exact same Houdini version can result in instability. This package will attempt to use the best Redshift
+plugin version to match the version of Houdini provided by:
+1. Looking for an exact match between the Houdini version and available Redshift plugin versions
+2. If no exact match is found, it will use a plugin version that matches the major.minor version of Houdini
+3. If no matching major.minor version is found, the package will exit and not configure Redshift
+4. If the `houdini --version` call doesn't print a valid version string, the package will exit and not configure Redshift
+
+## Adapting for other Redshift versions
+
+This recipe can be adapted for other Redshift versions by modifying the `sourceArchiveFilename` in `deadline-cloud.yaml`
+and the version string in `recipe.yaml`. You may also need to update the build script if the Redshift installer structure
+changes between versions.
+
+> **Warning**: When changing the Redshift version, be sure to check what versions of Houdini it supports due to how the
+plugin [integrates with Houdini](#integration-with-houdini). Details on Redshift version support for Houdini can be
+found [here](https://help.maxon.net/r3d/houdini/en-us/Content/html/Houdini+Plugin+Configuration.html).

--- a/conda_recipes/houdini-redshift-2025/deadline-cloud.yaml
+++ b/conda_recipes/houdini-redshift-2025/deadline-cloud.yaml
@@ -1,0 +1,10 @@
+condaPlatforms:
+  - platform: linux-64
+    defaultSubmit: true
+    sourceArchiveFilename: redshift_2025.6.0_1924545106_linux_x64.run
+    sourceDownloadInstructions: Download the Redshift installer from the Maxon website
+    buildTool: rattler-build
+jobParameters:
+  # conda-forge is used to get patchelf
+  - name: CondaChannels
+    value: conda-forge

--- a/conda_recipes/houdini-redshift-2025/recipe/build.sh
+++ b/conda_recipes/houdini-redshift-2025/recipe/build.sh
@@ -1,0 +1,106 @@
+#!/bin/sh
+set -xeuo pipefail
+
+# The version without the update number
+REDSHIFT_VERSION="$PKG_VERSION"
+
+INSTALLER_DIR="$SRC_DIR/installer"
+INSTALLER="$INSTALLER_DIR/redshift_${REDSHIFT_VERSION}_linux_x64.run"
+REDSHIFT_UNPACK_DIR="$INSTALLER_DIR/redshift_installer_artifacts"
+REDSHIFT_ROOT="$PREFIX/opt/redshift"
+
+# Extract the run file into its accompanying tarball and setup script
+chmod u+x "$INSTALLER"
+$INSTALLER --target "$REDSHIFT_UNPACK_DIR" --noexec
+
+# Skip superuser check by modifying the setup script in-place
+sed -i 's/\[ "$(id -u)" != "0" \]/false/' "$REDSHIFT_UNPACK_DIR/setup.sh"
+
+# Run the setup script
+cd "$REDSHIFT_UNPACK_DIR"
+./setup.sh --installpath "$REDSHIFT_ROOT"
+
+# Clean up unneeded DCC artifacts
+rm -r "$REDSHIFT_ROOT/redshift4blender"
+rm -r "$REDSHIFT_ROOT/redshift4c4d"
+rm -r "$REDSHIFT_ROOT/redshift4katana"
+rm -r "$REDSHIFT_ROOT/redshift4maya"
+
+# Create symlink for redshiftCmdLine
+mkdir -p "$PREFIX/bin"
+ln -r -s "$REDSHIFT_ROOT/bin/redshiftCmdLine" "$PREFIX/bin/redshiftCmdLine"
+
+# Add rpath into the Houdini installation in the same environment
+for so_file in $(find "$REDSHIFT_ROOT"/redshift4houdini/*/dso -iname "redshift4houdini.so"); do
+    patchelf --add-rpath '$ORIGIN/../../../../houdini/dsolib' "$so_file"
+done
+
+# Create Houdini package file for Redshift plugin and place into Houdini search path
+# https://help.maxon.net/r3d/houdini/en-us/Content/html/Houdini+Plugin+Configuration.html
+mkdir -p "$PREFIX/opt/houdini/packages"
+cat <<EOF > "$PREFIX/opt/houdini/packages/redshift_package.json"
+{
+    "env":[
+        {"HOUDINI_PATH": "\${REDSHIFT_COREDATAPATH}/redshift4houdini/\${RS_PLUGIN_VERSION}"},
+        {"PATH": "\${REDSHIFT_COREDATAPATH}/bin"},
+    ]
+}
+EOF
+
+# Script to set environment variables during activation
+# Environment variables are based on what is needed for portable Redshift installations
+# https://help.maxon.net/r3d/houdini/en-us/Content/html/Custom+Install+Locations.html
+mkdir -p "$PREFIX/etc/conda/activate.d"
+cat <<EOF > "$PREFIX/etc/conda/activate.d/houdini-redshift-$PKG_VERSION-vars.sh"
+export REDSHIFT_COREDATAPATH="$REDSHIFT_ROOT"
+export REDSHIFT_LOCALDATAPATH="\$REDSHIFT_COREDATAPATH/redshift_local_data"
+export REDSHIFT_PROCEDURALSPATH="\$REDSHIFT_COREDATAPATH/procedurals"
+export REDSHIFT_PREFSPATH="\$REDSHIFT_LOCALDATAPATH/preferences.xml"
+export HOUDINI_DSO_ERROR=2
+
+# Redshift plugins for Houdini are versioned to match the exact patch release
+# of the Houdini version. If there is no exact match this package will point
+# to the latest plugin version for either the matching MAJOR.MINOR Houdini version.
+# Using a plugin version that doesn't match the Houdini version could cause
+# instability and failures.
+
+HOU_VERSION_OUTPUT=\$(houdini --version 2>/dev/null)
+if [ $? -eq 0 ] && [[ "\$HOU_VERSION_OUTPUT" =~ Houdini\ FX\ ([0-9]+\.[0-9]+\.[0-9]+) ]]; then
+  HOU_VERSION="\${BASH_REMATCH[1]}"
+
+  # Get all available plugin versions
+  AVAILABLE_VERSIONS=\$(find "\$REDSHIFT_COREDATAPATH/redshift4houdini/" -mindepth 1 -maxdepth 1 -type d -printf "%f\n")
+
+  # Check for exact match first
+  if echo "\$AVAILABLE_VERSIONS" | grep -q "^\$HOU_VERSION$"; then
+    export RS_PLUGIN_VERSION="\$HOU_VERSION"
+  else
+    # Extract major.minor from HOU_VERSION (e.g. 20.5 from 20.5.654)
+    HOU_MAJOR_MINOR=\${HOU_VERSION%.*}
+    
+    # Find the latest patch release for a matching major.minor version
+    MATCHING_VERSION=\$(echo "\$AVAILABLE_VERSIONS" | grep "^\$HOU_MAJOR_MINOR" | sort -V | tail -1)
+
+    if [ -n "\$MATCHING_VERSION" ]; then
+      export RS_PLUGIN_VERSION="\$MATCHING_VERSION"
+      echo "Warning: No exact match Redshift plugin found for Houdini \$HOU_VERSION, using \$RS_PLUGIN_VERSION instead"
+    else
+      # If no matching major.minor version is found fail to load the package
+      echo "Error: No matching Redshift plugin found for Houdini \$HOU_MAJOR_MINOR in \$AVAILABLE_VERSIONS"
+      exit 1
+    fi
+  fi
+else
+  echo "Error: Could not determine Houdini version using 'houdini --version'"
+  exit 1
+fi
+EOF
+
+mkdir -p "$PREFIX/etc/conda/deactivate.d"
+cat <<EOF > "$PREFIX/etc/conda/deactivate.d/houdini-redshift-$PKG_VERSION-vars.sh"
+unset REDSHIFT_COREDATAPATH
+unset REDSHIFT_LOCALDATAPATH
+unset REDSHIFT_PROCEDURALSPATH
+unset REDSHIFT_PREFSPATH
+unset HOUDINI_DSO_ERROR
+EOF

--- a/conda_recipes/houdini-redshift-2025/recipe/recipe.yaml
+++ b/conda_recipes/houdini-redshift-2025/recipe/recipe.yaml
@@ -1,0 +1,43 @@
+# Recipe in rattler-build format.
+# See https://prefix-dev.github.io/rattler-build/latest/
+
+context:
+  version: "2025.6.0_1924545106"
+
+package:
+  name: houdini-redshift
+  version: ${{ version }}
+
+source:
+  - if: linux
+    then:
+      url: file://archive_files/redshift_${{ version }}_linux_x64.run
+      sha256: bdf0d787b3c991f1401bb31e2037a52a7ef686445812abed2d162882eb048039
+      target_directory: installer
+
+build:
+  number: 0
+  # These build options for repackaging an application
+  # https://prefix-dev.github.io/rattler-build/latest/build_options/#prefix-detection-replacement-options
+  prefix_detection:
+    ignore_binary_files: True
+  # https://prefix-dev.github.io/rattler-build/latest/build_options/#dynamic-linking-configuration
+  dynamic_linking:
+    binary_relocation: false
+    missing_dso_allowlist:
+      - "**"
+
+requirements:
+  build:
+    - patchelf
+  run:
+    - houdini >=20.5, <21
+
+tests:
+  - script:
+    - redshiftCmdLine -listrenderoptions
+
+about:
+  homepage: https://www.maxon.net/en/redshift
+  license: LicenseRef-MaxonEULA
+  summary: Redshift is a powerful 3D rendering software that helps visualize your 3D designs, models, animations, and scenes.


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
This is a continuation of #84 and thanks to @yuanmich2 for the starting point.
We have a Houdini sample now in the repository and Redshift is commonly used with Houdini, but had no sample of its own.
### What was the solution? (How)
- Add a Redshift for Houdini conda recipe sample
- Also a one line change to the Houdini sample so that we have the full MAJOR.MINOR.PATCH version in the HOUDINI_VERSION env var that it sets. Originally this was so that I could match the redshift version exactly by reading that env var, but I've instead gone with calling `houdini --version` to get than info. I still think it's valuable to have the full version string in HOUDINI_VERSION however
- Edit the Houdini package README to better clarify how other plugin packages should register themselves with Houdini installed by that package.

### What is the impact of this change?
Users can more easily self serve Redshift for Houdini via Conda

### How was this change tested?
- Ran render tests from Houdini+Redshift using the package and verified the outputs as well as looked at the render logs to make sure everything looked to be functioning correctly
- Manually tested the version detection logic with a variety of different version strings to make sure the best choice was always selected
- Verified that the package worked seamlessly with the Houdini package built using the sample in this repository

### Was this change documented?

- A README has been added

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*