### PR TITLE
feat: Added Maya 2026 Sample Recipe

### DIFF
--- a/conda_recipes/maya-2026/README.md
+++ b/conda_recipes/maya-2026/README.md
@@ -1,0 +1,23 @@
+# Maya 2026 conda build recipe
+
+## Requirements
+
+This recipe requires rattler-build version > 0.32.0 due to a bug fix for cleaning up .pyc files during the build process. Earlier versions may fail to build properly. See [rattler-build issue #1191](https://github.com/prefix-dev/rattler-build/issues/1191) for more details.
+
+## Instructions for Maya plugin packages
+
+This Maya conda build recipe configures the `MAYA_MODULE_PATH` environment variable
+to include several paths to search for plugin `.mod` files. When creating a plugin
+package, place its `.mod` file in one of these so that Maya loads the plugin at startup.
+
+* `$PREFIX/usr/autodesk/maya$MAYA_VERSION/modules`
+* `$PREFIX/usr/autodesk/modules/maya/$MAYA_VERSION`
+* `$PREFIX/usr/autodesk/modules/maya`
+
+## Download the archive file for Linux
+
+Download the Autodesk_Maya_2026_Linux_64bit.tgz full download file from Autodesk, and
+place it in the `conda_recipes/archive_files` directory in your git clone of the
+[https://github.com/aws-deadline/deadline-cloud-samples](deadline-cloud-samples) repository for
+submitting package build jobs.
+

--- a/conda_recipes/maya-2026/deadline-cloud.yaml
+++ b/conda_recipes/maya-2026/deadline-cloud.yaml
@@ -1,0 +1,11 @@
+condaPlatforms:
+  - platform: linux-64
+    defaultSubmit: true
+    sourceArchiveFilename:
+    - Autodesk_Maya_2026_Linux_64bit.tgz
+    sourceDownloadInstructions: 'Download the Autodesk_Maya_2026_Linux_64bit.tgz full download file from Autodesk.'
+    buildTool: rattler-build
+jobParameters:
+  # conda-forge is used to get patchelf on Linux
+  - name: CondaChannels
+    value: conda-forge

--- a/conda_recipes/maya-2026/recipe/build.sh
+++ b/conda_recipes/maya-2026/recipe/build.sh
@@ -1,0 +1,122 @@
+#!/bin/sh
+
+# Echo all the commands so debugging from log output is simpler
+set -x
+# Fail the script if any commands it runs fail
+set -euo pipefail
+
+# The version without the update number
+MAYA_VERSION=${PKG_VERSION%.*}
+# The location within $PREFIX where the RPM file extracts Maya
+AUTODESK_ROOT="usr/autodesk"
+MAYA_ROOT="$AUTODESK_ROOT/maya$MAYA_VERSION"
+INSTALL_DIR="$PREFIX/$MAYA_ROOT"
+
+cd $PREFIX
+
+# Extract the Maya RPM
+rpm2cpio "$SRC_DIR/installer/Packages"/Maya${MAYA_VERSION}_64-$PKG_VERSION-*.x86_64.rpm | cpio -idm
+
+# Remove examples, they're not needed on the farm
+rm -r "$MAYA_ROOT"/Examples
+
+# Maya needs this symlink that rpm2cpio did not create
+ln -r -s "$INSTALL_DIR/bin/maya$MAYA_VERSION" "$INSTALL_DIR/bin/maya"
+
+# Install dependencies not available on Deadline Cloud service-managed fleets
+# from the system package manager, dnf.
+mkdir -p "$SRC_DIR/download"
+cd "$SRC_DIR/download"
+dnf download --resolve -y freetype alsa-lib fontconfig harfbuzz libbrotli graphite2 \
+    libxkbfile xcb-util-cursor xcb-util-wm xcb-util-keysyms libxkbcommon-x11 \
+    libva libvdpau pciutils-libs fontconfig
+
+for RPM_FILE in *.rpm; do
+    rpm2cpio "$RPM_FILE" | cpio -idm
+done
+
+# Use patchelf to add relative RPATHs to the .so files where necessary.
+# This is to follow the recommendation of https://docs.conda.io/projects/conda-build/en/latest/resources/use-shared-libraries.html
+# to never use LD_LIBRARY_PATH in Conda environments.
+
+# The Maya RPM has libraries in both $MAYA_ROOT/lib and $MAYA_ROOT/lib/el9
+patchelf --add-rpath '$ORIGIN/../..' "$INSTALL_DIR"/lib/python*/site-packages/*.so
+patchelf --add-rpath '$ORIGIN/../..' "$INSTALL_DIR"/lib/python*/site-packages/*/*.so
+patchelf --add-rpath '$ORIGIN/../..' "$INSTALL_DIR"/lib/python*/lib-dynload/*.so
+patchelf --add-rpath '$ORIGIN/../../el9' "$INSTALL_DIR"/lib/python*/lib-dynload/*.so
+
+# Copy the .so libraries to the Maya lib directory, adding to their RPATHs so they see each other
+find . -type f,l -iname "*.so.*" -exec patchelf --add-rpath '$ORIGIN/.' {} \;
+find . -type f,l -iname "*.so.*" -exec cp -P {} "$INSTALL_DIR/lib/" \;
+
+# Add RPATH for libraries in $MAYA_ROOT/lib that lack one, allowing them to
+# find dependencies in their own directory
+for file in "$INSTALL_DIR/lib"/*; do
+    if file "$file" | grep -q "ELF"; then
+        if [[ -z "$(patchelf --print-rpath "$file")" ]]; then
+            patchelf --set-rpath "\$ORIGIN" "$file"
+        fi
+    fi
+done
+
+# Create symlinks
+mkdir -p $PREFIX/bin
+ln -r -s $PREFIX/$MAYA_ROOT/bin/maya$MAYA_VERSION $PREFIX/bin/maya$MAYA_VERSION
+ln -r -s $PREFIX/$MAYA_ROOT/bin/maya$MAYA_VERSION $PREFIX/bin/maya
+ln -r -s $PREFIX/$MAYA_ROOT/bin/mayapy.bin $PREFIX/bin/mayapy.bin
+ln -r -s $PREFIX/$MAYA_ROOT/bin/mayapy $PREFIX/bin/mayapy
+ln -r -s $PREFIX/$MAYA_ROOT/bin/Render $PREFIX/bin/Render
+
+# Use thin client licensing configuration to use the ProductInformation.pit from the Arnold installation.
+#
+# To learn more, see the Autodesk article "Thin Client Licensing for Maya and MotionBuilder"
+# at https://www.autodesk.com/support/technical/article/caas/tsarticles/ts/2zqRBCuGDrcPZDzULJQ27p.html
+# and the Arnold support tip "error: (44) Product key not found"
+# at https://arnoldsupport.com/2022/02/02/error-44-product-key-not-found/.
+
+unzip -j "$SRC_DIR/installer/Packages/package.zip" bin/ProductInformation.pit -d "$INSTALL_DIR"
+
+cat <<EOF > "$INSTALL_DIR"/AdlmThinClientCustomEnv.xml
+<?xml version="1.0"encoding="utf-8"?>
+<ADLMCUSTOMENV VERSION="1.0.0.0">
+   <PLATFORM OS="Linux">
+       <KEY ID="ADLM_PIT_FILE_LOCATION">
+       <!--Path to the ProductInformation.pit file-->
+       <!--Default: /var/opt/Autodesk/Adlm/.config-->
+       <STRING>$INSTALL_DIR/lib</STRING>
+       </KEY>
+   </PLATFORM>
+</ADLMCUSTOMENV>
+EOF
+
+# See https://docs.conda.io/projects/conda/en/latest/dev-guide/deep-dives/activation.html
+# for details on activation.
+
+# Activation scripts to set/unset environment variables
+mkdir -p "$PREFIX/etc/conda/activate.d"
+cat <<EOF > "$PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.sh"
+export MAYA_LOCATION="\$CONDA_PREFIX/$MAYA_ROOT"
+export MAYA_VERSION="$MAYA_VERSION"
+
+# Turn off the Maya application home for the render farm
+export MAYA_NO_HOME=1
+
+# Set the Maya module path to include the virtual environment equivalent of the default system module paths
+export MAYA_MODULE_PATH="\$CONDA_PREFIX/usr/autodesk/maya$MAYA_VERSION/modules:\$CONDA_PREFIX/usr/autodesk/modules/maya/$MAYA_VERSION:\$CONDA_PREFIX/usr/autodesk/modules/maya"
+
+# Set thin client mode to use the correct ProductInformation.pit file
+export AUTODESK_ADLM_THINCLIENT_ENV='$INSTALL_DIR/AdlmThinClientCustomEnv.xml'
+export MAYA_LEGACY_THINCLIENT=1
+EOF
+cat "$PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.sh"
+
+mkdir -p "$PREFIX/etc/conda/deactivate.d"
+cat <<EOF > "$PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.sh"
+unset MAYA_LEGACY_THINCLIENT
+unset AUTODESK_ADLM_THINCLIENT_ENV
+unset MAYA_MODULE_PATH
+unset MAYA_NO_HOME
+unset MAYA_VERSION
+unset MAYA_LOCATION
+EOF
+cat "$PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.sh"

--- a/conda_recipes/maya-2026/recipe/meta.yaml
+++ b/conda_recipes/maya-2026/recipe/meta.yaml
@@ -1,0 +1,39 @@
+# Recipe in conda-build format.
+
+# See https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html for information
+# about this file.
+
+{% set version = "2026.0" %}
+{% set major_version = "2026" %}
+{% set minor_version = "0" %}
+
+package:
+  name: maya
+  version: {{ version }}
+
+source:
+  url: archive_files/Autodesk_Maya_{{ major_version }}_Linux_64bit.tgz
+  sha256: d3e8cc63ea573383eb02046398a9f49c26cb55708eb8fb6266d04c46a5d6a48e
+  folder: installer
+
+build:
+  number: 0
+  detect_binary_files_with_prefix: false
+  binary_relocation: false
+  missing_dso_whitelist:
+    - "**"
+
+requirements:
+  build:
+    - patchelf
+
+test:
+  commands:
+    - mayapy --help
+    - mayapy -c 'import maya; import maya.standalone; import maya.OpenMaya as om1; import maya.api.OpenMaya as om2; maya.standalone.initialize(); print("Hello from mayapy"); maya.standalone.uninitialize()'
+    - maya -batch -command 'print "Hello from maya -batch"; quit -exitCode 0 -force'
+
+about:
+  home: https://www.autodesk.com/products/maya/overview
+  license: LicenseRef-AutodeskEULA
+  summary: Maya is professional 3D software for creating realistic characters and blockbuster-worthy effects.

--- a/conda_recipes/maya-2026/recipe/recipe.yaml
+++ b/conda_recipes/maya-2026/recipe/recipe.yaml
@@ -1,0 +1,47 @@
+# Recipe in rattler-build format.
+# See https://prefix-dev.github.io/rattler-build/latest/
+
+context:
+  version: "2026.0"
+  major_version: "2026"
+  minor_version: "0"
+
+package:
+  name: maya
+  version: ${{ version }}
+
+source:
+  url: file://archive_files/Autodesk_Maya_{{ major_version }}_Linux_64bit.tgz
+  sha256: d3e8cc63ea573383eb02046398a9f49c26cb55708eb8fb6266d04c46a5d6a48e
+  target_directory: installer
+
+build:
+  number: 0
+  # These build options for repackaging an application
+  # https://prefix-dev.github.io/rattler-build/latest/build_options/#prefix-detection-replacement-options
+  prefix_detection:
+    ignore_binary_files: True
+  # https://prefix-dev.github.io/rattler-build/latest/build_options/#dynamic-linking-configuration
+  dynamic_linking:
+    binary_relocation: False
+    missing_dso_allowlist:
+    - "**"
+
+requirements:
+  build:
+    - patchelf
+
+tests:
+   - script:
+     # Maya's Python interpreter
+     - mayapy --help
+     # Confirm that mayapy can initialize maya.standalone, and that both OpenMaya 1.0 and 2.0 are available
+     - mayapy -c 'import maya; import maya.standalone; import maya.OpenMaya as om1; import maya.api.OpenMaya as om2; maya.standalone.initialize(); print("Hello from mayapy"); maya.standalone.uninitialize()'
+     # The maya -batch command
+     - maya -batch -command 'print "Hello from maya -batch"; quit -exitCode 0 -force'
+
+
+about:
+  homepage: https://www.autodesk.com/products/maya/overview
+  license: LicenseRef-AutodeskEULA
+  summary: Maya is professional 3D software for creating realistic characters and blockbuster-worthy effects.


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Need a sample recipe for supporting Maya 2026 for Linux 64.

### What was the solution? (How)
Started with the [Maya 2025 recipe](https://github.com/aws-deadline/deadline-cloud-samples/blob/mainline/conda_recipes/maya-2025/recipe/build.sh) as a base, and made changes to get it working with Maya 2026.
- Added a [couple necessary packages](https://github.com/aws-deadline/deadline-cloud-samples/pull/112/files#diff-a854d8860c8eaaf3849a73535b58c8106f21e07996f04d2248317b48bf2276bbR32) with dnf
- Removed [adding to the PATH variable](https://github.com/aws-deadline/deadline-cloud-samples/blob/6972c3d0369f2402ff180440e6fa0bf8f975d0df/conda_recipes/maya-2025/recipe/build.sh#L94), since it could cause issues
- Added [RPATHS for libraries](https://github.com/aws-deadline/deadline-cloud-samples/pull/112/files#diff-a854d8860c8eaaf3849a73535b58c8106f21e07996f04d2248317b48bf2276bbR54) that do not have an existing RPATH to find necessary dependencies
- Removed [unnecessary workarounds](https://github.com/aws-deadline/deadline-cloud-samples/blob/6972c3d0369f2402ff180440e6fa0bf8f975d0df/conda_recipes/maya-2025/recipe/build.sh#L51), since the rattler-build issue seems to have been [fixed](https://github.com/prefix-dev/rattler-build/issues/1191).

### What is the impact of this change?
With this recipe, Maya 2026 can be built and run, and can use this to submit a job.

### How was this change tested?

- Added Maya 2026 installation file to `archive_files`
- Ran `./submit-package-job maya-2026 -p linux-64`
- Built successfully on Deadline Cloud Monitor
[Entire Rattler Build Log](https://github.com/user-attachments/files/21396456/Starter.Deadline.Cloud.Farm_Package.Build.Queue_session-3f2ddae8a4624348bf3919bdc6537af4.log)
<img width="1260" height="197" alt="image" src="https://github.com/user-attachments/assets/163d67cc-d0cd-4f73-a270-80bad962c99c" />

- Used the Maya submitter with the Maya 2026 package to submit a test job, which succeeded
[Entire test job log](https://github.com/user-attachments/files/21396499/Starter.Deadline.Cloud.Farm_Production.Job.Queue_session-b4861d0310ec47f48a973765c7f4927c.log)

<img width="803" height="188" alt="image" src="https://github.com/user-attachments/assets/60332362-5b19-471a-8ae7-f71f18d75e39" />

[Build log with Conda](https://github.com/user-attachments/files/21419735/Starter.Deadline.Cloud.Farm_Package.Build.Queue_session-abebfdf7511d40cb91283bd29211e074.log)
[Test Job log with Conda](https://github.com/user-attachments/files/21419872/Starter.Deadline.Cloud.Farm_Production.Job.Queue_session-08849d681e9a4412b7fc482cf1a11952.log)


### Was this change documented?

Added readme

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*