### PR TITLE
fix: update VREDCore conda recipe build scripts and cleanup

### DIFF
--- a/conda_recipes/vredcore-2025/recipe/build.sh
+++ b/conda_recipes/vredcore-2025/recipe/build.sh
@@ -12,9 +12,8 @@ $SRC_DIR/installer/VREDCore-2025.sh --target $INSTALL_DIR
 # from the system package manager, dnf.
 mkdir -p "$SRC_DIR/download"
 cd "$SRC_DIR/download"
-dnf download --resolve -y xorg-x11-server-Xorg \
-    pixman libXfont2 libepoxy cairo xkbcomp libunwind libgudev \
-    libX11-xcb xorg-x11-server-common xorg-x11-xauth \
+dnf download --resolve -y xorg-x11-server-Xorg xorg-x11-server-common \
+    libX11-xcb pixman libXfont2 libepoxy cairo xkbcomp libunwind libgudev \
     freetype fontconfig harfbuzz libbrotli graphite2 libfontenc \
     xcb-util-cursor libXfixes libXdmcp libxkbfile
 
@@ -22,8 +21,6 @@ dnf download --resolve -y xorg-x11-server-Xorg \
 for rpm_file in $(realpath $SRC_DIR/download/*.rpm); do
     rpm2cpio "$rpm_file" | cpio -idm
 done
-
-patchelf --add-rpath '$ORIGIN/../..' "$INSTALL_DIR"/lib/python*/lib-dynload/*.so
 
 # Copy and patch shared libraries
 for SO_FILE in $(find usr/lib64 -type f,l); do
@@ -80,7 +77,6 @@ for PYSO in "$INSTALL_DIR"/lib/python*/site-packages/*/*.so \
 done
 
 # Xorg tries to call /usr/lib/xkbcomp. This switches that to just call xkbcmp, a symlink to the original
-# # ln -sf $INSTALL_DIR/usr/bin/xkbcomp $INSTALL_DIR/usr/bin/xkbcmp
 python <<EOF
 with open("$INSTALL_DIR/usr/libexec/Xorg", "rb+") as fh:
     data = fh.read()
@@ -98,17 +94,17 @@ with open("$INSTALL_DIR/usr/libexec/Xorg", "rb+") as fh:
     fh.write(data)
 EOF
 
-# Patches Xorg.wrap binary to redirect hardcoded paths to /tmp/xorg.
-# - /usr/libexec -> /tmp/xorg (for executable lookup)
-# - /etc/X11/Xwrapper.config -> /tmp/xorg/Xwrapper.conf (for config)
+# Patches Xorg.wrap binary to redirect hardcoded paths to usr/libexec.
+# - /usr/libexec -> usr/libexec (for executable lookup)
+# - /etc/X11/Xwrapper.config -> usr/libexec/Xwrap.cfg (for config)
 # These modifications allow Xorg to work with files in conda-managed locations 
-# via symlinks that will be created to /tmp/xorg.
+# via symlinks that will be created to usr/libexec.
 python <<EOF
 with open("$INSTALL_DIR/usr/libexec/Xorg.wrap", "rb+") as fh:
     data = fh.read()
 
     old_path = b"/usr/libexec"
-    new_path = "/tmp/xorg".encode()
+    new_path = "usr/libexec".encode()
     if len(new_path) <= len(old_path):
         new_path = new_path.ljust(len(old_path), b'\0')
         data = data.replace(old_path, new_path)
@@ -118,7 +114,7 @@ with open("$INSTALL_DIR/usr/libexec/Xorg.wrap", "rb+") as fh:
         )
 
     old_config_path = b"/etc/X11/Xwrapper.config"
-    new_config_path = "/tmp/xorg/Xwrapper.conf".encode()
+    new_config_path = "usr/libexec/Xwrap.cfg".encode()
     if len(new_config_path) <= len(old_config_path):
         new_config_path = new_config_path.ljust(len(old_config_path), b'\0')
         data = data.replace(old_config_path, new_config_path)
@@ -155,27 +151,35 @@ sed -i "/^Section \"Files\"/a\\
     ModulePath \"$PREFIX/opt/Autodesk/VRED_2025/lib\"" $INSTALL_DIR/etc/X11/xorg.conf
 
 # Create symbolic link
-ln -sf $INSTALL_DIR/usr/libexec /tmp/xorg
 ln -sf $INSTALL_DIR/usr/bin/xkbcomp $INSTALL_DIR/usr/bin/xkbcmp
 
 # Create a Xorg wrapper config file
-# This should has symlink setup: /tmp/xorg/Xwrapper.conf --> $INSTALL_DIR/usr/libexec/Xwrapper.conf
-if [ -f  $INSTALL_DIR/usr/libexec/Xwrapper.conf ]; then
+if [ -f  $INSTALL_DIR/usr/libexec/Xwrap.cfg ]; then
   echo "Xwrapper Config file already exists"
 else
   echo "Creating a new Xwrapper Config"
   mkdir -p $INSTALL_DIR/usr/libexec
-  cat << EOF2 > $INSTALL_DIR/usr/libexec/Xwrapper.conf
+  cat << EOF2 > $INSTALL_DIR/usr/libexec/Xwrap.cfg
 needs_root_rights=no
 allowed_users=anybody
 EOF2
-  echo "New Xwrapper.conf file created at $INSTALL_DIR/usr/libexec/Xwrapper.conf"
-  cat $INSTALL_DIR/usr/libexec/Xwrapper.conf
+  echo "New Xwrapper conf file created at $INSTALL_DIR/usr/libexec/Xwrap.cfg"
+  cat $INSTALL_DIR/usr/libexec/Xwrap.cfg
 fi
+
+mkdir -p $INSTALL_DIR/var/run
+# Go to $INSTALL_DIR just for launching X Server
+pushd $INSTALL_DIR
 
 # Start X Server
 $INSTALL_DIR/usr/bin/Xorg -keeptty -sharevts -novtswitch -ignoreABI -nolisten tcp -config $INSTALL_DIR/etc/X11/xorg.conf &
 sleep 3
+
+# Write Xorg PID to a file
+echo \$! > "$INSTALL_DIR/var/run/xorg.pid"
+
+# Go back to the original location
+popd
 EOF
 
 chmod +x $INSTALL_DIR/bin/start-xserver
@@ -191,7 +195,6 @@ if ! pgrep -x Xorg > /dev/null; then
     $INSTALL_DIR/bin/start-xserver
 fi
 export DISPLAY=:0
-export XAUTHORITY=/tmp/.Xauthority
 
 "$INSTALL_DIR/bin/VREDCore" "\$@"
 EOF
@@ -207,5 +210,17 @@ EOF
 # Setup environment variables for deactivation
 mkdir -p "$PREFIX/etc/conda/deactivate.d"
 cat <<EOF > $PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.sh
+#!/bin/bash
+
 unset VREDCORE
+
+# Kill Xorg server if it's running
+if [ -f "$INSTALL_DIR/var/run/xorg.pid" ]; then
+    XORG_PID=\$(cat "$INSTALL_DIR/var/run/xorg.pid")
+    if ps -p \$XORG_PID > /dev/null; then
+        kill \$XORG_PID
+        # Wait for X server to completely shut down
+        sleep 2
+    fi
+fi
 EOF

--- a/conda_recipes/vredcore-2026/recipe/build.sh
+++ b/conda_recipes/vredcore-2026/recipe/build.sh
@@ -12,9 +12,8 @@ $SRC_DIR/installer/VREDCore-2026.sh --target $INSTALL_DIR
 # from the system package manager, dnf.
 mkdir -p "$SRC_DIR/download"
 cd "$SRC_DIR/download"
-dnf download --resolve -y xorg-x11-server-Xorg \
-    pixman libXfont2 libepoxy cairo xkbcomp libunwind libgudev \
-    libX11-xcb xorg-x11-server-common xorg-x11-xauth \
+dnf download --resolve -y xorg-x11-server-Xorg xorg-x11-server-common \
+    libX11-xcb pixman libXfont2 libepoxy cairo xkbcomp libunwind libgudev \
     freetype fontconfig harfbuzz libbrotli graphite2 libfontenc \
     xcb-util-cursor libXfixes libXdmcp libxkbfile
 
@@ -22,8 +21,6 @@ dnf download --resolve -y xorg-x11-server-Xorg \
 for rpm_file in $(realpath $SRC_DIR/download/*.rpm); do
     rpm2cpio "$rpm_file" | cpio -idm
 done
-
-patchelf --add-rpath '$ORIGIN/../..' "$INSTALL_DIR"/lib/python*/lib-dynload/*.so
 
 # Copy and patch shared libraries
 for SO_FILE in $(find usr/lib64 -type f,l); do
@@ -80,7 +77,6 @@ for PYSO in "$INSTALL_DIR"/lib/python*/site-packages/*/*.so \
 done
 
 # Xorg tries to call /usr/lib/xkbcomp. This switches that to just call xkbcmp, a symlink to the original
-# # ln -sf $INSTALL_DIR/usr/bin/xkbcomp $INSTALL_DIR/usr/bin/xkbcmp
 python <<EOF
 with open("$INSTALL_DIR/usr/libexec/Xorg", "rb+") as fh:
     data = fh.read()
@@ -98,17 +94,17 @@ with open("$INSTALL_DIR/usr/libexec/Xorg", "rb+") as fh:
     fh.write(data)
 EOF
 
-# Patches Xorg.wrap binary to redirect hardcoded paths to /tmp/xorg.
-# - /usr/libexec -> /tmp/xorg (for executable lookup)
-# - /etc/X11/Xwrapper.config -> /tmp/xorg/Xwrapper.conf (for config)
+# Patches Xorg.wrap binary to redirect hardcoded paths to usr/libexec.
+# - /usr/libexec -> usr/libexec (for executable lookup)
+# - /etc/X11/Xwrapper.config -> usr/libexec/Xwrap.cfg (for config)
 # These modifications allow Xorg to work with files in conda-managed locations 
-# via symlinks that will be created to /tmp/xorg.
+# via symlinks that will be created to usr/libexec.
 python <<EOF
 with open("$INSTALL_DIR/usr/libexec/Xorg.wrap", "rb+") as fh:
     data = fh.read()
 
     old_path = b"/usr/libexec"
-    new_path = "/tmp/xorg".encode()
+    new_path = "usr/libexec".encode()
     if len(new_path) <= len(old_path):
         new_path = new_path.ljust(len(old_path), b'\0')
         data = data.replace(old_path, new_path)
@@ -118,7 +114,7 @@ with open("$INSTALL_DIR/usr/libexec/Xorg.wrap", "rb+") as fh:
         )
 
     old_config_path = b"/etc/X11/Xwrapper.config"
-    new_config_path = "/tmp/xorg/Xwrapper.conf".encode()
+    new_config_path = "usr/libexec/Xwrap.cfg".encode()
     if len(new_config_path) <= len(old_config_path):
         new_config_path = new_config_path.ljust(len(old_config_path), b'\0')
         data = data.replace(old_config_path, new_config_path)
@@ -155,27 +151,35 @@ sed -i "/^Section \"Files\"/a\\
     ModulePath \"$PREFIX/opt/Autodesk/VRED_2026/lib\"" $INSTALL_DIR/etc/X11/xorg.conf
 
 # Create symbolic link
-ln -sf $INSTALL_DIR/usr/libexec /tmp/xorg
 ln -sf $INSTALL_DIR/usr/bin/xkbcomp $INSTALL_DIR/usr/bin/xkbcmp
 
 # Create a Xorg wrapper config file
-# This should has symlink setup: /tmp/xorg/Xwrapper.conf --> $INSTALL_DIR/usr/libexec/Xwrapper.conf
-if [ -f  $INSTALL_DIR/usr/libexec/Xwrapper.conf ]; then
+if [ -f  $INSTALL_DIR/usr/libexec/Xwrap.cfg ]; then
   echo "Xwrapper Config file already exists"
 else
   echo "Creating a new Xwrapper Config"
   mkdir -p $INSTALL_DIR/usr/libexec
-  cat << EOF2 > $INSTALL_DIR/usr/libexec/Xwrapper.conf
+  cat << EOF2 > $INSTALL_DIR/usr/libexec/Xwrap.cfg
 needs_root_rights=no
 allowed_users=anybody
 EOF2
-  echo "New Xwrapper.conf file created at $INSTALL_DIR/usr/libexec/Xwrapper.conf"
-  cat $INSTALL_DIR/usr/libexec/Xwrapper.conf
+  echo "New Xwrapper conf file created at $INSTALL_DIR/usr/libexec/Xwrap.cfg"
+  cat $INSTALL_DIR/usr/libexec/Xwrap.cfg
 fi
+
+mkdir -p $INSTALL_DIR/var/run
+# Go to $INSTALL_DIR just for launching X Server
+pushd $INSTALL_DIR
 
 # Start X Server
 $INSTALL_DIR/usr/bin/Xorg -keeptty -sharevts -novtswitch -ignoreABI -nolisten tcp -config $INSTALL_DIR/etc/X11/xorg.conf &
 sleep 3
+
+# Write Xorg PID to a file
+echo \$! > "$INSTALL_DIR/var/run/xorg.pid"
+
+# Go back to the original location
+popd
 EOF
 
 chmod +x $INSTALL_DIR/bin/start-xserver
@@ -191,7 +195,6 @@ if ! pgrep -x Xorg > /dev/null; then
     $INSTALL_DIR/bin/start-xserver
 fi
 export DISPLAY=:0
-export XAUTHORITY=/tmp/.Xauthority
 
 "$INSTALL_DIR/bin/VREDCore" "\$@"
 EOF
@@ -207,5 +210,17 @@ EOF
 # Setup environment variables for deactivation
 mkdir -p "$PREFIX/etc/conda/deactivate.d"
 cat <<EOF > $PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.sh
+#!/bin/bash
+
 unset VREDCORE
+
+# Kill Xorg server if it's running
+if [ -f "$INSTALL_DIR/var/run/xorg.pid" ]; then
+    XORG_PID=\$(cat "$INSTALL_DIR/var/run/xorg.pid")
+    if ps -p \$XORG_PID > /dev/null; then
+        kill \$XORG_PID
+        # Wait for X server to completely shut down
+        sleep 2
+    fi
+fi
 EOF


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The VREDCore conda recipe build scripts for both 2025 and 2026 versions had several issues:
- Included `xorg-x11-xauth` dependency that is not required
- Had redundant `patchelf` command for Python libraries
- Exported unnecessary `XAUTHORITY` env variable
- **Shared symlink conflicts**: The recipe created symlinks at `/tmp/xorg`, potentially causing conflicts when multiple conda environments containing the same package were used simultaneously
- Lacked proper cleanup in the deactivation script, potentially leaving Xorg processes running after conda environment deactivation
   - the deactivation script should not use `pgrep -x Xorg` to kill ALL Xorg processes, because it would potentially terminate user's independent Xorg sessions


### What was the solution? (How)
- Remove unnecessary `xorg-x11-xauth` dependency 
- Remove redundant `patchelf` command
- Remove `XAUTHORITY` environment variable export

- Add cleanup in deactivation script to kill Xorg process
   - Store Xorg PID in a file in conda package-specific location (`$INSTALL_DIR/var/run/xorg.pid`)
   - Kill only the specific Xorg process started by this package instance

- **Simplified approach that does not need a symlink**: Remove the need for creating the temporary symlink
   - Update Xorg.wrap binary patches to use relative `usr/libexec`, instead of the absolute path `/tmp/xorg`
   - Change working directory to `$INSTALL_DIR` before launching X server, enabling relative path resolution from the package installation directory
   - After launching X, it returns to original location


### What is the impact of this change?
Improved conda recipe build script


### How was this change tested?
For both VRED 2025 and 2026:
1. Built conda package using the updated recipe
2. The resulting packages were installed in my own conda channel in a test environment. 
3. Applied [conda caching queue environment](https://github.com/aws-deadline/deadline-cloud-samples/blob/57fa7a374cbe0ac21fc145aeb43f511828c00038/queue_environments/conda_queue_env_improved_caching.yaml) to my test queue
4. Basic VRED render jobs, which requires GPU rendering, were tested to ensure the conda package is properly loaded and working.
   - The deactivation script `deactivate.d ` looks like:
   ```
   #!/bin/bash
   set -xeuo pipefail
 
   unset VREDCORE
 
   # Kill Xorg server if it's running
   if [ -f "$PREFIX/opt/Autodesk/VRED_2025/var/run/xorg.pid" ]; then
       XORG_PID=$(cat "$PREFIX/opt/Autodesk/VRED_2025/var/run/xorg.pid")
       if ps -p $XORG_PID > /dev/null; then
          kill $XORG_PID
           # Wait for X server to completely shut down
           sleep 2
       fi
   fi
   ```
   - With additional lines for debugging, (not included in this PR,) I found that it correctly captures and kills the PID for the specific Xorg started by this session, (in this example it was `16533`) in the Task logs:
   ```
   09:40:25-05:00 ⭐️ Let's check the Xorg PID...
   09:40:25-05:00 + ps aux
   09:40:25-05:00 + grep Xorg
   09:40:25-05:00 job-user   16533  7.3  0.4 25407764 71320 ?      Sl   14:40   0:00 tmp/xorg/Xorg -keeptty -sharevts -novtswitch -ignoreABI -nolisten tcp -config /home/job-user/.conda/envs/hashname_17770fd68341eb48237f1dcf/opt/Autodesk/VRED_2025/etc/X11/xorg.conf
   09:40:25-05:00 job-user   16539  0.0  0.0 222320  2052 ?        S    14:40   0:00 grep Xorg
   ...
   Exiting Environment: Conda 
   ...
   09:41:34-05:00 Command started as pid: 16955
   09:41:34-05:00 Output:
   09:41:35-05:00 +++ unset VREDCORE
   09:41:35-05:00 +++ '[' -f /home/job-user/.conda/envs/hashname_17770fd68341eb48237f1dcf/opt/Autodesk/VRED_2025/var/run/xorg.pid ']'
   09:41:35-05:00 ++++ cat /home/job-user/.conda/envs/hashname_17770fd68341eb48237f1dcf/opt/Autodesk/VRED_2025/var/run/xorg.pid
   09:41:35-05:00 +++ XORG_PID=16533
   09:41:35-05:00 +++ ps -p 16533
   09:41:35-05:00 +++ kill 16533
   09:41:35-05:00 +++ sleep 2
   ...
   09:41:41-05:00 Process pid 16955 exited with code: 0 (unsigned) / 0x0 (hex)
   ```

   - Executed test scenario with two back-to-back jobs. Verified that each job created separate conda environments, and successfully completed the rendering:
     1. Job requiring only "vredcore" 
     2. Job requiring "vredcore" and "blender" (using same worker)

### Was this change documented?
No

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*