### PR TITLE
feat: Add Nuke render job bundle sample

### DIFF
--- a/job_bundles/README.md
+++ b/job_bundles/README.md
@@ -58,6 +58,7 @@ and a short script that substitutes job parameters and the Frame task parameter 
 * [afterfx_render_one_task](afterfx_render_one_task)
 * [maya_cli_render](maya_cli_render)
 * [houdini_husk_usd_render](houdini_husk_usd_render)
+* [nuke_render](nuke_render)
 * [vray_render](vray_render/template.yaml)
 
 If you've created a similar job for your favorite DCC, see [CONTRIBUTING.md](../CONTRIBUTING.md) for how to add it here.

--- a/job_bundles/nuke_render/README.md
+++ b/job_bundles/nuke_render/README.md
@@ -1,0 +1,102 @@
+# Nuke Render Job Bundle
+
+## Job summary
+
+This job bundle renders Nuke scripts using Nuke's headless rendering mode with the `nuke -x` command.
+
+To run it, you will need a Nuke installation available in the PATH in one of the following ways:
+* As a conda package when your queue has a conda queue environment set up to
+  provide virtual environments for jobs. For more information see the developer guide section
+  [Provide applications for your jobs](https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/provide-applications.html).
+* Installed on the worker hosts that run the job. You can customize your Deadline Cloud
+  queues, fleets, and this job to fit your own production pipeline.
+
+The core of this job is an embedded bash script that runs the `nuke` command with these flags:
+* `-F {frame}` - Renders a specific frame number
+* `--sro` - Skip render output logging
+* `-V 2` - Set verbosity level to 2
+* `-x` - Execute the script without opening the GUI
+
+The job creates one task per frame using Open Job Description's parameter space feature,
+where the Frames parameter (e.g. "1-10") gets expanded into individual frame tasks.
+The job is restricted to Linux workers through host requirements.
+
+## What this sample does
+
+This job bundle takes a Nuke script file and renders it frame by frame using Nuke's command-line interface. The sample includes:
+
+- **MotionBlur3D Scene**: A pre-configured Nuke script that demonstrates 3D motion blur effects
+- **Frame-based rendering**: Supports single frames or frame ranges
+- **Flexible output**: Configurable output directory and project paths
+- **Environment support**: Works with both Conda and Rez package management systems
+
+## Requirements
+
+- Nuke installed and available in your queue environment
+- A queue environment configured with Nuke packages (see [queue environments](../../queue_environments/README.md))
+- The `deadline` CLI configured for your farm
+
+## Sample scene
+
+The included `scene/motionblur3d_10.nk` file is based on Foundry's MotionBlur3D example, configured with:
+- Relative file paths for portability
+- Pre-configured Write node for output
+- 3D geometry with motion blur effects
+
+## Job submission
+
+### CLI submission
+
+Submit the job with default parameters:
+
+```bash
+deadline bundle submit job_bundles/nuke_render
+```
+
+Submit with custom parameters:
+
+```bash
+deadline bundle submit job_bundles/nuke_render \
+  --name "My Nuke Render" \
+  -p Frames="1-10" \
+  -p NukeScript="/path/to/my/script.nk" \
+  -p OutputDir="/path/to/output"
+```
+
+### GUI submission
+
+Launch the GUI submitter to interactively configure parameters:
+
+```bash
+deadline bundle gui-submit job_bundles/nuke_render
+```
+
+## Parameters
+
+### Render Parameters
+
+- **Nuke Script File**: Path to the .nk script file to render
+- **Frames**: Frame range (e.g., "1-10", "1,5,10", or "1")
+- **Project Directory**: Working directory containing the script and assets
+- **Output Directory**: Where rendered frames will be saved
+
+### Software Environment
+
+- **Conda Packages**: Conda packages to install (default: "nuke nuke-openjd")
+- **Rez Packages**: Rez packages to install if using Rez environments
+
+## Expected output
+
+When rendered, the sample scene produces:
+- Rendered frames in the specified output directory
+- 3D composited images with motion blur effects
+- Output files named according to the Write node configuration in the Nuke script
+
+## Customizing the job
+
+To use this template with your own Nuke scripts:
+
+1. Replace the sample scene file or point to your own .nk file
+2. Adjust the frame range as needed
+3. Configure output paths and directories
+4. Add any additional assets via job attachments

--- a/job_bundles/nuke_render/scene/motionblur3d_10.nk
+++ b/job_bundles/nuke_render/scene/motionblur3d_10.nk
@@ -1,0 +1,216 @@
+#! D:/Programs/Nuke13.2v4/nuke-13.2.4.dll -nx
+#write_info Write1 file:"nuke_output/motionblur3d_output_%04d.png" format:"2048 1556 1" chans:":rgba.red:rgba.green:rgba.blue:" framerange:"1 100" fps:"0" colorspace:"default (sRGB)" datatype:"8 bit" transfer:"unknown" views:"main" colorManagement:"Nuke"
+version 13.2 v4
+define_window_layout_xml {<?xml version="1.0" encoding="UTF-8"?>
+<layout version="1.0">
+    <window x="0" y="0" w="1917" h="1018" screen="0">
+        <splitter orientation="1">
+            <split size="40"/>
+            <dock id="" hideTitles="1" activePageId="Toolbar.1">
+                <page id="Toolbar.1"/>
+            </dock>
+            <split size="1254" stretch="1"/>
+            <splitter orientation="2">
+                <split size="573"/>
+                <dock id="" activePageId="Viewer.1" focus="true">
+                    <page id="Viewer.1"/>
+                </dock>
+                <split size="403"/>
+                <dock id="" activePageId="DAG.1">
+                    <page id="DAG.1"/>
+                    <page id="Curve Editor.1"/>
+                    <page id="DopeSheet.1"/>
+                </dock>
+            </splitter>
+            <split size="615"/>
+            <dock id="" activePageId="Properties.1">
+                <page id="Properties.1"/>
+                <page id="uk.co.thefoundry.backgroundrenderview.1"/>
+            </dock>
+        </splitter>
+    </window>
+</layout>
+}
+Root {
+ inputs 0
+ name motionblur3d_10.nk
+ project_directory "\[python \{nuke.script_directory()\}]"
+ frame 20
+ format "2048 1556 0 0 2048 1556 1 2K_Super_35(full-ap)"
+ proxy_type scale
+ proxy_format "1024 778 0 0 1024 778 1 1K_Super_35(full-ap)"
+ colorManagement Nuke
+ workingSpaceLUT linear
+ monitorLut sRGB
+ monitorOutLUT rec709
+ int8Lut sRGB
+ int16Lut sRGB
+ logLut Cineon
+ floatLut linear
+}
+StickyNote {
+ inputs 0
+ name StickyNote1
+ tile_color 0x9b9b9bff
+ label "While similar to the MotionBlur2D node \nin that it does not produce motion blur \nindependently, MotionBlur3D is designed \nspecifically for camera moves rather \nthan 2D transforms.\n\nIt generates motion vectors from\nfootage and a camera input. \nIf a z-depth channel is available,\nthis is also taken into account.\n\nThe generated motion vectors can\nthen be used in the VectorBlur node\nto apply motion blur to the footage.\n\n"
+ note_font_size 18
+ xpos -586
+ ypos -270
+}
+Camera2 {
+ inputs 0
+ translate {{curve i x1 -3.730796576 x7 5.078611374 x10 7.377658844 x16 5.452919006 x18 4.485298634 3.046649694} {curve i x1 3.436206818 x7 5.077408791 x10 5.380681515 x16 4.597033501 x18 3.988295555 3.570898533} {curve i x1 10.02727699 x7 7.394742012 x10 5.295120716 x16 0.2301386297 x18 -1.379944086 -2.820096016}}
+ rotate {{curve i x1 -17.79999733 x10 -30.20003128 x20 -39.80005264} {curve i x1 -16.80001259 x10 47.39998245 x20 132.6000366} {curve i x1 0 x10 0 x20 0}}
+ name Camera1
+ xpos 64
+ ypos -129
+}
+set Ne89a2400 [stack 0]
+Dot {
+ name Dot1
+ xpos 88
+ ypos -45
+}
+push $Ne89a2400
+Light2 {
+ inputs 0
+ intensity 1.3
+ translate {0.9146963954 1.1832937 0.9894348383}
+ rotate {-21.40003586 46.40003204 0}
+ name Light1
+ xpos -200
+ ypos -220
+}
+Constant {
+ inputs 0
+ channels rgb
+ color {0.1083612218 0.06631816924 0.3199999928 0}
+ name Constant2
+ xpos 17
+ ypos -510
+}
+Shuffle {
+ alpha white
+ name Shuffle1
+ xpos 17
+ ypos -420
+}
+Phong {
+ name Phong2
+ xpos 17
+ ypos -349
+}
+Sphere {
+ translate {1 0 0}
+ uniform_scale 0.68
+ name Sphere1
+ xpos 17
+ ypos -298
+}
+Constant {
+ inputs 0
+ channels rgb
+ color {0.053299997 0.09904222935 0.4099999964 0}
+ name Constant1
+ xpos -100
+ ypos -508
+}
+Shuffle {
+ alpha white
+ name Shuffle2
+ xpos -100
+ ypos -419
+}
+Phong {
+ diffuse 0.7
+ specular 0.98
+ min_shininess 9.4
+ max_shininess 12.6
+ name Phong1
+ xpos -100
+ ypos -350
+}
+Cube {
+ translate {-1 0 0}
+ name Cube1
+ xpos -100
+ ypos -296
+}
+CheckerBoard2 {
+ inputs 0
+ name CheckerBoard1
+ xpos -212
+ ypos -509
+}
+Phong {
+ diffuse 0.06
+ specular 0.28
+ name Phong3
+ xpos -212
+ ypos -349
+}
+Card2 {
+ translate {0 -0.7 0}
+ rotate {90 0 0}
+ uniform_scale 30
+ control_points {3 3 3 6
+
+1 {-0.5 -0.5 0} 0 {0.1666666865 0 0} 0 {0 0 0} 0 {0 0.1666666865 0} 0 {0 0 0} 0 {0 0 0}
+1 {0 -0.5 0} 0 {0.1666666716 0 0} 0 {-0.1666666716 0 0} 0 {0 0.1666666865 0} 0 {0 0 0} 0 {0.5 0 0}
+1 {0.5 -0.5 0} 0 {0 0 0} 0 {-0.1666666865 0 0} 0 {0 0.1666666865 0} 0 {0 0 0} 0 {1 0 0}
+1 {-0.5 0 0} 0 {0.1666666865 0 0} 0 {0 0 0} 0 {0 0.1666666716 0} 0 {0 -0.1666666716 0} 0 {0 0.5 0}
+1 {0 0 0} 0 {0.1666666716 0 0} 0 {-0.1666666716 0 0} 0 {0 0.1666666716 0} 0 {0 -0.1666666716 0} 0 {0.5 0.5 0}
+1 {0.5 0 0} 0 {0 0 0} 0 {-0.1666666865 0 0} 0 {0 0.1666666716 0} 0 {0 -0.1666666716 0} 0 {1 0.5 0}
+1 {-0.5 0.5 0} 0 {0.1666666865 0 0} 0 {0 0 0} 0 {0 0 0} 0 {0 -0.1666666865 0} 0 {0 1 0}
+1 {0 0.5 0} 0 {0.1666666716 0 0} 0 {-0.1666666716 0 0} 0 {0 0 0} 0 {0 -0.1666666865 0} 0 {0.5 1 0}
+1 {0.5 0.5 0} 0 {0 0 0} 0 {-0.1666666865 0 0} 0 {0 0 0} 0 {0 -0.1666666865 0} 0 {1 1 0} }
+ name Card1
+ xpos -212
+ ypos -295
+}
+Scene {
+ inputs 4
+ name Scene1
+ xpos -90
+ ypos -220
+}
+push 0
+ScanlineRender {
+ inputs 3
+ motion_vectors_type velocity
+ name ScanlineRender1
+ xpos -100
+ ypos -108
+}
+MotionBlur3D {
+ inputs 2
+ Z depth.Z
+ name MotionBlur3D1
+ xpos -100
+ ypos -48
+}
+VectorBlur2 {
+ uv motion
+ scale 2
+ name VectorBlur2_1
+ xpos -100
+ ypos 20
+}
+set N9fd22800 [stack 0]
+Viewer {
+ frame 20
+ frame_range 1-100
+ monitorOutOutputTransform rec709
+ name Viewer1
+ xpos -100
+ ypos 95
+}
+push $N9fd22800
+Write {
+ file nuke_output/motionblur3d_output_####.png
+ file_type png
+ checkHashOnRead false
+ name Write1
+ xpos -4
+ ypos 95
+}

--- a/job_bundles/nuke_render/template.yaml
+++ b/job_bundles/nuke_render/template.yaml
@@ -1,0 +1,119 @@
+specificationVersion: 'jobtemplate-2023-09'
+name: Nuke Render
+description: |
+  This job bundle renders Nuke scripts using Nuke's headless rendering mode.
+  
+  To run it, you will need a Nuke installation available in the PATH in one of the following ways:
+    * As a conda package when your queue has a conda queue environment set up to
+      provide virtual environments for jobs.
+    * Installed on the worker hosts that run the job. You can customize your Deadline Cloud
+      queue, fleets, and this job to fit your own production pipeline.
+
+parameterDefinitions:
+
+# Render Parameters
+- name: NukeScript
+  type: PATH
+  objectType: FILE
+  dataFlow: IN
+  userInterface:
+    control: CHOOSE_INPUT_FILE
+    label: Nuke Script File
+    groupLabel: Render Parameters
+    fileFilters:
+    - label: Nuke Script Files
+      patterns: ["*.nk"]
+    - label: All Files
+      patterns: ["*"]
+  minLength: 1
+  default: "./scene/motionblur3d_10.nk"
+  description: >
+    Choose the Nuke script file you want to render. Use the 'Job Attachments' tab
+    to add additional assets that the job needs.
+- name: Frames
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Frames
+    groupLabel: Render Parameters
+  default: "1"
+  description: Frame range to render (e.g., "1-10" or "1,5,10").
+- name: ProjectPath
+  type: PATH
+  objectType: DIRECTORY
+  dataFlow: INOUT
+  userInterface:
+    control: CHOOSE_DIRECTORY
+    label: Project Directory
+    groupLabel: Render Parameters
+  default: "./scene"
+  description: Choose the project working directory containing the Nuke script and assets.
+- name: OutputDir
+  type: PATH
+  objectType: DIRECTORY
+  dataFlow: OUT
+  userInterface:
+    control: CHOOSE_DIRECTORY
+    label: Output Directory
+    groupLabel: Render Parameters
+  default: "./scene/nuke_output"
+  description: Choose the render output directory.
+
+# Software Environment
+- name: CondaPackages
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Conda Packages
+    groupLabel: Software Environment
+  default: "nuke nuke-openjd"
+  description: >
+    Conda packages to install for the render. 
+    Example: "nuke=16.* nuke-openjd" or "nuke nuke-openjd"
+- name: RezPackages
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Rez Packages
+    groupLabel: Software Environment
+  default: "nuke"
+  description: >
+    If you have a Queue Environment that creates a Rez environment from a parameter called RezPackages, this will
+    tell it to install nuke.
+
+steps:
+- name: NukeRender
+  parameterSpace:
+    taskParameterDefinitions:
+    - name: Frame
+      type: INT
+      range: "{{Param.Frames}}"
+  script:
+    actions:
+      onRun:
+        command: bash
+        args: ['{{Task.File.Render}}']
+        cancelation:
+          mode: NOTIFY_THEN_TERMINATE
+    embeddedFiles:
+    - name: Render
+      type: TEXT
+      data: |
+        # Configure the task to fail if any individual command fails.
+        set -xeuo pipefail
+        
+        echo "Nuke script is {{Param.NukeScript}}"
+        cd '{{Param.ProjectPath}}'
+        
+        # Create output directory if it doesn't exist
+        mkdir -p '{{Param.OutputDir}}'
+        
+        # Render the frame using Nuke
+        nuke -F {{Task.Param.Frame}} \
+             --sro -V 2 \
+             -x '{{Param.NukeScript}}'
+  hostRequirements:
+    attributes:
+    - name: attr.worker.os.family
+      anyOf:
+      - linux


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The deadline-cloud-samples repository was missing a Nuke render job bundle sample.

### What was the solution? (How)

Created a complete Nuke render job bundle with OJD 2023-09 template, MotionBlur3D sample scene, and documentation. Uses Nuke's headless rendering (`nuke -x`) with frame-based task distribution.

### What is the impact of this change?

Users can now render Nuke scripts on AWS Deadline Cloud with a ready-to-use template that follows established DCC sample patterns.

### How was this change tested?

- Successfully submitted via CLI: `deadline bundle submit job_bundles/nuke_render`

### Was this change documented?

Yes - comprehensive README.md with usage instructions and integration added to main job bundles index.
