### PR TITLE
feat: Add VREDCore conda recipes

### DIFF
--- a/conda_recipes/vredcore-2025/README.md
+++ b/conda_recipes/vredcore-2025/README.md
@@ -1,0 +1,34 @@
+# VRED 2025 Conda Recipe
+
+## Download the Installation File For Linux
+
+Download the VRED Core 2025 installation file for Linux (VREDCOre-2025.sh) from Autodesk Account page.
+Place the file in the `conda_recipes/archive_files` directory within your local clone of the [deadline-cloud-samples](https://github.com/aws-deadline/deadline-cloud-samples) repository for submitting package build jobs.
+
+## Building the Package
+
+To set up your environment for submitting package build jobs, please refer to this [README](https://github.com/aws-deadline/deadline-cloud-samples/blob/mainline/conda_recipes/README.md).
+
+Once your environment is prepared, navigate to the `conda_recipes` directory and execute the following command from your shell to submit a package build job for VRED 2025:
+
+```
+./submit-package-job vredcore-2025
+```
+
+## Prerequisites for Package Usage
+
+For VRED's GPU rendering capabilities, it is crucial to ensure that an X Server is running in the background. This Conda package automatically starts X Server, but the Linux user running this package must have the following permissions:
+
+1. Membership in the 'tty' group
+2. Read/write permissions for virtual terminals (specifically /dev/tty1)
+
+These requirements can be set up using:
+```bash
+# Adds the user to the group 'tty'
+sudo usermod -a -G tty job-user
+
+# Sets permissions of /dev/tty1 device file to 660 (to give read + write permissions to group)
+sudo chmod 660 /dev/tty1
+```
+
+Note: If you're using this package within Deadline Cloud Service-Managed Fleet (SMF), these prerequisites are already configured for the job-user and no additional setup is required.

--- a/conda_recipes/vredcore-2025/deadline-cloud.yaml
+++ b/conda_recipes/vredcore-2025/deadline-cloud.yaml
@@ -1,0 +1,6 @@
+condaPlatforms:
+  - platform: linux-64
+    defaultSubmit: true
+    sourceArchiveFilename: VREDCore-2025.sh
+    sourceDownloadInstructions: 'Download the VREDCore-2025.sh file from Autodesk website.'
+    buildTool: rattler-build  # conda-build or rattler-build

--- a/conda_recipes/vredcore-2025/recipe/build.sh
+++ b/conda_recipes/vredcore-2025/recipe/build.sh
@@ -1,0 +1,211 @@
+#!/bin/sh
+set -xeuo pipefail
+
+# Copy the VRED installation into the prefix
+INSTALL_DIR="$PREFIX/opt/Autodesk/VRED_2025"
+mkdir -p $INSTALL_DIR
+find $SRC_DIR/installer
+chmod +x $SRC_DIR/installer/VREDCore-2025.sh
+$SRC_DIR/installer/VREDCore-2025.sh --target $INSTALL_DIR
+
+# Install dependencies not available on Deadline Cloud service-managed fleets
+# from the system package manager, dnf.
+mkdir -p "$SRC_DIR/download"
+cd "$SRC_DIR/download"
+dnf download --resolve -y xorg-x11-server-Xorg \
+    pixman libXfont2 libepoxy cairo xkbcomp libunwind libgudev \
+    libX11-xcb xorg-x11-server-common xorg-x11-xauth \
+    freetype fontconfig harfbuzz libbrotli graphite2 libfontenc \
+    xcb-util-cursor libXfixes libXdmcp libxkbfile
+
+# Extract and install dependencies
+for rpm_file in $(realpath $SRC_DIR/download/*.rpm); do
+    rpm2cpio "$rpm_file" | cpio -idm
+done
+
+patchelf --add-rpath '$ORIGIN/../..' "$INSTALL_DIR"/lib/python*/lib-dynload/*.so
+
+# Copy and patch shared libraries
+for SO_FILE in $(find usr/lib64 -type f,l); do
+    DEST_FILE="$INSTALL_DIR/lib/$(basename $SO_FILE)"
+    cp --preserve=links $SO_FILE $DEST_FILE
+    if file $DEST_FILE | grep -q ELF; then
+        patchelf --add-rpath '$ORIGIN/.' $DEST_FILE
+    fi
+done
+
+# Copy binaries to the installation
+mkdir -p $INSTALL_DIR/usr/bin
+for BINARY in $(find usr/bin -type f); do
+    cp --preserve=links $BINARY $INSTALL_DIR/$BINARY
+    if file $BINARY | grep -q ELF; then
+        patchelf --add-rpath '$ORIGIN/../../lib' $INSTALL_DIR/$BINARY
+    fi
+done
+
+# Change the location of Xorg.wrap and Xorg
+LIBEXEC_DIR="$INSTALL_DIR/usr/libexec"
+
+cat <<EOF > $INSTALL_DIR/usr/bin/Xorg
+#!/usr/bin/sh
+#
+# Execute Xorg.wrap if it exists otherwise execute Xorg directly.
+# This allows distros to put the suid wrapper in a separate package.
+
+if [ -x "$LIBEXEC_DIR"/Xorg.wrap ]; then
+    exec "$LIBEXEC_DIR"/Xorg.wrap "\$@"
+else
+    exec "$LIBEXEC_DIR"/Xorg "\$@"
+fi
+EOF
+chmod +x $INSTALL_DIR/usr/bin/Xorg
+
+# Copy stuff in $SRC_DIR/download/usr/libexec to the installation
+mkdir -p $INSTALL_DIR/usr/libexec
+for LIBEXEC in $(find usr/libexec -type f); do
+    DEST_DIR="$INSTALL_DIR/$(dirname $LIBEXEC)"
+    mkdir -p $DEST_DIR
+    cp --preserve=links $LIBEXEC "$DEST_DIR/$(basename $LIBEXEC)"
+    if file $LIBEXEC | grep -q ELF; then
+        patchelf --add-rpath '$ORIGIN/../../lib' $INSTALL_DIR/$LIBEXEC
+    fi
+done
+
+# Handle Python-specific libraries
+for PYSO in "$INSTALL_DIR"/lib/python*/site-packages/*/*.so \
+           "$INSTALL_DIR"/lib/python*/lib-dynload/*.so; do
+    if file $PYSO | grep -q ELF; then
+        patchelf --add-rpath '$ORIGIN/../..' $PYSO
+    fi
+done
+
+# Xorg tries to call /usr/lib/xkbcomp. This switches that to just call xkbcmp, a symlink to the original
+# # ln -sf $INSTALL_DIR/usr/bin/xkbcomp $INSTALL_DIR/usr/bin/xkbcmp
+python <<EOF
+with open("$INSTALL_DIR/usr/libexec/Xorg", "rb+") as fh:
+    data = fh.read()
+
+    old_path = b'"%s%sxkbcomp"'
+    new_path = "A=%s%s xkbcmp".encode()
+    if len(new_path) <= len(old_path):
+        new_path = new_path.ljust(len(old_path), b'\0')
+        data = data.replace(old_path, new_path)
+    else:
+        raise RuntimeError(
+            "Cannot patch Xorg binary: New path is longer than original path: manual binary patch required!"
+        )
+    fh.seek(0)
+    fh.write(data)
+EOF
+
+# Patches Xorg.wrap binary to redirect hardcoded paths to /tmp/xorg.
+# - /usr/libexec -> /tmp/xorg (for executable lookup)
+# - /etc/X11/Xwrapper.config -> /tmp/xorg/Xwrapper.conf (for config)
+# These modifications allow Xorg to work with files in conda-managed locations 
+# via symlinks that will be created to /tmp/xorg.
+python <<EOF
+with open("$INSTALL_DIR/usr/libexec/Xorg.wrap", "rb+") as fh:
+    data = fh.read()
+
+    old_path = b"/usr/libexec"
+    new_path = "/tmp/xorg".encode()
+    if len(new_path) <= len(old_path):
+        new_path = new_path.ljust(len(old_path), b'\0')
+        data = data.replace(old_path, new_path)
+    else:
+        raise RuntimeError(
+            "Cannot patch Xorg.wrap binary: New path is longer than original path: manual binary patch required!"
+        )
+
+    old_config_path = b"/etc/X11/Xwrapper.config"
+    new_config_path = "/tmp/xorg/Xwrapper.conf".encode()
+    if len(new_config_path) <= len(old_config_path):
+        new_config_path = new_config_path.ljust(len(old_config_path), b'\0')
+        data = data.replace(old_config_path, new_config_path)
+    else:
+        raise RuntimeError(
+            "Cannot patch Xorg.wrap binary: New path is longer than original path: manual binary patch required!"
+        )
+
+    fh.seek(0)
+    fh.write(data)
+EOF
+
+
+# Create X server startup script
+mkdir -p $INSTALL_DIR/bin
+cat <<EOF > $INSTALL_DIR/bin/start-xserver
+#!/bin/bash
+set -xeuo pipefail
+
+export DISPLAY=:0
+
+# Create X configuration directory in the package
+mkdir -p $INSTALL_DIR/etc/X11
+
+# Generate etc/X11/xorg.conf
+/usr/bin/nvidia-xconfig -a \
+    --allow-empty-initial-configuration \
+    --no-connected-monitor \
+    --output-xconfig $INSTALL_DIR/etc/X11/xorg.conf
+
+# Edit "Files" section
+sed -i "/^Section \"Files\"/a\\
+    ModulePath \"/usr/lib64/xorg/modules\"\\
+    ModulePath \"$PREFIX/opt/Autodesk/VRED_2025/lib\"" $INSTALL_DIR/etc/X11/xorg.conf
+
+# Create symbolic link
+ln -sf $INSTALL_DIR/usr/libexec /tmp/xorg
+ln -sf $INSTALL_DIR/usr/bin/xkbcomp $INSTALL_DIR/usr/bin/xkbcmp
+
+# Create a Xorg wrapper config file
+# This should has symlink setup: /tmp/xorg/Xwrapper.conf --> $INSTALL_DIR/usr/libexec/Xwrapper.conf
+if [ -f  $INSTALL_DIR/usr/libexec/Xwrapper.conf ]; then
+  echo "Xwrapper Config file already exists"
+else
+  echo "Creating a new Xwrapper Config"
+  mkdir -p $INSTALL_DIR/usr/libexec
+  cat << EOF2 > $INSTALL_DIR/usr/libexec/Xwrapper.conf
+needs_root_rights=no
+allowed_users=anybody
+EOF2
+  echo "New Xwrapper.conf file created at $INSTALL_DIR/usr/libexec/Xwrapper.conf"
+  cat $INSTALL_DIR/usr/libexec/Xwrapper.conf
+fi
+
+# Start X Server
+$INSTALL_DIR/usr/bin/Xorg -keeptty -sharevts -novtswitch -ignoreABI -nolisten tcp -config $INSTALL_DIR/etc/X11/xorg.conf &
+sleep 3
+EOF
+
+chmod +x $INSTALL_DIR/bin/start-xserver
+
+# Create VRED wrapper scripts
+mkdir -p $PREFIX/bin
+cat <<EOF > $PREFIX/bin/VREDCore
+#!/bin/bash
+PATH="$INSTALL_DIR/usr/bin:$INSTALL_DIR/usr/libexec:\$PATH"
+
+# If Xorg is not running, run the X server startup script
+if ! pgrep -x Xorg > /dev/null; then
+    $INSTALL_DIR/bin/start-xserver
+fi
+export DISPLAY=:0
+export XAUTHORITY=/tmp/.Xauthority
+
+"$INSTALL_DIR/bin/VREDCore" "\$@"
+EOF
+chmod +x $PREFIX/bin/VREDCore
+
+
+# Setup environment variables for activation
+mkdir -p "$PREFIX/etc/conda/activate.d"
+cat <<EOF > $PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.sh
+export VREDCORE=\$CONDA_PREFIX/bin/VREDCore
+EOF
+
+# Setup environment variables for deactivation
+mkdir -p "$PREFIX/etc/conda/deactivate.d"
+cat <<EOF > $PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.sh
+unset VREDCORE
+EOF

--- a/conda_recipes/vredcore-2025/recipe/meta.yaml
+++ b/conda_recipes/vredcore-2025/recipe/meta.yaml
@@ -1,0 +1,32 @@
+# Recipe in conda-build format.
+# See https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html for information
+# about this file.
+
+{% set version = "2025" %}
+
+package:
+  name: vredcore
+  version: {{ version }}
+
+source:
+  url: file://archive_files/VREDCore-${{version}}.sh
+  sha256: ab1cfcc60c71dbcab7f96e9f886e14d47c6df501a65a2d9e0a6e8dbf5716094a
+  folder: installer
+
+build:
+  number: 0
+  # These build options for repackaging an application
+  # https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html
+  binary_relocation: False
+  detect_binary_files_with_prefix: False
+  missing_dso_whitelist:
+    - "**"
+
+test:
+  script:
+    - $VREDCORE -help
+
+about:
+  homepage: https://www.autodesk.com/products/vred/overview
+  license: Commercial
+  summary: Autodesk VRED is a 3D visualization software used to create product presentations, design reviews, and virtual prototypes

--- a/conda_recipes/vredcore-2025/recipe/recipe.yaml
+++ b/conda_recipes/vredcore-2025/recipe/recipe.yaml
@@ -1,0 +1,33 @@
+# Recipe in rattler-build format.
+# See https://prefix-dev.github.io/rattler-build/latest/
+
+context:
+  version: "2025"
+
+package:
+  name: vredcore
+  version: ${{ version }}
+
+source:
+  url: file://archive_files/VREDCore-${{version}}.sh
+  sha256: ab1cfcc60c71dbcab7f96e9f886e14d47c6df501a65a2d9e0a6e8dbf5716094a
+  target_directory: installer
+
+build:
+  number: 0
+  # These build options for repackaging an application
+  # https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html
+  prefix_detection:
+    ignore_binary_files: True
+  dynamic_linking:
+    binary_relocation: False
+    missing_dso_allowlist:
+    - "**"
+
+tests:
+  - script:
+    - $VREDCORE -help
+
+about:
+  homepage: https://www.autodesk.com/products/vred/overview
+  summary: Autodesk VRED is a 3D visualization software used to create product presentations, design reviews, and virtual prototypes

--- a/conda_recipes/vredcore-2026/README.md
+++ b/conda_recipes/vredcore-2026/README.md
@@ -1,0 +1,34 @@
+# VRED 2026 Conda Recipe
+
+## Download the Installation File For Linux
+
+Download the VRED Core 2026 installation file for Linux (VREDCOre-2026.sh) from Autodesk Account page.
+Place the file in the `conda_recipes/archive_files` directory within your local clone of the [deadline-cloud-samples](https://github.com/aws-deadline/deadline-cloud-samples) repository for submitting package build jobs.
+
+## Building the Package
+
+To set up your environment for submitting package build jobs, please refer to this [README](https://github.com/aws-deadline/deadline-cloud-samples/blob/mainline/conda_recipes/README.md).
+
+Once your environment is prepared, navigate to the `conda_recipes` directory and execute the following command from your shell to submit a package build job for VRED 2026:
+
+```
+./submit-package-job vredcore-2026
+```
+
+## Prerequisites for Package Usage
+
+For VRED's GPU rendering capabilities, it is crucial to ensure that an X Server is running in the background. This Conda package automatically starts X Server, but the Linux user running this package must have the following permissions:
+
+1. Membership in the 'tty' group
+2. Read/write permissions for virtual terminals (specifically /dev/tty1)
+
+These requirements can be set up using:
+```bash
+# Adds the user to the group 'tty'
+sudo usermod -a -G tty job-user
+
+# Sets permissions of /dev/tty1 device file to 660 (to give read + write permissions to group)
+sudo chmod 660 /dev/tty1
+```
+
+Note: If you're using this package within Deadline Cloud Service-Managed Fleet (SMF), these prerequisites are already configured for the job-user and no additional setup is required.

--- a/conda_recipes/vredcore-2026/deadline-cloud.yaml
+++ b/conda_recipes/vredcore-2026/deadline-cloud.yaml
@@ -1,0 +1,6 @@
+condaPlatforms:
+  - platform: linux-64
+    defaultSubmit: true
+    sourceArchiveFilename: VREDCore-2026.sh
+    sourceDownloadInstructions: 'Download the VREDCore-2026.sh file from Autodesk website.'
+    buildTool: rattler-build  # conda-build or rattler-build

--- a/conda_recipes/vredcore-2026/recipe/build.sh
+++ b/conda_recipes/vredcore-2026/recipe/build.sh
@@ -1,0 +1,211 @@
+#!/bin/sh
+set -xeuo pipefail
+
+# Copy the VRED installation into the prefix
+INSTALL_DIR="$PREFIX/opt/Autodesk/VRED_2026"
+mkdir -p $INSTALL_DIR
+find $SRC_DIR/installer
+chmod +x $SRC_DIR/installer/VREDCore-2026.sh
+$SRC_DIR/installer/VREDCore-2026.sh --target $INSTALL_DIR
+
+# Install dependencies not available on Deadline Cloud service-managed fleets
+# from the system package manager, dnf.
+mkdir -p "$SRC_DIR/download"
+cd "$SRC_DIR/download"
+dnf download --resolve -y xorg-x11-server-Xorg \
+    pixman libXfont2 libepoxy cairo xkbcomp libunwind libgudev \
+    libX11-xcb xorg-x11-server-common xorg-x11-xauth \
+    freetype fontconfig harfbuzz libbrotli graphite2 libfontenc \
+    xcb-util-cursor libXfixes libXdmcp libxkbfile
+
+# Extract and install dependencies
+for rpm_file in $(realpath $SRC_DIR/download/*.rpm); do
+    rpm2cpio "$rpm_file" | cpio -idm
+done
+
+patchelf --add-rpath '$ORIGIN/../..' "$INSTALL_DIR"/lib/python*/lib-dynload/*.so
+
+# Copy and patch shared libraries
+for SO_FILE in $(find usr/lib64 -type f,l); do
+    DEST_FILE="$INSTALL_DIR/lib/$(basename $SO_FILE)"
+    cp --preserve=links $SO_FILE $DEST_FILE
+    if file $DEST_FILE | grep -q ELF; then
+        patchelf --add-rpath '$ORIGIN/.' $DEST_FILE
+    fi
+done
+
+# Copy binaries to the installation
+mkdir -p $INSTALL_DIR/usr/bin
+for BINARY in $(find usr/bin -type f); do
+    cp --preserve=links $BINARY $INSTALL_DIR/$BINARY
+    if file $BINARY | grep -q ELF; then
+        patchelf --add-rpath '$ORIGIN/../../lib' $INSTALL_DIR/$BINARY
+    fi
+done
+
+# Change the location of Xorg.wrap and Xorg
+LIBEXEC_DIR="$INSTALL_DIR/usr/libexec"
+
+cat <<EOF > $INSTALL_DIR/usr/bin/Xorg
+#!/usr/bin/sh
+#
+# Execute Xorg.wrap if it exists otherwise execute Xorg directly.
+# This allows distros to put the suid wrapper in a separate package.
+
+if [ -x "$LIBEXEC_DIR"/Xorg.wrap ]; then
+    exec "$LIBEXEC_DIR"/Xorg.wrap "\$@"
+else
+    exec "$LIBEXEC_DIR"/Xorg "\$@"
+fi
+EOF
+chmod +x $INSTALL_DIR/usr/bin/Xorg
+
+# Copy stuff in $SRC_DIR/download/usr/libexec to the installation
+mkdir -p $INSTALL_DIR/usr/libexec
+for LIBEXEC in $(find usr/libexec -type f); do
+    DEST_DIR="$INSTALL_DIR/$(dirname $LIBEXEC)"
+    mkdir -p $DEST_DIR
+    cp --preserve=links $LIBEXEC "$DEST_DIR/$(basename $LIBEXEC)"
+    if file $LIBEXEC | grep -q ELF; then
+        patchelf --add-rpath '$ORIGIN/../../lib' $INSTALL_DIR/$LIBEXEC
+    fi
+done
+
+# Handle Python-specific libraries
+for PYSO in "$INSTALL_DIR"/lib/python*/site-packages/*/*.so \
+           "$INSTALL_DIR"/lib/python*/lib-dynload/*.so; do
+    if file $PYSO | grep -q ELF; then
+        patchelf --add-rpath '$ORIGIN/../..' $PYSO
+    fi
+done
+
+# Xorg tries to call /usr/lib/xkbcomp. This switches that to just call xkbcmp, a symlink to the original
+# # ln -sf $INSTALL_DIR/usr/bin/xkbcomp $INSTALL_DIR/usr/bin/xkbcmp
+python <<EOF
+with open("$INSTALL_DIR/usr/libexec/Xorg", "rb+") as fh:
+    data = fh.read()
+
+    old_path = b'"%s%sxkbcomp"'
+    new_path = "A=%s%s xkbcmp".encode()
+    if len(new_path) <= len(old_path):
+        new_path = new_path.ljust(len(old_path), b'\0')
+        data = data.replace(old_path, new_path)
+    else:
+        raise RuntimeError(
+            "Cannot patch Xorg binary: New path is longer than original path: manual binary patch required!"
+        )
+    fh.seek(0)
+    fh.write(data)
+EOF
+
+# Patches Xorg.wrap binary to redirect hardcoded paths to /tmp/xorg.
+# - /usr/libexec -> /tmp/xorg (for executable lookup)
+# - /etc/X11/Xwrapper.config -> /tmp/xorg/Xwrapper.conf (for config)
+# These modifications allow Xorg to work with files in conda-managed locations 
+# via symlinks that will be created to /tmp/xorg.
+python <<EOF
+with open("$INSTALL_DIR/usr/libexec/Xorg.wrap", "rb+") as fh:
+    data = fh.read()
+
+    old_path = b"/usr/libexec"
+    new_path = "/tmp/xorg".encode()
+    if len(new_path) <= len(old_path):
+        new_path = new_path.ljust(len(old_path), b'\0')
+        data = data.replace(old_path, new_path)
+    else:
+        raise RuntimeError(
+            "Cannot patch Xorg.wrap binary: New path is longer than original path: manual binary patch required!"
+        )
+
+    old_config_path = b"/etc/X11/Xwrapper.config"
+    new_config_path = "/tmp/xorg/Xwrapper.conf".encode()
+    if len(new_config_path) <= len(old_config_path):
+        new_config_path = new_config_path.ljust(len(old_config_path), b'\0')
+        data = data.replace(old_config_path, new_config_path)
+    else:
+        raise RuntimeError(
+            "Cannot patch Xorg.wrap binary: New path is longer than original path: manual binary patch required!"
+        )
+
+    fh.seek(0)
+    fh.write(data)
+EOF
+
+
+# Create X server startup script
+mkdir -p $INSTALL_DIR/bin
+cat <<EOF > $INSTALL_DIR/bin/start-xserver
+#!/bin/bash
+set -xeuo pipefail
+
+export DISPLAY=:0
+
+# Create X configuration directory in the package
+mkdir -p $INSTALL_DIR/etc/X11
+
+# Generate etc/X11/xorg.conf
+/usr/bin/nvidia-xconfig -a \
+    --allow-empty-initial-configuration \
+    --no-connected-monitor \
+    --output-xconfig $INSTALL_DIR/etc/X11/xorg.conf
+
+# Edit "Files" section
+sed -i "/^Section \"Files\"/a\\
+    ModulePath \"/usr/lib64/xorg/modules\"\\
+    ModulePath \"$PREFIX/opt/Autodesk/VRED_2026/lib\"" $INSTALL_DIR/etc/X11/xorg.conf
+
+# Create symbolic link
+ln -sf $INSTALL_DIR/usr/libexec /tmp/xorg
+ln -sf $INSTALL_DIR/usr/bin/xkbcomp $INSTALL_DIR/usr/bin/xkbcmp
+
+# Create a Xorg wrapper config file
+# This should has symlink setup: /tmp/xorg/Xwrapper.conf --> $INSTALL_DIR/usr/libexec/Xwrapper.conf
+if [ -f  $INSTALL_DIR/usr/libexec/Xwrapper.conf ]; then
+  echo "Xwrapper Config file already exists"
+else
+  echo "Creating a new Xwrapper Config"
+  mkdir -p $INSTALL_DIR/usr/libexec
+  cat << EOF2 > $INSTALL_DIR/usr/libexec/Xwrapper.conf
+needs_root_rights=no
+allowed_users=anybody
+EOF2
+  echo "New Xwrapper.conf file created at $INSTALL_DIR/usr/libexec/Xwrapper.conf"
+  cat $INSTALL_DIR/usr/libexec/Xwrapper.conf
+fi
+
+# Start X Server
+$INSTALL_DIR/usr/bin/Xorg -keeptty -sharevts -novtswitch -ignoreABI -nolisten tcp -config $INSTALL_DIR/etc/X11/xorg.conf &
+sleep 3
+EOF
+
+chmod +x $INSTALL_DIR/bin/start-xserver
+
+# Create VRED wrapper scripts
+mkdir -p $PREFIX/bin
+cat <<EOF > $PREFIX/bin/VREDCore
+#!/bin/bash
+PATH="$INSTALL_DIR/usr/bin:$INSTALL_DIR/usr/libexec:\$PATH"
+
+# If Xorg is not running, run the X server startup script
+if ! pgrep -x Xorg > /dev/null; then
+    $INSTALL_DIR/bin/start-xserver
+fi
+export DISPLAY=:0
+export XAUTHORITY=/tmp/.Xauthority
+
+"$INSTALL_DIR/bin/VREDCore" "\$@"
+EOF
+chmod +x $PREFIX/bin/VREDCore
+
+
+# Setup environment variables for activation
+mkdir -p "$PREFIX/etc/conda/activate.d"
+cat <<EOF > $PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.sh
+export VREDCORE=\$CONDA_PREFIX/bin/VREDCore
+EOF
+
+# Setup environment variables for deactivation
+mkdir -p "$PREFIX/etc/conda/deactivate.d"
+cat <<EOF > $PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.sh
+unset VREDCORE
+EOF

--- a/conda_recipes/vredcore-2026/recipe/meta.yaml
+++ b/conda_recipes/vredcore-2026/recipe/meta.yaml
@@ -1,0 +1,32 @@
+# Recipe in conda-build format.
+# See https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html for information
+# about this file.
+
+{% set version = "2026" %}
+
+package:
+  name: vredcore
+  version: {{ version }}
+
+source:
+  url: file://archive_files/VREDCore-${{version}}.sh
+  sha256: 22c4113d9efaf71e1176373954cf6ce2f68b1463e8067a23df955238aeeb830b
+  folder: installer
+
+build:
+  number: 0
+  # These build options for repackaging an application
+  # https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html
+  binary_relocation: False
+  detect_binary_files_with_prefix: False
+  missing_dso_whitelist:
+    - "**"
+
+test:
+  script:
+    - $VREDCORE -help
+
+about:
+  homepage: https://www.autodesk.com/products/vred/overview
+  license: Commercial
+  summary: Autodesk VRED is a 3D visualization software used to create product presentations, design reviews, and virtual prototypes

--- a/conda_recipes/vredcore-2026/recipe/recipe.yaml
+++ b/conda_recipes/vredcore-2026/recipe/recipe.yaml
@@ -1,0 +1,33 @@
+# Recipe in rattler-build format.
+# See https://prefix-dev.github.io/rattler-build/latest/
+
+context:
+  version: "2026"
+
+package:
+  name: vredcore
+  version: ${{ version }}
+
+source:
+  url: file://archive_files/VREDCore-${{version}}.sh
+  sha256: 22c4113d9efaf71e1176373954cf6ce2f68b1463e8067a23df955238aeeb830b
+  target_directory: installer
+
+build:
+  number: 0
+  # These build options for repackaging an application
+  # https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html
+  prefix_detection:
+    ignore_binary_files: True
+  dynamic_linking:
+    binary_relocation: False
+    missing_dso_allowlist:
+    - "**"
+
+tests:
+  - script:
+    - $VREDCORE -help
+
+about:
+  homepage: https://www.autodesk.com/products/vred/overview
+  summary: Autodesk VRED is a 3D visualization software used to create product presentations, design reviews, and virtual prototypes


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We would like to add sample recipes for VRED Core.

### What was the solution? (How)
Adding Conda recipes for VRED 2025 and 2026, which include:
- A README file with instructions for building and using the package (README.md)
- deadline-cloud.yaml
- A Recipe in rattler-build format (recipe.yaml)
- A Recipe in conda-build format (meta.yaml)
- A build script for creating the Conda package (build.sh)

### What is the impact of this change?
This addition allows Deadline Cloud users to build conda package for VRED 2025 and 2026 in their render farm.

### How was this change tested?
1. Used the conda recipe introduced in this PR to build conda package for VRED 2025 and 2026 following the readme instructions
2. The resulting package was installed in my own conda channel in a test environment.
3. Basic VRED render jobs, which requires GPU rendering, were tested to ensure both conda packages are properly loaded and working.

- Successful completion of conda build jobs:
<img width="1344" height="294" alt="Screenshot 2025-07-17 at 3 41 59 PM" src="https://github.com/user-attachments/assets/977501c1-e5cf-433f-a743-709958a3d8e8" />

- Logs of the conda package build job (using `conda-build`)
```
...
2025/07/17 14:35:03-05:00 Source and build intermediates have been left in /sessions/session-59142ff343114d6e90c23bec79cc542b97c68yjh/conda-bld.
2025/07/17 14:35:03-05:00 There are currently 1 accumulated.
2025/07/17 14:35:03-05:00 To remove them, you can run the ```conda build purge``` command
2025/07/17 14:35:04-05:00 Package vredcore-2026-14.conda is 1003020394 bytes
2025/07/17 14:35:04-05:00 openjd_status: Uploading the package vredcore-2026-14.conda to s3://gahyusuh-conda/Conda/linux-64/vredcore-2026-14.conda...
2025/07/17 14:35:15-05:00 Process pid 27565 exited with code: 0 (unsigned) / 0x0 (hex)
...
```

- Logs of the conda package build job (using `rattler-build`):
```
...
2025/07/17 16:19:25-05:00 ✔ all tests passed!
2025/07/17 16:19:25-05:00 Artifact: /sessions/session-858e1c3c347149649135eae1387d2612zjd50q2o/conda-bld/linux-64/vredcore-2025-hb0f4dca_7.conda (607.13 MiB)
2025/07/17 16:19:25-05:00 Variant configuration (hash: hb0f4dca_7):
2025/07/17 16:19:25-05:00 ╭─────────────────┬────────────╮
2025/07/17 16:19:25-05:00 │ target_platform ┆ "linux-64" │
2025/07/17 16:19:25-05:00 ╰─────────────────┴────────────╯
2025/07/17 16:19:25-05:00  
2025/07/17 16:19:25-05:00  
2025/07/17 16:19:25-05:00 Package vredcore-2025-hb0f4dca_7.conda is 636619976 bytes
2025/07/17 16:19:25-05:00 openjd_status: Uploading the package vredcore-2025-hb0f4dca_7.conda to s3://gahyusuh-conda/Conda/linux-64/vredcore-2025-hb0f4dca_7.conda...
2025/07/17 16:19:32-05:00 Process pid 39638 exited with code: 0 (unsigned) / 0x0 (hex)
...
```

- Logs of the successful render job (you can find from the logs that X Server starts before we start VRED rendering):
```
2025/07/17 14:52:42-05:00 ==============================================
2025/07/17 14:52:42-05:00 --------- Running Task
2025/07/17 14:52:42-05:00 ==============================================
2025/07/17 14:52:42-05:00 Parameter values:
2025/07/17 14:52:42-05:00 StartFrameFromCurrentChunk(INT) = 0
2025/07/17 14:52:42-05:00 TileNumberX(INT) = 1
2025/07/17 14:52:42-05:00 TileNumberY(INT) = 1
2025/07/17 14:52:42-05:00 ----------------------------------------------
2025/07/17 14:52:42-05:00 Phase: Setup
2025/07/17 14:52:42-05:00 ----------------------------------------------
2025/07/17 14:52:42-05:00 Writing embedded files for Task to disk.
2025/07/17 14:52:42-05:00 Mapping: Task.File.LoadRenderParameterValues -> /sessions/session-412feda753c2485ca3f8926842c66be3jgnoj8_u/embedded_files12sxun6n/load_render_parameter_values.py
2025/07/17 14:52:42-05:00 Mapping: Task.File.VREDInvocation -> /sessions/session-412feda753c2485ca3f8926842c66be3jgnoj8_u/embedded_files12sxun6n/invoke-vred.py
2025/07/17 14:52:42-05:00 Wrote: LoadRenderParameterValues -> /sessions/session-412feda753c2485ca3f8926842c66be3jgnoj8_u/embedded_files12sxun6n/load_render_parameter_values.py
2025/07/17 14:52:42-05:00 Wrote: VREDInvocation -> /sessions/session-412feda753c2485ca3f8926842c66be3jgnoj8_u/embedded_files12sxun6n/invoke-vred.py
2025/07/17 14:52:42-05:00 ----------------------------------------------
2025/07/17 14:52:42-05:00 Phase: Running action
2025/07/17 14:52:42-05:00 ----------------------------------------------
2025/07/17 14:52:42-05:00 Running command sudo -u job-user -i setsid -w /sessions/session-412feda753c2485ca3f8926842c66be3jgnoj8_u/tmp3gr_k7lx.sh
2025/07/17 14:52:43-05:00 Command started as pid: 4247
2025/07/17 14:52:43-05:00 Output:
2025/07/17 14:52:43-05:00 + export DISPLAY=:0
2025/07/17 14:52:43-05:00 + DISPLAY=:0
2025/07/17 14:52:43-05:00 + mkdir -p /sessions/session-412feda753c2485ca3f8926842c66be3jgnoj8_u/.env/opt/Autodesk/VRED_2026/etc/X11
2025/07/17 14:52:43-05:00 + /usr/bin/nvidia-xconfig -a --allow-empty-initial-configuration --no-connected-monitor --output-xconfig /sessions/session-412feda753c2485ca3f8926842c66be3jgnoj8_u/.env/opt/Autodesk/VRED_2026/etc/X11/xorg.conf
2025/07/17 14:52:43-05:00  
2025/07/17 14:52:43-05:00 WARNING: Unable to locate/open X configuration file.
2025/07/17 14:52:43-05:00  
2025/07/17 14:52:43-05:00  
2025/07/17 14:52:43-05:00 WARNING: Unable to parse X.Org version string.
2025/07/17 14:52:43-05:00  
2025/07/17 14:52:44-05:00 Option "AllowEmptyInitialConfiguration" "True" added to Screen "Screen0".
2025/07/17 14:52:44-05:00 New X configuration file written to '/sessions/session-412feda753c2485ca3f8926842c66be3jgnoj8_u/.env/opt/Autodesk/VRED_2026/etc/X11/xorg.conf'
2025/07/17 14:52:44-05:00  
2025/07/17 14:52:44-05:00 + sed -i '/^Section "Files"/a    ModulePath "/usr/lib64/xorg/modules"    ModulePath "/sessions/session-412feda753c2485ca3f8926842c66be3jgnoj8_u/.env/opt/Autodesk/VRED_2026/lib"' /sessions/session-412feda753c2485ca3f8926842c66be3jgnoj8_u/.env/opt/Autodesk/VRED_2026/etc/X11/xorg.conf
2025/07/17 14:52:44-05:00 + ln -sf /sessions/session-412feda753c2485ca3f8926842c66be3jgnoj8_u/.env/opt/Autodesk/VRED_2026/usr/libexec /tmp/xorg
2025/07/17 14:52:44-05:00 + ln -sf /sessions/session-412feda753c2485ca3f8926842c66be3jgnoj8_u/.env/opt/Autodesk/VRED_2026/usr/bin/xkbcomp /sessions/session-412feda753c2485ca3f8926842c66be3jgnoj8_u/.env/opt/Autodesk/VRED_2026/usr/bin/xkbcmp
2025/07/17 14:52:44-05:00 + '[' -f /sessions/session-412feda753c2485ca3f8926842c66be3jgnoj8_u/.env/opt/Autodesk/VRED_2026/usr/libexec/Xwrapper.conf ']'
2025/07/17 14:52:44-05:00 + echo 'Creating a new Xwrapper Config'
2025/07/17 14:52:44-05:00 Creating a new Xwrapper Config
2025/07/17 14:52:44-05:00 + mkdir -p /sessions/session-412feda753c2485ca3f8926842c66be3jgnoj8_u/.env/opt/Autodesk/VRED_2026/usr/libexec
2025/07/17 14:52:44-05:00 + cat
2025/07/17 14:52:44-05:00 + echo 'New Xwrapper.conf file created at /sessions/session-412feda753c2485ca3f8926842c66be3jgnoj8_u/.env/opt/Autodesk/VRED_2026/usr/libexec/Xwrapper.conf'
2025/07/17 14:52:44-05:00 New Xwrapper.conf file created at /sessions/session-412feda753c2485ca3f8926842c66be3jgnoj8_u/.env/opt/Autodesk/VRED_2026/usr/libexec/Xwrapper.conf
2025/07/17 14:52:44-05:00 + cat /sessions/session-412feda753c2485ca3f8926842c66be3jgnoj8_u/.env/opt/Autodesk/VRED_2026/usr/libexec/Xwrapper.conf
2025/07/17 14:52:44-05:00 needs_root_rights=no
2025/07/17 14:52:44-05:00 allowed_users=anybody
2025/07/17 14:52:44-05:00 + sleep 3
2025/07/17 14:52:44-05:00 + /sessions/session-412feda753c2485ca3f8926842c66be3jgnoj8_u/.env/opt/Autodesk/VRED_2026/usr/bin/Xorg -keeptty -sharevts -novtswitch -ignoreABI -nolisten tcp -config /sessions/session-412feda753c2485ca3f8926842c66be3jgnoj8_u/.env/opt/Autodesk/VRED_2026/etc/X11/xorg.conf
2025/07/17 14:52:44-05:00  
2025/07/17 14:52:44-05:00 X.Org X Server 1.21.1.13
2025/07/17 14:52:44-05:00 X Protocol Version 11, Revision 0
2025/07/17 14:52:44-05:00 Current Operating System: Linux ip-100-100-105-158.us-west-2.compute.internal 6.1.141-155.222.amzn2023.x86_64 #1 SMP PREEMPT_DYNAMIC Tue Jun 17 10:29:47 UTC 2025 x86_64
2025/07/17 14:52:44-05:00 Kernel command line: BOOT_IMAGE=(hd0,gpt1)/boot/vmlinuz-6.1.141-155.222.amzn2023.x86_64 root=UUID=8ccb215f-5a99-42c1-8ecd-1a3ec537135b ro console=tty0 console=ttyS0,115200n8 nvme_core.io_timeout=4294967295 rd.emergency=poweroff rd.shell=0 selinux=1 security=selinux quiet
2025/07/17 14:52:44-05:00 Build ID: xorg-x11-server 21.1.13-5.amzn2023.0.5 
2025/07/17 14:52:44-05:00 Current version of pixman: 0.43.4
2025/07/17 14:52:44-05:00 	Before reporting problems, check http://wiki.x.org
2025/07/17 14:52:44-05:00 	to make sure that you have the latest version.
2025/07/17 14:52:44-05:00 Markers: (--) probed, (**) from config file, (==) default setting,
2025/07/17 14:52:44-05:00 	(++) from command line, (!!) notice, (II) informational,
2025/07/17 14:52:44-05:00 	(WW) warning, (EE) error, (NI) not implemented, (??) unknown.
2025/07/17 14:52:44-05:00 (==) Log file: "/home/job-user/.local/share/xorg/Xorg.0.log", Time: Thu Jul 17 19:52:44 2025
2025/07/17 14:52:44-05:00 (++) Using config file: "/sessions/session-412feda753c2485ca3f8926842c66be3jgnoj8_u/.env/opt/Autodesk/VRED_2026/etc/X11/xorg.conf"
2025/07/17 14:52:47-05:00 --- command line options start ---
2025/07/17 14:52:47-05:00  
2025/07/17 14:52:47-05:00     hide user interface
2025/07/17 14:52:47-05:00     import files:
2025/07/17 14:52:47-05:00         /sessions/session-412feda753c2485ca3f8926842c66be3jgnoj8_u/assetroot-e9d0fb1ef0c583c3434b/lightweight.vpb
2025/07/17 14:52:47-05:00     set post python to 'load_module=getattr(__builtins__,'__import__');os=load_module('os');exec(os.environ.get('BOOTSTRAP_CODE'));'
2025/07/17 14:52:47-05:00  
2025/07/17 14:52:47-05:00 --- command line options end ---
2025/07/17 14:52:47-05:00  
2025/07/17 14:52:47-05:00 vrMain::run: starting ...
...

```

### Was this change documented?
A README file has been added to the VRED recipe directory

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*