### PR TITLE
feat: add VRED render job bundle

### DIFF
--- a/job_bundles/vred_render/README.md
+++ b/job_bundles/vred_render/README.md
@@ -1,0 +1,136 @@
+# VRED Renderer Job Bundle
+
+## Overview
+
+This job bundle is for rendering VRED scenes using either VRED Core or VRED Pro in headless mode. It uses VRED's Python API through the `VRED_RenderScript_DeadlineCloud.py` script, which:
+- Controls and executes the actual rendering process
+- Converts job template parameters into VRED API calls
+- Manages all rendering settings (quality, resolution, tiling, etc.)
+- Handles file references and error management
+
+## Available Templates
+
+This job bundle provides two template options:
+- **Basic Template** (`template.yaml`): Standard rendering functionality
+- **Tiling Template**: Additional support for region/tile-based rendering
+  - Includes all features of basic template plus tile-based rendering capability
+    - Adds a "Tile Assembly" step that combines rendered tiles into final images
+  - To use this template, rename `template_tiling.yaml` to `template.yaml`
+
+## Requirements
+
+### For Service-Managed Fleets (SMF)
+- Access to 'deadline-cloud' conda channel
+- GPU-enabled worker
+- (Optional) For tile assembly when using the `template_tiling.yaml` template, ImageMagick must be available in the rendering environment. The easiest way is to add the `imagemagick` conda package from the `conda-forge` channel to your Queue Environment. For detailed instructions on configuring conda packages, see the [Configure jobs using queue environments](https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/configure-jobs.html).
+
+### For Custom-Managed Fleets (CMF)
+- VRED Core or VRED Pro (2025.X/17.X or 2026.X/18.X)
+- Windows or Linux operating system
+- GPU with appropriate drivers
+  - Please review the [system requirements and software dependencies](https://www.autodesk.com/support/technical/article/caas/sfdcarticles/sfdcarticles/System-requirements-for-Autodesk-VRED-products.html).
+- Environment variable setup:
+  - `VREDCORE` pointing to VRED Core executable, or
+  - `VREDPRO` pointing to VRED Pro executable
+- (Optional) If using the `template_tiling.yaml` template, ImageMagick must be available in the rendering environment for tile assembly.
+
+### Required Files
+- A job template (yaml) file named `template.yaml`
+- `scripts/VRED_RenderScript_DeadlineCloud.py`: a controller script that must be present in job bundle with the provided job template
+- VRED scene file (.vpb) and/or its referenced files
+
+## Job Submission Examples
+
+### CLI Submission
+
+Submit with default parameters:
+```bash
+deadline bundle submit .
+```
+
+Submit with custom parameters:
+```bash
+deadline bundle submit . \
+  -p SceneFile="path/to/scene.vpb" \
+  -p OutputDir="path/to/output" \
+  -p ImageWidth=1920 \
+  -p ImageHeight=1080
+```
+
+### GUI Submission
+Launch the GUI submitter to interactively configure parameters:
+
+```bash
+deadline bundle gui-submit .
+```
+
+## Job Parameters
+
+### Input/Output
+- **SceneFile**: VRED scene file (.vpb) to render (must be relative path)
+- **OutputDir**: Directory for downloading rendered outputs (must be relative path)
+- **OutputFileNamePrefix**: Prefix for output filenames (default: "output")
+- **OutputFormat**: Image format (default: PNG, supports multiple formats including EXR, JPG, etc.)
+
+Note: All `PATH` type parameters must use relative paths from the current working directory. Absolute paths are not supported.
+
+### Render Settings
+- **ImageWidth**: Output width in pixels (default: 800)
+- **ImageHeight**: Output height in pixels (default: 600)
+- **DPI**: Resolution in dots per inch (default: 72)
+- **RenderQuality**: Quality preset (Analytic Low/High, Realistic Low/High, Raytracing, NPR)
+- **View**: Specific viewpoint/camera to render from
+- **GPURaytracing**: Enable GPU-accelerated ray tracing
+
+### NVIDIA DLSS Options
+- **DLSSQuality**: Deep Learning Super Sampling quality setting (Off, Performance, Balanced, Quality, Ultra Performance)
+- **SSQuality**: Supersampling quality setting (Off, Low, Medium, High, Ultra High)
+
+### Frame Control Settings
+- **StartFrame**: First frame to render (default: 0)
+- **EndFrame**: Last frame to render (default: 20)
+- **FrameStep**: Frame increment - e.g., 2 for rendering every second frame (default: 1)
+- **FramesPerTask**: Number of consecutive frames to render in a single Task (default: 1)
+    This can improve rendering efficiency by reducing overhead from task initialization.
+    Example with `FramesPerTask=5`:
+    - Task 1 renders frames 1-5
+    - Task 2 renders frames 6-10
+    - And so on...
+
+### Animation Settings
+- **RenderAnimation**: Enable animation rendering (true/false)
+- **AnimationType**: Animation type (Clip/Timeline)
+- **AnimationClip**: Name of animation clip to render
+
+### (Optional) Region/Tile-based Rendering
+This feature is available when using the tiling template (`template_tiling.yaml`).
+Tile-based rendering divides each frame into smaller tiles that are rendered independently and later assembled into the final image.
+
+**Important**: When using tile-based rendering, **GPURaytracing** must also be enabled to prevent solid black tile outputs.
+
+- **RegionRendering**: Enable tile-based rendering (true/false)
+- **NumXTiles**: Number of tiles to divide the image horizontally (default: 1)
+- **NumYTiles**: Number of tiles to divide the image vertically (default: 1)
+
+#### Process
+1. Image is divided into tiles based on NumXTiles and NumYTiles
+2. Each tile is rendered as a separate task
+3. After all tiles are rendered, a final "Tile Assembly" step combines them into the final image
+
+## Expected Output
+The renderer produces image files in the specified output directory following this naming pattern:
+- Single images: `<OutputFileNamePrefix>.<OutputFormat>`
+- Animation frames: `<OutputFileNamePrefix>-#####.<OutputFormat>`
+- Region rendering temporary files (Individual tiles): `<OutputFileNamePrefix>_YxX_AxB.<OutputFormat>` Where:
+  - Y: Vertical tile number
+  - X: Horizontal tile number
+  - A: Total number of horizontal tiles
+  - B: Total number of vertical tiles
+
+## Notes
+
+- When using conda environments, ensure your queue has access to the required conda channels (e.g., `deadline-cloud`, `conda-forge`)
+- For optimal performance with large images, consider enabling region rendering
+- GPU ray tracing requires compatible hardware
+- DLSS features require NVIDIA RTX GPUs
+- **Tile rendering**: Requires GPURaytracing to be enabled. Scene files must be properly configured (such as adding sufficient lighting) to support ray tracing, otherwise rendered images may appear black.

--- a/job_bundles/vred_render/scripts/VRED_RenderScript_DeadlineCloud.py
+++ b/job_bundles/vred_render/scripts/VRED_RenderScript_DeadlineCloud.py
@@ -1,0 +1,552 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Defines the render script (referenced by a job bundle). It is invoked by a worker node
+to initialize rendering settings and to perform rendering. It should always terminate VRED
+after rendering (or when encountering errors) to allow a render job to continue to progress.
+"""
+
+import json
+import logging
+import os
+import traceback
+
+from dataclasses import dataclass
+from enum import auto, Enum, IntEnum
+from typing import Any, Dict, List
+
+from builtins import vrCameraService, vrReferenceService  # type: ignore[attr-defined]
+from vrController import crashVred, terminateVred
+from vrOSGWidget import (
+    enableRaytracing,
+    isDLSSSupported,
+    setDLSSQuality,
+    setRenderQuality,
+    setSuperSampling,
+    setSuperSamplingQuality,
+    VR_QUALITY_ANALYTIC_HIGH,
+    VR_QUALITY_ANALYTIC_LOW,
+    VR_QUALITY_NPR,
+    VR_QUALITY_RAYTRACING,
+    VR_QUALITY_REALISTIC_HIGH,
+    VR_QUALITY_REALISTIC_LOW,
+    VR_SS_QUALITY_HIGH,
+    VR_SS_QUALITY_LOW,
+    VR_SS_QUALITY_MEDIUM,
+    VR_SS_QUALITY_OFF,
+    VR_SS_QUALITY_ULTRA_HIGH,
+    VR_DLSS_BALANCED,
+    VR_DLSS_PERFORMANCE,
+    VR_DLSS_OFF,
+    VR_DLSS_QUALITY,
+    VR_DLSS_ULTRA_PERFORMANCE,
+)
+from vrRenderSettings import (
+    getRenderFilename,
+    setRaytracingMode,
+    setRaytracingRenderRegion,
+    setRenderAlpha,
+    setRenderAnimation,
+    setRenderAnimationClip,
+    setRenderAnimationFormat,
+    setRenderAnimationType,
+    setRenderFilename,
+    setRenderFrameStep,
+    setRenderPixelResolution,
+    setRenderPremultiply,
+    setRenderRegionEndX,
+    setRenderRegionEndY,
+    setRenderRegionStartX,
+    setRenderRegionStartY,
+    setRenderStartFrame,
+    setRenderStopFrame,
+    setRenderSupersampling,
+    setRenderTonemapHDR,
+    setRenderUseClipRange,
+    setRenderView,
+    setUseRenderPasses,
+    setUseRenderRegion,
+    startRenderToFile,
+)
+from vrSequencer import runAllSequences, runSequence
+
+
+class StrEnum(str, Enum):
+    """
+    This is a backport of Python 3.11's StrEnum for compatibility with Python 3.10.
+    """
+
+    def __new__(cls, value):
+        if not isinstance(value, str):
+            raise TypeError(f"{cls.__name__} members must be strings")
+        obj = str.__new__(cls, value)
+        obj._value_ = value
+        return obj
+
+    def __str__(self):
+        return str(self.value)
+
+    @staticmethod
+    def _generate_next_value_(name: str, start: int, count: int, last_values: list) -> str:
+        return name.lower()
+
+
+class DynamicKeyValueObject:
+    def __init__(self, data_dict: Dict[str, Any]) -> None:
+        """
+        Assigns attributes and values to this object; reflect the contents of data_dict for easy attribute-based access.
+        :param: data_dict: attributes/properties and values
+        """
+        for k, v in data_dict.items():
+            setattr(self, k, v)
+
+
+class JobType(StrEnum):
+    @staticmethod
+    def _generate_next_value_(name: str, start: int, count: int, last_values: list[str]) -> str:
+        return name.capitalize()
+
+    RENDER = auto()
+    SEQUENCER = auto()
+
+
+class AnimationFormat(IntEnum):
+    IMAGE = 0
+    VIDEO = 1
+
+
+class CurrentState(IntEnum):
+    Off = 0
+    On = 1
+
+
+@dataclass
+class PathMappingRule:
+    """
+    Provides path mapping fields corresponding to those in the Deadline Cloud API
+    path mapping JSON file.
+    """
+
+    source_path_format: str
+    """The path format associated with the source path (WINDOWS vs POSIX)"""
+
+    source_path: str
+    """The path to match (convert from)"""
+
+    destination_path: str
+    """The path to transform to (from source_path)"""
+
+
+class PathFormat(StrEnum):
+    """
+    Identifies source_path format per Deadline Cloud API path mapping JSON file.
+    """
+
+    @staticmethod
+    def _generate_next_value_(name, start, count, last_values):
+        return name
+
+    POSIX = auto()
+    WINDOWS = auto()
+
+
+class DeadlineCloudRenderer:
+    # Note: keep enabled when not debugging
+    #
+    WANT_VRED_TERMINATION = True
+
+    LOGGING_FORMAT = "%(levelname)s - %(message)s"
+    LOGGING_LEVEL = logging.INFO
+
+    DLSS_QUALITY_DICT = {
+        "Off": VR_DLSS_OFF,
+        "Performance": VR_DLSS_PERFORMANCE,
+        "Balanced": VR_DLSS_BALANCED,
+        "Quality": VR_DLSS_QUALITY,
+        "Ultra Performance": VR_DLSS_ULTRA_PERFORMANCE,
+    }
+    RENDER_QUALITY_DICT = {
+        "Analytic Low": VR_QUALITY_ANALYTIC_LOW,
+        "Analytic High": VR_QUALITY_ANALYTIC_HIGH,
+        "Realistic Low": VR_QUALITY_REALISTIC_LOW,
+        "Realistic High": VR_QUALITY_REALISTIC_HIGH,
+        "Raytracing": VR_QUALITY_RAYTRACING,
+        "NPR": VR_QUALITY_NPR,
+    }
+    SS_QUALITY_DICT = {
+        "Off": VR_SS_QUALITY_OFF,
+        "Low": VR_SS_QUALITY_LOW,
+        "Medium": VR_SS_QUALITY_MEDIUM,
+        "High": VR_SS_QUALITY_HIGH,
+        "Ultra High": VR_SS_QUALITY_ULTRA_HIGH,
+    }
+    ANIMATION_TYPE_DICT = {"Clip": 0, "Timeline": 1}
+    CAMERA_FOUND = "Found camera in view list:"
+    DLSS_SUPER_SAMPLING_ASSIGNED = "Deep Learning Supersampling quality level set to:"
+    ERROR_DLSS_SUPERSAMPLING_CONFLICT = (
+        "DLSS is already enabled. Non-DLSS Supersampling will be ignored."
+    )
+    ERROR_INVALID_ANIMATION_TYPE = "Invalid animation type"
+    ERROR_INVALID_RENDER_QUALITY = "Invalid render quality"
+    ERROR_INVALID_SS_QUALITY = "Invalid Supersampling quality"
+    ERROR_INVALID_DLSS_QUALITY = "Invalid DLSS quality"
+    ERROR_START_FRAME_EXCEEDS_END_FRAME = "StartFrame exceeds EndFrame"
+    ERROR_VIEW_MISSING = "Could not find the specified camera or viewpoint name:"
+    GPU_RAYTRACING_ASSIGNED = "GPU Raytracing value set to:"
+    PATH_MAPPING_RULES_FIELD = "path_mapping_rules"
+    READ_FLAG = "r"
+    REMAPPING_FILE_REFERENCE = "Remapping file reference:"
+    RENDERING_TO_FILE = "Render output filename is:"
+    RUNNING_ALL_SEQUENCES_STARTING = "Starting to run all sequences"
+    RUNNING_SEQUENCE_STARTING = "Starting to run the following sequence:"
+    STARTING_RENDER_PROCESS = "Starting render process."
+    SUPER_SAMPLING_ASSIGNED = "Supersampling quality level set to:"
+    VALIDATING_RENDER_SETTINGS = "Validating render settings"
+    VIEWPOINT_FOUND = "Found viewpoint in view list:"
+
+    def __init__(self, render_parameters_dict: Dict[str, Any]) -> None:
+        """
+        Initializes Deadline Cloud for VRED logging and render parameters (prior to applying them later)
+        :param: render_parameters_dict: a dictionary of render parameters
+        """
+        self.logger = logging.getLogger(__name__)
+        logging.basicConfig(format=self.LOGGING_FORMAT, level=self.LOGGING_LEVEL)
+        self.path_mapping_rules: List[PathMappingRule] = []
+        self.render_parameters: Any = DynamicKeyValueObject(render_parameters_dict)
+        self.output_filename = self._get_conventional_output_filename()
+
+    def _get_conventional_output_filename(self) -> str:
+        """
+        Initializes the convention-based output filename depending on whether there are render regions enabled
+        return: output filename as a path that includes its filename as: prefix.suffix or prefix_YxX_BxA.suffix
+        (filename convention for tile-based rendering).
+        Note: tile assembly filename convention is specified in the job template and represents X, Y for tiling
+        on row (Y) and column (X), while total tiles are denoted as [# of X tiles]x[# of Y tiles] - not the reverse!
+        Tiles are initially processed left to right from top to bottom.
+        """
+        output_directory = self.render_parameters.OutputDir.strip().replace("\\", "/")
+        output_file_prefix = self.render_parameters.OutputFileNamePrefix.strip()
+        output_file_suffix = self.render_parameters.OutputFormat.strip().lower()
+        output_file_render_region_prefix = ""
+        if self.render_parameters.RegionRendering:
+            output_file_render_region_prefix = (
+                f"{self.render_parameters.TileNumberY}x"
+                f"{self.render_parameters.TileNumberX}_{self.render_parameters.NumXTiles}"
+                f"x{self.render_parameters.NumYTiles}"
+            )
+        return os.path.join(
+            output_directory,
+            f"{output_file_prefix}{output_file_render_region_prefix}.{output_file_suffix}",
+        )
+
+    def validate_parameter_in_dict(
+        self, parameter_name: str, dictionary: Dict, error_message: str
+    ) -> None:
+        """
+        Validates the existence of a parameter in a dictionary.
+        If the parameter is not found, then an error is logged and a ValueError is raised.
+        :param: parameter_name: name of parameter
+        :param: dictionary: dictionary to check for parameter_name as a key name
+        :param: error_message: message to print when parameter_name is absent in dictionary's keys
+        :raises: ValueError: if parameter_name absent in dictionary's keys
+        """
+        if parameter_name not in dictionary:
+            self.logger.error(f"{error_message}: {parameter_name}")
+            raise ValueError(f"{error_message}: {parameter_name}")
+
+    def validate_render_settings(self) -> None:
+        """
+        Validates against accepted values for specific rendering-related settings
+        :raises: ValueError: if a render setting violates its accepted values/constraints
+        """
+        self.logger.info(self.VALIDATING_RENDER_SETTINGS)
+
+        self.validate_parameter_in_dict(
+            self.render_parameters.RenderQuality,
+            self.RENDER_QUALITY_DICT,
+            self.ERROR_INVALID_RENDER_QUALITY,
+        )
+        self.validate_parameter_in_dict(
+            self.render_parameters.SSQuality,
+            self.SS_QUALITY_DICT,
+            self.ERROR_INVALID_SS_QUALITY,
+        )
+        self.validate_parameter_in_dict(
+            self.render_parameters.DLSSQuality,
+            self.DLSS_QUALITY_DICT,
+            self.ERROR_INVALID_DLSS_QUALITY,
+        )
+        self.validate_parameter_in_dict(
+            self.render_parameters.AnimationType,
+            self.ANIMATION_TYPE_DICT,
+            self.ERROR_INVALID_ANIMATION_TYPE,
+        )
+        if self.render_parameters.StartFrame > self.render_parameters.EndFrame:
+            raise ValueError(self.ERROR_START_FRAME_EXCEEDS_END_FRAME)
+
+    def perform_sequencer_job(self) -> None:
+        """
+        Performs sequencer tasks related to Sequencer-typed jobs
+        """
+        sequence_name = self.render_parameters.SequenceName
+        if not sequence_name:
+            self.logger.info(self.RUNNING_ALL_SEQUENCES_STARTING)
+            runAllSequences()
+        else:
+            self.logger.info(f"{self.RUNNING_SEQUENCE_STARTING} {sequence_name}")
+            runSequence(sequence_name)
+
+    def init_render_quality_modes(self):
+        """
+        Initializes (in VRED API) settings related to render quality modes
+        """
+        setRenderQuality(self.RENDER_QUALITY_DICT[self.render_parameters.RenderQuality])
+        supersampling_quality = self.SS_QUALITY_DICT[self.render_parameters.SSQuality]
+        dlss_quality = self.DLSS_QUALITY_DICT[self.render_parameters.DLSSQuality]
+        dlss_quality_applied = False
+        if (dlss_quality is not VR_DLSS_OFF) and isDLSSSupported():
+            self.logger.info(f"{self.DLSS_SUPER_SAMPLING_ASSIGNED} {dlss_quality}")
+            setDLSSQuality(self.DLSS_QUALITY_DICT[self.render_parameters.DLSSQuality])
+            dlss_quality_applied = True
+        if supersampling_quality is not VR_SS_QUALITY_OFF:
+            if dlss_quality_applied:
+                self.process_warning(self.ERROR_DLSS_SUPERSAMPLING_CONFLICT)
+            else:
+                setSuperSamplingQuality(self.SS_QUALITY_DICT[self.render_parameters.SSQuality])
+                self.logger.info(f"{self.SUPER_SAMPLING_ASSIGNED} {supersampling_quality}")
+                setSuperSampling(CurrentState.On)
+        self.logger.info(f"{self.GPU_RAYTRACING_ASSIGNED} {self.render_parameters.GPURaytracing}")
+        enableRaytracing(bool(self.render_parameters.GPURaytracing))
+        setRaytracingMode(self.render_parameters.GPURaytracing)
+
+    def init_render_job(self) -> None:
+        """
+        Initializes (in VRED API) settings related to Render-typed jobs
+        """
+        self.init_camera_view(self.render_parameters.View)
+        self.init_render_quality_modes()
+        setRenderPixelResolution(
+            self.render_parameters.ImageWidth,
+            self.render_parameters.ImageHeight,
+            self.render_parameters.DPI,
+        )
+        setRenderAnimation(self.render_parameters.RenderAnimation)
+        if self.render_parameters.RenderAnimation:
+            self.init_render_animation()
+        setRenderAlpha(self.render_parameters.IncludeAlphaChannel)
+
+    def init_camera_view(self, view_name: str) -> None:
+        """
+        Initializes (in VRED API) view (a viewpoint or camera). If view_name is empty, then the scene
+        file's current active view (i.e. getRenderView()=="Current") will remain - typically the default (Perspective) camera.
+        :param: view_name: the name of the viewpoint or camera.
+        """
+        if view_name:
+            # Consider the camera or view name and use it for rendering. In case of an identically-named camera
+            # and viewpoint, have that viewpoint take precedence over the camera.
+            view_list = [vp.getName() for vp in vrCameraService.getAllViewpoints()]
+            cam_list = vrCameraService.getCameraNames()
+            if view_name in view_list:
+                self.logger.info(f"{self.VIEWPOINT_FOUND} {view_name}")
+                setRenderView(view_name)
+                vrCameraService.getViewpoint(view_name).activate()
+            elif view_name in cam_list:
+                self.logger.info(f"{self.CAMERA_FOUND} {view_name}")
+                setRenderView(view_name)
+                vrCameraService.getCamera(view_name).activate()
+            else:
+                self.process_warning(f"{self.ERROR_VIEW_MISSING} {view_name}")
+
+    def init_render_animation(self) -> None:
+        """
+        Initializes (in VRED API) render settings related to animations
+        """
+        setRenderStartFrame(self.render_parameters.StartFrame)
+        setRenderStopFrame(self.render_parameters.EndFrame)
+        setRenderFrameStep(self.render_parameters.FrameStep)
+        setRenderAnimationFormat(AnimationFormat.IMAGE)
+        setRenderAnimationType(self.ANIMATION_TYPE_DICT[self.render_parameters.AnimationType])
+        setRenderAnimationClip(self.render_parameters.AnimationClip)
+        # Tech note: when Supersampling is disabled, it can potentially render a black noisy frame when the GUI isn't
+        # available (i.e. on Linux) for some scene files and not others. Enables basic antialiasing.
+        setRenderSupersampling(CurrentState.On)
+        # Frame range to be rendered is provided if the clip range is used.
+        setRenderUseClipRange(False)
+
+    def init_override_render_passes(self) -> None:
+        """
+        Initializes (in VRED API) render settings related to overriding render passes
+        Note: additional render pass configuration options could be exposed in the future
+        """
+        setUseRenderPasses(self.render_parameters.ExportRenderPasses)
+
+    def init_common_features(self) -> None:
+        """
+        Initializes (in VRED API) render settings common to all render jobs
+        """
+        setRenderPremultiply(self.render_parameters.PremultiplyAlpha)
+        setRenderTonemapHDR(self.render_parameters.TonemapHDR)
+
+    def load_path_mapping_rules(self) -> bool:
+        """
+        Loads path mapping rules from the Deadline Cloud API-generated path mapping JSON file.
+        :return: True if rules enumerated successful; False otherwise
+        """
+        try:
+            with open(self.render_parameters.PathMappingRulesFile, self.READ_FLAG) as file_handle:
+                data = json.load(file_handle)
+                self.path_mapping_rules = [
+                    PathMappingRule(**mapping)
+                    for mapping in data.get(self.PATH_MAPPING_RULES_FIELD)
+                ]
+        except Exception as exc:
+            self.logger.error(exc)
+            return False
+        return True
+
+    def map_path(self, path) -> str:
+        """
+        Maps the provided path to the appropriate destination path based on established path mapping rules per
+        Deadline Cloud API convention. Loads path mapping rules if absent.
+        :param: path: the path to be mapped.
+        :return: the mapped destination path; note: this may be the same path if there is no appropriate mapping.
+        """
+        if not self.path_mapping_rules and not self.load_path_mapping_rules():
+            return path
+        for rule in self.path_mapping_rules:
+            in_path = os.path.normpath(path)
+            source_path = os.path.normpath(rule.source_path)
+            in_path_norm = in_path.replace("\\", "/")
+            source_path_norm = source_path.replace("\\", "/")
+            # Check if path starts with source path (case-insensitive for Windows)
+            if (
+                rule.source_path_format == PathFormat.WINDOWS
+                and in_path_norm.lower().startswith(source_path_norm.lower())
+            ) or (
+                rule.source_path_format == PathFormat.POSIX
+                and in_path_norm.startswith(source_path_norm)
+            ):
+                dest_path = os.path.normpath(rule.destination_path)
+                return os.path.normpath(f"{dest_path}{os.sep}{in_path[len(source_path):]}").replace(
+                    "\\", os.sep
+                )
+        return path
+
+    def init_file_references(self) -> None:
+        """
+        Initializes (in VRED API) remapped file references.
+        Supports Source References and Smart References
+        """
+        for node in vrReferenceService.getSceneReferences():
+            if node.hasSmartReference():
+                orig_path = node.getSmartPath()
+                self.logger.info(
+                    f"{self.REMAPPING_FILE_REFERENCE}: {orig_path} -> {self.map_path(orig_path)}"
+                )
+                node.setSmartPath(self.map_path(orig_path))
+            else:
+                orig_path = node.getSourcePath()
+                self.logger.info(
+                    f"{self.REMAPPING_FILE_REFERENCE}: {orig_path} -> {self.map_path(orig_path)}"
+                )
+                node.setSourcePath(self.map_path(orig_path))
+
+    def init_render_region(self) -> None:
+        """
+        Initializes (in VRED API) computed render region (tile-based) settings
+        Note: regions (sizes) are automatically computed below and are 1-indexed
+        Note: separate tasks are (currently) generated per individual tile
+        """
+        setUseRenderRegion(self.render_parameters.RegionRendering)
+        if self.render_parameters.RegionRendering:
+            # Tile number uses 1-based indexing. Treat first tile (top left) as x=0, y=0.
+            tile_num_x = self.render_parameters.TileNumberX
+            tile_num_y = self.render_parameters.TileNumberY
+            total_x_tiles = self.render_parameters.NumXTiles
+            total_y_tiles = self.render_parameters.NumYTiles
+            width = self.render_parameters.ImageWidth
+            height = self.render_parameters.ImageHeight
+            # Calculate the bounds for the tile with rounding applied.
+            # Include a small overlap between tiles for addressing tile gap concerns
+            left = int((float(width) / total_x_tiles * (tile_num_x - 1)) + 0.5)
+            right = int((float(width) / total_x_tiles * tile_num_x) + 0.5)
+            bottom = int((float(height) / total_y_tiles * (tile_num_y - 1)) + 0.5)
+            top = int((float(height) / total_y_tiles * tile_num_y) + 0.5)
+            # Set the border ranges for the tile
+            setRenderRegionStartX(left)
+            setRenderRegionEndX(right)
+            setRenderRegionStartY(bottom)
+            setRenderRegionEndY(top)
+            # Set the active render region per convention: setRaytracingRenderRegion(xBegin, yBegin, xEnd, yEnd)
+            # Each parameter becomes a relative normalized coordinate (in [0.0,1.0]).
+            left = float(left) / self.render_parameters.ImageWidth
+            right = float(right) / self.render_parameters.ImageWidth
+            bottom = float(bottom) / self.render_parameters.ImageHeight
+            top = float(top) / self.render_parameters.ImageHeight
+            setRaytracingRenderRegion(left, 1 - top, right, 1 - bottom)
+            # Ensures that the render region will be respected
+            enableRaytracing(True)
+
+    def init_by_job_type(self) -> None:
+        """
+        Initializes render settings by render job type
+        """
+        job_type = self.render_parameters.JobType
+        if job_type == JobType.SEQUENCER:
+            self.perform_sequencer_job()
+        elif job_type == JobType.RENDER:
+            self.init_render_job()
+
+    def init_render_settings(self) -> None:
+        """
+        High-level render settings initialization method
+        """
+        self.init_by_job_type()
+        if self.render_parameters.OverrideRenderPass:
+            self.init_override_render_passes()
+        self.init_common_features()
+        self.init_render_region()
+        setRenderFilename(self.output_filename)
+
+    def process_warning(self, message) -> None:
+        """
+        Logs a warning
+        :param: message: warning message to log
+        """
+        self.logger.warning(message)
+
+    def render(self) -> None:
+        """
+        High-level render initiation routine with error handling
+        """
+        try:
+            self.validate_render_settings()
+            self.init_file_references()
+            self.init_render_settings()
+            self.logger.info(self.STARTING_RENDER_PROCESS)
+            self.logger.info(f"{self.RENDERING_TO_FILE} {getRenderFilename()}")
+            startRenderToFile(True)
+            # Important to close VRED for further frame rendering to proceed and to release license
+            if self.WANT_VRED_TERMINATION:
+                terminateVred()
+        except Exception as exc:
+            self.logger.error(exc)
+            self.logger.error(traceback.format_exc())
+            if self.WANT_VRED_TERMINATION:
+                crashVred(1)
+        finally:
+            if self.WANT_VRED_TERMINATION:
+                terminateVred()
+
+
+def deadline_cloud_render(render_parameters_dict: Dict[str, Any]) -> None:
+    """
+    Main entry point (to be triggered externally and indirectly via VRED "postpython" argument):
+    - reads render parameters and values from a dictionary (render_parameters_dict)
+    - applies render parameter values to VRED API
+    - initiates rendering process with error handling
+    :param: render_parameters_dict: a dictionary containing the render parameters and values
+    """
+    if render_parameters_dict:
+        renderer = DeadlineCloudRenderer(render_parameters_dict)
+        renderer.render()

--- a/job_bundles/vred_render/template.yaml
+++ b/job_bundles/vred_render/template.yaml
@@ -1,0 +1,621 @@
+specificationVersion: jobtemplate-2023-09
+name: VRED Renderer
+description: |
+  This render job template depends on Autodesk VRED Core (or optionally VRED Pro) to perform rendering and supports
+  versions 2025.X (17.X) and 2026.X (18.X) on Windows and Linux platforms. Please review official system requirements
+  and software dependencies on Autodesk's official website:
+      https://www.autodesk.com/support/technical/article/caas/sfdcarticles/sfdcarticles/System-requirements-for-Autodesk-VRED-products.html
+
+  Render jobs take a VPB project file (including its file references) as input, and produce render output per
+  the chosen output format and additional render settings.
+
+  To run the render job without a conda virtual environment created by a Deadline Cloud queue environment,
+  you must ensure that the environment variable "VREDCORE" (for VRED Core) or "VREDPRO" (for VRED Pro) is defined by a
+  valid path to its product's executable file. You can find these executable files in paths similar to:
+    (Linux): /opt/Autodesk/VREDCluster-{version}/bin/VREDCore
+    (Windows): C:/Program Files/Autodesk/VREDPro-{version}/bin/WIN64/VREDCore.exe"
+  Note: if both of these environment variables are assigned, then "VREDCORE" will take precedence.
+
+  If you're using a conda queue environment, then please ensure that the channels listed in your CondaChannels list
+  include all of the packages for these software dependencies. On Deadline Cloud service-managed fleets, there are
+  two channels (deadline-cloud, conda-forge) that provide those packages.
+
+  You can also create a custom conda channel on S3 using the approach documented below:
+      https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/configure-jobs-s3-channel.html
+
+parameterDefinitions:
+  - name: SceneFile
+    type: PATH
+    objectType: FILE
+    dataFlow: IN
+    userInterface:
+      control: CHOOSE_INPUT_FILE
+      label: VRED Scene File
+      fileFilters:
+        - label: VRED Scene Files
+          patterns:
+            - '*.vpb'
+        - label: All Files
+          patterns:
+            - '*'
+    description: >
+      Choose the VRED scene file that you want to render.
+      Use the 'Job Attachments' tab of the submitter GUI to add
+      other dependent files that the job needs.
+  - name: OutputDir
+    type: PATH
+    objectType: DIRECTORY
+    dataFlow: OUT
+    userInterface:
+      control: CHOOSE_DIRECTORY
+      label: Output Directory
+      groupLabel: Render Options
+    description: The render output directory.
+  - name: OutputFileNamePrefix
+    type: STRING
+    userInterface:
+      control: LINE_EDIT
+      label: Output Filename Prefix
+      groupLabel: Render Options
+    default: output
+    description: The render output filename prefix (without extension).
+  - name: OutputFormat
+    type: STRING
+    userInterface:
+      control: DROPDOWN_LIST
+      label: Output File Format
+      groupLabel: Render Options
+    description: The file format for rendered images.
+    default: PNG
+    allowedValues:
+      - BMP
+      - DDS
+      - DIB
+      - EXR
+      - HDR
+      - JFIF
+      - JPE
+      - JPEG
+      - JPG
+      - NRRD
+      - PBM
+      - PGM
+      - PNG
+      - PNM
+      - PPM
+      - PSB
+      - PSD
+      - RLE
+      - TIF
+      - TIFF
+      - VIF
+      - ZIP
+  - name: View
+    type: STRING
+    userInterface:
+      control: LINE_EDIT
+      label: Render Viewpoint/Camera
+      groupLabel: Render Options
+    default: ""
+    description: The name of the viewpoint or camera from which to render.
+  - name: ImageWidth
+    type: INT
+    userInterface:
+      control: SPIN_BOX
+      label: Image Width (px)
+      groupLabel: Render Options
+    minValue: 1
+    default: 800
+    description: The rendered image width in pixels.
+  - name: ImageHeight
+    type: INT
+    userInterface:
+      control: SPIN_BOX
+      label: Image Height (px)
+      groupLabel: Render Options
+    minValue: 1
+    default: 600
+    description: The rendered image height in pixels.
+  - name: DPI
+    type: INT
+    userInterface:
+      control: SPIN_BOX
+      label: Resolution (px/inch)
+      groupLabel: Render Options
+    minValue: 1
+    default: 72
+    description: The dots-per-inch (DPI) physical scaling factor (pixels per inch).
+  - name: RenderQuality
+    type: STRING
+    userInterface:
+      control: DROPDOWN_LIST
+      label: Render Quality
+      groupLabel: Render Options
+    default: 'Realistic High'
+    allowedValues:
+      - 'Analytic Low'
+      - 'Analytic High'
+      - 'Realistic Low'
+      - 'Realistic High'
+      - 'Raytracing'
+      - 'NPR'
+    description: The render quality level to apply.
+  - name: DLSSQuality
+    type: STRING
+    userInterface:
+      control: DROPDOWN_LIST
+      label: DLSS Quality
+      groupLabel: Render Options
+    default: 'Off'
+    allowedValues:
+      - 'Off'
+      - 'Performance'
+      - 'Balanced'
+      - 'Quality'
+      - 'Ultra Performance'
+    description: The Deep Learning Super Sampling (DLSS) quality level to apply.
+  - name: SSQuality
+    type: STRING
+    userInterface:
+      control: DROPDOWN_LIST
+      label: SS Quality
+      groupLabel: Render Options
+    default: 'Off'
+    allowedValues:
+      - 'Off'
+      - 'Low'
+      - 'Medium'
+      - 'High'
+      - 'Ultra High'
+    description: >
+      The Super Sampling quality level to apply; note: DLSS quality level takes precedence.
+  - name: RenderAnimation
+    type: STRING
+    userInterface:
+      control: CHECK_BOX
+      label: Render Animation
+      groupLabel: Render Options
+    default: 'true'
+    allowedValues:
+      - 'true'
+      - 'false'
+    description: >
+      If checked, allows specifying an animation type (which can also include a specific animation clip),
+      corresponding frame range and frames per task.
+  - name: GPURaytracing
+    type: STRING
+    userInterface:
+      control: CHECK_BOX
+      label: Use GPU Ray Tracing
+      groupLabel: Render Options
+    default: 'false'
+    allowedValues:
+      - 'true'
+      - 'false'
+    description: Attempts to apply GPU raytracing to the rendering process (if sufficient hardware is available).
+  - name: AnimationType
+    type: STRING
+    userInterface:
+      control: DROPDOWN_LIST
+      label: Animation Type
+      groupLabel: Render Options
+    default: 'Clip'
+    allowedValues:
+      - 'Clip'
+      - 'Timeline'
+    description: The type of animation (Clip or Timeline).
+  - name: AnimationClip
+    type: STRING
+    userInterface:
+      control: LINE_EDIT
+      label: Animation Clip
+      groupLabel: Render Options
+    default: ""
+    description: The name of the animation clip to render.
+  - name: StartFrame
+    type: INT
+    userInterface:
+      control: SPIN_BOX
+      label: Start Frame
+      groupLabel: Render Options
+    default: 0
+    description: The first frame of a range to render.
+  - name: EndFrame
+    type: INT
+    userInterface:
+      control: SPIN_BOX
+      label: End Frame
+      groupLabel: Render Options
+    default: 20
+    description: The last frame of a range to render.
+  - name: FrameStep
+    type: INT
+    userInterface:
+      control: SPIN_BOX
+      label: Frame Step
+      groupLabel: Render Options
+    default: 1
+    description: The frame step for the frame range (i.e. 2 for rendering every second frame).
+  - name: FramesPerTask
+    type: INT
+    userInterface:
+      control: SPIN_BOX
+      label: Frames Per Task
+      groupLabel: Render Options
+    minValue: 1
+    default: 1
+    description: The number of frames that will be rendered at a time for each task within a render job.
+  - name: IncludeAlphaChannel
+    type: STRING
+    userInterface:
+      control: HIDDEN
+      label: Include Alpha Channel
+      groupLabel: Render Options
+    default: 'false'
+    allowedValues:
+      - 'true'
+      - 'false'
+    description: Enables export of images with an alpha channel.
+  - name: RegionRendering
+    type: STRING
+    userInterface:
+      control: CHECK_BOX
+      label: Enable Region Rendering
+      groupLabel: Tiling Settings
+    default: 'false'
+    allowedValues:
+      - 'true'
+      - 'false'
+    description: >
+      When enabled, the output rendered image will be divided into multiple tiles (sub-regions)
+      that are first rendered as separate tasks for a given frame. These tiles will then be
+      assembled (combined) into one output image for a given frame (in a separate task).
+  - name: NumXTiles
+    type: INT
+    userInterface:
+      control: SPIN_BOX
+      label: Tiles in X
+      groupLabel: Tiling Settings
+    minValue: 1
+    default: 1
+    description: The number of tiles to horizontally divide the specified image size.
+  - name: NumYTiles
+    type: INT
+    userInterface:
+      control: SPIN_BOX
+      label: Tiles in Y
+      groupLabel: Tiling Settings
+    minValue: 1
+    default: 1
+    description: The number of tiles to vertically divide the specified image size.
+  - name: OverrideRenderPass
+    type: STRING
+    userInterface:
+      control: HIDDEN
+      label: Override Render Pass
+      groupLabel: Render Options
+    default: 'false'
+    allowedValues:
+      - 'true'
+      - 'false'
+    description: >
+      Enables the exporting of render passes when rendering to a file. If enabled, then the render pass
+      settings via the job properties will be used; otherwise the settings defined in the scene will be used.
+  - name: PremultiplyAlpha
+    type: STRING
+    userInterface:
+      control: HIDDEN
+      label: Premultiply Alpha
+      groupLabel: Render Options
+    default: 'false'
+    allowedValues:
+      - 'true'
+      - 'false'
+    description: Enables premultiplied alpha.
+  - name: TonemapHDR
+    type: STRING
+    userInterface:
+      control: HIDDEN
+      label: Tone map HDR
+      groupLabel: Render Options
+    default: 'false'
+    allowedValues:
+      - 'true'
+      - 'false'
+    description: Enables tone mapping when rendering to a HDR image format.
+  - name: JobType
+    type: STRING
+    userInterface:
+      control: HIDDEN
+      label: Job Type
+      groupLabel: Render Options
+    default: 'Render'
+    allowedValues:
+      - 'Render'
+      - 'Sequencer'
+    description: Type of job to submit.
+  - name: SequenceName
+    type: STRING
+    userInterface:
+      control: HIDDEN
+      label: Sequence Name
+      groupLabel: Render Options
+    default: ""
+    description: The name of the sequence to render; if empty, then all sequences will be rendered.
+  - name: JobScriptDir
+    userInterface:
+      control: HIDDEN
+    type: PATH
+    objectType: DIRECTORY
+    dataFlow: IN
+    default: scripts
+    description: Directory containing bundled scripts.
+  - name: CondaPackages
+    userInterface:
+      control: HIDDEN
+    type: STRING
+    default: 'vredcore=2026*'
+    description: >
+      A list of conda packages to install. If a queue accepts this parameter, then it will create a conda virtual
+      environment.
+  - name: submitter_name
+    type: STRING
+    userInterface:
+      control: HIDDEN
+    default: 'VRED'
+    description: >
+      The type of submitter that is used to submit the render job.
+  - name: name
+    type: STRING
+    userInterface:
+      control: HIDDEN
+    default: ''
+    description: >
+      The name of the render job.
+  - name: description
+    type: STRING
+    userInterface:
+      control: HIDDEN
+    default: ''
+    description: >
+      The description of the render job.
+  - name: input_filenames
+    type: STRING
+    userInterface:
+      control: HIDDEN
+    default: ''
+    description: >
+      Input filenames.
+  - name: input_directories
+    type: STRING
+    userInterface:
+      control: HIDDEN
+    default: ''
+    description: >
+      Input directories.
+  - name: output_directories
+    type: STRING
+    userInterface:
+      control: HIDDEN
+    default: ''
+    description: >
+      Output directories.
+
+steps:
+  - name: VRED Render
+    parameterSpace:
+      taskParameterDefinitions:
+        - name: StartFrameFromCurrentChunk
+          type: INT
+          range: "{{Param.StartFrame}}-{{Param.EndFrame}}:{{Param.FramesPerTask}}"
+        - name: TileNumberX
+          type: INT
+          range: "1-{{Param.NumXTiles}}"
+        - name: TileNumberY
+          type: INT
+          range: "1-{{Param.NumYTiles}}"
+    description: Invokes VRED Core, supplying it with render parameter data.
+    script:
+      embeddedFiles:
+        - name: LoadRenderParameterValues
+          filename: load_render_parameter_values.py
+          type: TEXT
+          data: |-
+            from typing import Any, Dict
+
+            def str_to_bool(s:str)->bool: return s.lower() == 'true'
+
+            def get_vred_render_parameters() -> Dict[str, Any]:
+                """
+                *WARNING*: it is imperative to maintain correct value typing for all parameters that you add using
+                the conversion schemes below (for int, str, bool) as a guide. Value types are VRED API
+                sensitive -- they need to be synchronized with future VRED API changes (if any). Please
+                also keep value typing pairwise with parameterDefinitions-supported types (above).
+
+                :return: a dictionary containing appropriately-typed values (non-inferred) for use in VRED API calls.
+                """
+
+                # Depending on implementation, a frame chunk ID or an actual starting frame number that
+                # corresponds to that ID could be provided.
+                #
+                start_frame = int({{Task.Param.StartFrameFromCurrentChunk}})
+                frames_per_task = int({{Param.FramesPerTask}})
+                end_frame = min(start_frame + frames_per_task - 1, int({{Param.EndFrame}}))
+                return {
+                    'AnimationClip': str('{{Param.AnimationClip}}'),
+                    'AnimationType': str('{{Param.AnimationType}}'),
+                    'DLSSQuality': str('{{Param.DLSSQuality}}'),
+                    'DPI': int({{Param.DPI}}),
+                    'EndFrame': int(end_frame),
+                    'FrameStep': int({{Param.FrameStep}}),
+                    'FramesPerTask': int(frames_per_task),
+                    'GPURaytracing': int(str_to_bool('{{Param.GPURaytracing}}')),
+                    'ImageHeight': int({{Param.ImageHeight}}),
+                    'ImageWidth': int({{Param.ImageWidth}}),
+                    'IncludeAlphaChannel': str_to_bool('{{Param.IncludeAlphaChannel}}'),
+                    'JobType': str('{{Param.JobType}}'),
+                    'NumXTiles': int({{Param.NumXTiles}}),
+                    'NumYTiles': int({{Param.NumYTiles}}),
+                    'OutputDir': str(r'{{Param.OutputDir}}'),
+                    'OutputFileNamePrefix': str('{{Param.OutputFileNamePrefix}}'),
+                    'OutputFormat': str('{{Param.OutputFormat}}'),
+                    'OverrideRenderPass': str_to_bool('{{Param.OverrideRenderPass}}'),
+                    'PathMappingRulesFile': str(r'{{Session.PathMappingRulesFile}}'),
+                    'PremultiplyAlpha': str_to_bool('{{Param.PremultiplyAlpha}}'),
+                    'RegionRendering': str_to_bool('{{Param.RegionRendering}}'),
+                    'RenderAnimation': str_to_bool('{{Param.RenderAnimation}}'),
+                    'RenderQuality': str('{{Param.RenderQuality}}'),
+                    'SceneFile': str(r'{{Param.SceneFile}}'),
+                    'SequenceName': str('{{Param.SequenceName}}'),
+                    'SSQuality': str('{{Param.SSQuality}}'),
+                    'StartFrame': int(start_frame),
+                    'TileNumberX': int({{Task.Param.TileNumberX}}),
+                    'TileNumberY': int({{Task.Param.TileNumberY}}),
+                    'TonemapHDR': str_to_bool('{{Param.TonemapHDR}}'),
+                    'View': str('{{Param.View}}'),
+                }
+        - name: VREDInvocation
+          filename: invoke-vred.py
+          type: TEXT
+          runnable: True
+          data: |-
+            # Please set one of the following environment variables: "VREDCORE" or "VREDPRO".
+            # Please ensure that it resolves to a VRED binary executable that is reachable.
+            # You can find relevant executables in paths similar to:
+            #   (Linux): /opt/Autodesk/VREDCluster-{version}/bin/VREDCore
+            #   (Windows): C:/Program Files/Autodesk/VREDPro-{version}/bin/WIN64/VREDCore.exe"
+            # Note: if both of these environment variables are assigned, then "VREDCORE" will be take precedence.
+            #
+            import io
+            import os
+            import platform
+            import subprocess
+            import sys
+
+            sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
+
+            CODE_PASSING_ENV_VAR = "BOOTSTRAP_CODE"
+            DISABLE_PYTHON_SANDBOX_PARAM = "-insecure_python"
+            DISABLE_WEBINTERFACE_ENV_VAR = "VRED_DISABLE_WEBINTERFACE"
+            DISABLE_WEBINTERFACE_VALUE = "1"
+            ERROR_UNKNOWN_VRED_PATH = (
+                "Cannot determine valid VRED binary to invoke from VREDCORE and VREDPRO environment "
+                "variables."
+            )
+            FAST_START_PARAM = "-fast_start"
+            FLEXLM_DIAGNOSTICS_ENV_VAR = "FLEXLM_DIAGNOSTICS"
+            FLEXLM_DIAGNOSTICS_HIGH_VALUE = "3"
+            HIDE_GUI_PARAM = "-hide_gui"
+            IS_WINDOWS = platform.system().lower() == "windows"
+            LICENSE_RELEASE_TIME_ENV_VAR = "VRED_IDLE_LICENSE_TIME"
+            LICENSE_RELEASE_TIME_SECONDS_LIMIT = "60"
+            POST_PYTHON_PARAM = "-postpython"
+            VRED_CORE_ENV_VAR = "VREDCORE"
+            VRED_PRO_ENV_VAR = "VREDPRO"
+
+            # Invoke code found in VRED_PYTHON_BOOTSTRAP_CODE via CODE_PASSING_ENV_VAR without using import statements.
+            # Remove all spaces to prevent VRED from assuming non-intended arguments.
+            #
+            VRED_PYTHON_PRE_BOOTSTRAP_CODE = fr"""
+            load_module = getattr(__builtins__, '__import__');
+            os = load_module('os');
+            exec(os.environ.get('{CODE_PASSING_ENV_VAR}'));
+            """.replace(
+                "\n", ""
+            ).replace(
+                " ", ""
+            )
+            # Inject render parameters into render script, loading both of them at startup, enforce universal exit
+            #
+            VRED_PYTHON_BOOTSTRAP_CODE = r"""
+            import importlib;
+            import os;
+            import sys;
+            from vrController import terminateVred, vrLogError;
+            sys.path.extend([r'{{Param.JobScriptDir}}', os.path.dirname(r'{{Task.File.LoadRenderParameterValues}}')]);
+            render_module_name='VRED_RenderScript_DeadlineCloud';
+            render_param_module_name='load_render_parameter_values';
+            render_module = importlib.util.find_spec(render_module_name) is not None and importlib.import_module(
+            render_module_name) or None;
+            render_param_module = importlib.util.find_spec(render_param_module_name) is not None and importlib.import_module(
+            render_param_module_name) or None;
+            render_module.deadline_cloud_render(
+            render_param_module.get_vred_render_parameters()) if render_module and render_param_module else vrLogError(
+            'failed to import module for render script and/or render parameters');
+
+            terminateVred();
+            """.replace(
+                "\n", ""
+            ).replace(
+                "\\", "/"
+            )
+
+
+            def get_vred_executable() -> str:
+                """
+                Determine VRED binary to use based on environment variable state and binary availability
+                return: path to VRED binary
+                raise: OSError: if a valid binary can't be determined.
+                """
+                try:
+                    vred_executable = os.environ[VRED_CORE_ENV_VAR]
+                    if not os.path.isfile(vred_executable):
+                        raise FileNotFoundError(f"VREDCORE binary not found at: {vred_executable}")
+                except (KeyError, FileNotFoundError):
+                    try:
+                        vred_executable = os.environ[VRED_PRO_ENV_VAR]
+                        if not os.path.isfile(vred_executable):
+                            raise FileNotFoundError(f"VREDPRO binary not found at: {vred_executable}")
+                    except (KeyError, FileNotFoundError):
+                        raise OSError(ERROR_UNKNOWN_VRED_PATH)
+                return vred_executable
+
+
+            def setup_vred_environment() -> None:
+                """
+                Disable VRED's web interface, release license on idle, pass bootstrapping code via environment variable
+                """
+                os.environ[DISABLE_WEBINTERFACE_ENV_VAR] = DISABLE_WEBINTERFACE_VALUE
+                os.environ[LICENSE_RELEASE_TIME_ENV_VAR] = LICENSE_RELEASE_TIME_SECONDS_LIMIT
+                os.environ[CODE_PASSING_ENV_VAR] = VRED_PYTHON_BOOTSTRAP_CODE
+                os.environ[FLEXLM_DIAGNOSTICS_ENV_VAR] = FLEXLM_DIAGNOSTICS_HIGH_VALUE
+
+            def invoke_vred(vred_executable: str) -> None:
+                """
+                Invoke VRED binary, passing it parameters to run headless, grant script access, load scene file,
+                and execute code for the render process to complete
+                param: vred_executable: path to VRED binary
+                """
+                executable = f'"{vred_executable}"' if IS_WINDOWS else vred_executable
+                scene_file_path = r'"{{Param.SceneFile}}"' if IS_WINDOWS else r"{{Param.SceneFile}}"
+                command_and_arg_list: list[str] = [
+                    executable,
+                    scene_file_path,
+                    DISABLE_PYTHON_SANDBOX_PARAM,
+                    FAST_START_PARAM,
+                    HIDE_GUI_PARAM,
+                    POST_PYTHON_PARAM,
+                    VRED_PYTHON_PRE_BOOTSTRAP_CODE,
+                ]
+                try:
+                    invocation = " ".join(command_and_arg_list) if IS_WINDOWS else command_and_arg_list
+                    output = subprocess.run(invocation, stderr=subprocess.STDOUT, check=True, text=True)
+                    print(output)
+                except subprocess.CalledProcessError as error:
+                    print(f"Command: [{invocation}] failed: \n{error.output}\n with return code {error.returncode}")
+
+            setup_vred_environment()
+            invoke_vred(get_vred_executable())
+      actions:
+        onRun:
+          command: python
+          args: [ '{{Task.File.VREDInvocation}}' ]
+    hostRequirements:
+      amounts:
+        - name: amount.worker.gpu
+          min: 1
+      attributes:
+        - name: attr.worker.os.family
+          anyOf:
+            - linux
+            - windows

--- a/job_bundles/vred_render/template_tiling.yaml
+++ b/job_bundles/vred_render/template_tiling.yaml
@@ -1,0 +1,697 @@
+specificationVersion: jobtemplate-2023-09
+name: VRED Renderer
+description: |
+  This render job template depends on Autodesk VRED Core (or optionally VRED Pro) to perform rendering and supports
+  versions 2025.X (17.X) and 2026.X (18.X) on Windows and Linux platforms. Please review official system requirements
+  and software dependencies on Autodesk's official website:
+      https://www.autodesk.com/support/technical/article/caas/sfdcarticles/sfdcarticles/System-requirements-for-Autodesk-VRED-products.html
+
+  Render jobs take a VPB project file (including its file references) as input, and produce render output per
+  the chosen output format and additional render settings.
+
+  To run the render job without a conda virtual environment created by a Deadline Cloud queue environment,
+  you must ensure that the environment variable "VREDCORE" (for VRED Core) or "VREDPRO" (for VRED Pro) is defined by a
+  valid path to its product's executable file. You can find these executable files in paths similar to:
+    (Linux): /opt/Autodesk/VREDCluster-{version}/bin/VREDCore
+    (Windows): C:/Program Files/Autodesk/VREDPro-{version}/bin/WIN64/VREDCore.exe"
+  Note: if both of these environment variables are assigned, then "VREDCORE" will take precedence.
+
+  If you're using a conda queue environment, then please ensure that the channels listed in your CondaChannels list
+  include all of the packages for these software dependencies. On Deadline Cloud service-managed fleets, there are
+  two channels (deadline-cloud, conda-forge) that provide those packages.
+
+  You can also create a custom conda channel on S3 using the approach documented below:
+      https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/configure-jobs-s3-channel.html
+
+parameterDefinitions:
+  - name: SceneFile
+    type: PATH
+    objectType: FILE
+    dataFlow: IN
+    userInterface:
+      control: CHOOSE_INPUT_FILE
+      label: VRED Scene File
+      fileFilters:
+        - label: VRED Scene Files
+          patterns:
+            - '*.vpb'
+        - label: All Files
+          patterns:
+            - '*'
+    description: >
+      Choose the VRED scene file that you want to render.
+      Use the 'Job Attachments' tab of the submitter GUI to add
+      other dependent files that the job needs.
+  - name: OutputDir
+    type: PATH
+    objectType: DIRECTORY
+    dataFlow: OUT
+    userInterface:
+      control: CHOOSE_DIRECTORY
+      label: Output Directory
+      groupLabel: Render Options
+    description: The render output directory.
+  - name: OutputFileNamePrefix
+    type: STRING
+    userInterface:
+      control: LINE_EDIT
+      label: Output Filename Prefix
+      groupLabel: Render Options
+    default: output
+    description: The render output filename prefix (without extension).
+  - name: OutputFormat
+    type: STRING
+    userInterface:
+      control: DROPDOWN_LIST
+      label: Output File Format
+      groupLabel: Render Options
+    description: The file format for rendered images.
+    default: PNG
+    allowedValues:
+      - BMP
+      - DDS
+      - DIB
+      - EXR
+      - HDR
+      - JFIF
+      - JPE
+      - JPEG
+      - JPG
+      - NRRD
+      - PBM
+      - PGM
+      - PNG
+      - PNM
+      - PPM
+      - PSB
+      - PSD
+      - RLE
+      - TIF
+      - TIFF
+      - VIF
+      - ZIP
+  - name: View
+    type: STRING
+    userInterface:
+      control: LINE_EDIT
+      label: Render Viewpoint/Camera
+      groupLabel: Render Options
+    default: ""
+    description: The name of the viewpoint or camera from which to render.
+  - name: ImageWidth
+    type: INT
+    userInterface:
+      control: SPIN_BOX
+      label: Image Width (px)
+      groupLabel: Render Options
+    minValue: 1
+    default: 800
+    description: The rendered image width in pixels.
+  - name: ImageHeight
+    type: INT
+    userInterface:
+      control: SPIN_BOX
+      label: Image Height (px)
+      groupLabel: Render Options
+    minValue: 1
+    default: 600
+    description: The rendered image height in pixels.
+  - name: DPI
+    type: INT
+    userInterface:
+      control: SPIN_BOX
+      label: Resolution (px/inch)
+      groupLabel: Render Options
+    minValue: 1
+    default: 72
+    description: The dots-per-inch (DPI) physical scaling factor (pixels per inch).
+  - name: RenderQuality
+    type: STRING
+    userInterface:
+      control: DROPDOWN_LIST
+      label: Render Quality
+      groupLabel: Render Options
+    default: 'Realistic High'
+    allowedValues:
+      - 'Analytic Low'
+      - 'Analytic High'
+      - 'Realistic Low'
+      - 'Realistic High'
+      - 'Raytracing'
+      - 'NPR'
+    description: The render quality level to apply.
+  - name: DLSSQuality
+    type: STRING
+    userInterface:
+      control: DROPDOWN_LIST
+      label: DLSS Quality
+      groupLabel: Render Options
+    default: 'Off'
+    allowedValues:
+      - 'Off'
+      - 'Performance'
+      - 'Balanced'
+      - 'Quality'
+      - 'Ultra Performance'
+    description: The Deep Learning Super Sampling (DLSS) quality level to apply.
+  - name: SSQuality
+    type: STRING
+    userInterface:
+      control: DROPDOWN_LIST
+      label: SS Quality
+      groupLabel: Render Options
+    default: 'Off'
+    allowedValues:
+      - 'Off'
+      - 'Low'
+      - 'Medium'
+      - 'High'
+      - 'Ultra High'
+    description: >
+      The Super Sampling quality level to apply; note: DLSS quality level takes precedence.
+  - name: RenderAnimation
+    type: STRING
+    userInterface:
+      control: CHECK_BOX
+      label: Render Animation
+      groupLabel: Render Options
+    default: 'true'
+    allowedValues:
+      - 'true'
+      - 'false'
+    description: >
+      If checked, allows specifying an animation type (which can also include a specific animation clip),
+      corresponding frame range and frames per task.
+  - name: GPURaytracing
+    type: STRING
+    userInterface:
+      control: CHECK_BOX
+      label: Use GPU Ray Tracing
+      groupLabel: Render Options
+    default: 'false'
+    allowedValues:
+      - 'true'
+      - 'false'
+    description: Attempts to apply GPU raytracing to the rendering process (if sufficient hardware is available).
+  - name: AnimationType
+    type: STRING
+    userInterface:
+      control: DROPDOWN_LIST
+      label: Animation Type
+      groupLabel: Render Options
+    default: 'Clip'
+    allowedValues:
+      - 'Clip'
+      - 'Timeline'
+    description: The type of animation (Clip or Timeline).
+  - name: AnimationClip
+    type: STRING
+    userInterface:
+      control: LINE_EDIT
+      label: Animation Clip
+      groupLabel: Render Options
+    default: ""
+    description: The name of the animation clip to render.
+  - name: StartFrame
+    type: INT
+    userInterface:
+      control: SPIN_BOX
+      label: Start Frame
+      groupLabel: Render Options
+    default: 0
+    description: The first frame of a range to render.
+  - name: EndFrame
+    type: INT
+    userInterface:
+      control: SPIN_BOX
+      label: End Frame
+      groupLabel: Render Options
+    default: 20
+    description: The last frame of a range to render.
+  - name: FrameStep
+    type: INT
+    userInterface:
+      control: SPIN_BOX
+      label: Frame Step
+      groupLabel: Render Options
+    default: 1
+    description: The frame step for the frame range (i.e. 2 for rendering every second frame).
+  - name: FramesPerTask
+    type: INT
+    userInterface:
+      control: SPIN_BOX
+      label: Frames Per Task
+      groupLabel: Render Options
+    minValue: 1
+    default: 1
+    description: The number of frames that will be rendered at a time for each task within a render job.
+  - name: IncludeAlphaChannel
+    type: STRING
+    userInterface:
+      control: HIDDEN
+      label: Include Alpha Channel
+      groupLabel: Render Options
+    default: 'false'
+    allowedValues:
+      - 'true'
+      - 'false'
+    description: Enables export of images with an alpha channel.
+  - name: RegionRendering
+    type: STRING
+    userInterface:
+      control: CHECK_BOX
+      label: Enable Region Rendering
+      groupLabel: Tiling Settings
+    default: 'false'
+    allowedValues:
+      - 'true'
+      - 'false'
+    description: >
+      When enabled, the output rendered image will be divided into multiple tiles (sub-regions)
+      that are first rendered as separate tasks for a given frame. These tiles will then be
+      assembled (combined) into one output image for a given frame (in a separate task).
+  - name: NumXTiles
+    type: INT
+    userInterface:
+      control: SPIN_BOX
+      label: Tiles in X
+      groupLabel: Tiling Settings
+    minValue: 1
+    default: 1
+    description: The number of tiles to horizontally divide the specified image size.
+  - name: NumYTiles
+    type: INT
+    userInterface:
+      control: SPIN_BOX
+      label: Tiles in Y
+      groupLabel: Tiling Settings
+    minValue: 1
+    default: 1
+    description: The number of tiles to vertically divide the specified image size.
+  - name: OverrideRenderPass
+    type: STRING
+    userInterface:
+      control: HIDDEN
+      label: Override Render Pass
+      groupLabel: Render Options
+    default: 'false'
+    allowedValues:
+      - 'true'
+      - 'false'
+    description: >
+      Enables the exporting of render passes when rendering to a file. If enabled, then the render pass
+      settings via the job properties will be used; otherwise the settings defined in the scene will be used.
+  - name: PremultiplyAlpha
+    type: STRING
+    userInterface:
+      control: HIDDEN
+      label: Premultiply Alpha
+      groupLabel: Render Options
+    default: 'false'
+    allowedValues:
+      - 'true'
+      - 'false'
+    description: Enables premultiplied alpha.
+  - name: TonemapHDR
+    type: STRING
+    userInterface:
+      control: HIDDEN
+      label: Tone map HDR
+      groupLabel: Render Options
+    default: 'false'
+    allowedValues:
+      - 'true'
+      - 'false'
+    description: Enables tone mapping when rendering to a HDR image format.
+  - name: JobType
+    type: STRING
+    userInterface:
+      control: HIDDEN
+      label: Job Type
+      groupLabel: Render Options
+    default: 'Render'
+    allowedValues:
+      - 'Render'
+      - 'Sequencer'
+    description: Type of job to submit.
+  - name: SequenceName
+    type: STRING
+    userInterface:
+      control: HIDDEN
+      label: Sequence Name
+      groupLabel: Render Options
+    default: ""
+    description: The name of the sequence to render; if empty, then all sequences will be rendered.
+  - name: JobScriptDir
+    userInterface:
+      control: HIDDEN
+    type: PATH
+    objectType: DIRECTORY
+    dataFlow: IN
+    default: scripts
+    description: Directory containing bundled scripts.
+  - name: CondaPackages
+    userInterface:
+      control: HIDDEN
+    type: STRING
+    default: 'vredcore=2026*'
+    description: >
+      A list of conda packages to install. If a queue accepts this parameter, then it will create a conda virtual
+      environment.
+  - name: submitter_name
+    type: STRING
+    userInterface:
+      control: HIDDEN
+    default: 'VRED'
+    description: >
+      The type of submitter that is used to submit the render job.
+  - name: name
+    type: STRING
+    userInterface:
+      control: HIDDEN
+    default: ''
+    description: >
+      The name of the render job.
+  - name: description
+    type: STRING
+    userInterface:
+      control: HIDDEN
+    default: ''
+    description: >
+      The description of the render job.
+  - name: input_filenames
+    type: STRING
+    userInterface:
+      control: HIDDEN
+    default: ''
+    description: >
+      Input filenames.
+  - name: input_directories
+    type: STRING
+    userInterface:
+      control: HIDDEN
+    default: ''
+    description: >
+      Input directories.
+  - name: output_directories
+    type: STRING
+    userInterface:
+      control: HIDDEN
+    default: ''
+    description: >
+      Output directories.
+
+steps:
+  - name: VRED Render
+    parameterSpace:
+      taskParameterDefinitions:
+        - name: StartFrameFromCurrentChunk
+          type: INT
+          range: "{{Param.StartFrame}}-{{Param.EndFrame}}:{{Param.FramesPerTask}}"
+        - name: TileNumberX
+          type: INT
+          range: "1-{{Param.NumXTiles}}"
+        - name: TileNumberY
+          type: INT
+          range: "1-{{Param.NumYTiles}}"
+    description: Invokes VRED Core, supplying it with render parameter data.
+    script:
+      embeddedFiles:
+        - name: LoadRenderParameterValues
+          filename: load_render_parameter_values.py
+          type: TEXT
+          data: |-
+            from typing import Any, Dict
+
+            def str_to_bool(s:str)->bool: return s.lower() == 'true'
+
+            def get_vred_render_parameters() -> Dict[str, Any]:
+                """
+                *WARNING*: it is imperative to maintain correct value typing for all parameters that you add using
+                the conversion schemes below (for int, str, bool) as a guide. Value types are VRED API
+                sensitive -- they need to be synchronized with future VRED API changes (if any). Please
+                also keep value typing pairwise with parameterDefinitions-supported types (above).
+
+                :return: a dictionary containing appropriately-typed values (non-inferred) for use in VRED API calls.
+                """
+
+                # Depending on implementation, a frame chunk ID or an actual starting frame number that
+                # corresponds to that ID could be provided.
+                #
+                start_frame = int({{Task.Param.StartFrameFromCurrentChunk}})
+                frames_per_task = int({{Param.FramesPerTask}})
+                end_frame = min(start_frame + frames_per_task - 1, int({{Param.EndFrame}}))
+                return {
+                    'AnimationClip': str('{{Param.AnimationClip}}'),
+                    'AnimationType': str('{{Param.AnimationType}}'),
+                    'DLSSQuality': str('{{Param.DLSSQuality}}'),
+                    'DPI': int({{Param.DPI}}),
+                    'EndFrame': int(end_frame),
+                    'FrameStep': int({{Param.FrameStep}}),
+                    'FramesPerTask': int(frames_per_task),
+                    'GPURaytracing': int(str_to_bool('{{Param.GPURaytracing}}')),
+                    'ImageHeight': int({{Param.ImageHeight}}),
+                    'ImageWidth': int({{Param.ImageWidth}}),
+                    'IncludeAlphaChannel': str_to_bool('{{Param.IncludeAlphaChannel}}'),
+                    'JobType': str('{{Param.JobType}}'),
+                    'NumXTiles': int({{Param.NumXTiles}}),
+                    'NumYTiles': int({{Param.NumYTiles}}),
+                    'OutputDir': str(r'{{Param.OutputDir}}'),
+                    'OutputFileNamePrefix': str('{{Param.OutputFileNamePrefix}}'),
+                    'OutputFormat': str('{{Param.OutputFormat}}'),
+                    'OverrideRenderPass': str_to_bool('{{Param.OverrideRenderPass}}'),
+                    'PathMappingRulesFile': str(r'{{Session.PathMappingRulesFile}}'),
+                    'PremultiplyAlpha': str_to_bool('{{Param.PremultiplyAlpha}}'),
+                    'RegionRendering': str_to_bool('{{Param.RegionRendering}}'),
+                    'RenderAnimation': str_to_bool('{{Param.RenderAnimation}}'),
+                    'RenderQuality': str('{{Param.RenderQuality}}'),
+                    'SceneFile': str(r'{{Param.SceneFile}}'),
+                    'SequenceName': str('{{Param.SequenceName}}'),
+                    'SSQuality': str('{{Param.SSQuality}}'),
+                    'StartFrame': int(start_frame),
+                    'TileNumberX': int({{Task.Param.TileNumberX}}),
+                    'TileNumberY': int({{Task.Param.TileNumberY}}),
+                    'TonemapHDR': str_to_bool('{{Param.TonemapHDR}}'),
+                    'View': str('{{Param.View}}'),
+                }
+        - name: VREDInvocation
+          filename: invoke-vred.py
+          type: TEXT
+          runnable: True
+          data: |-
+            # Please set one of the following environment variables: "VREDCORE" or "VREDPRO".
+            # Please ensure that it resolves to a VRED binary executable that is reachable.
+            # You can find relevant executables in paths similar to:
+            #   (Linux): /opt/Autodesk/VREDCluster-{version}/bin/VREDCore
+            #   (Windows): C:/Program Files/Autodesk/VREDPro-{version}/bin/WIN64/VREDCore.exe"
+            # Note: if both of these environment variables are assigned, then "VREDCORE" will be take precedence.
+            #
+            import io
+            import os
+            import platform
+            import subprocess
+            import sys
+
+            sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
+
+            CODE_PASSING_ENV_VAR = "BOOTSTRAP_CODE"
+            DISABLE_PYTHON_SANDBOX_PARAM = "-insecure_python"
+            DISABLE_WEBINTERFACE_ENV_VAR = "VRED_DISABLE_WEBINTERFACE"
+            DISABLE_WEBINTERFACE_VALUE = "1"
+            ERROR_UNKNOWN_VRED_PATH = (
+                "Cannot determine valid VRED binary to invoke from VREDCORE and VREDPRO environment "
+                "variables."
+            )
+            FAST_START_PARAM = "-fast_start"
+            FLEXLM_DIAGNOSTICS_ENV_VAR = "FLEXLM_DIAGNOSTICS"
+            FLEXLM_DIAGNOSTICS_HIGH_VALUE = "3"
+            HIDE_GUI_PARAM = "-hide_gui"
+            IS_WINDOWS = platform.system().lower() == "windows"
+            LICENSE_RELEASE_TIME_ENV_VAR = "VRED_IDLE_LICENSE_TIME"
+            LICENSE_RELEASE_TIME_SECONDS_LIMIT = "60"
+            POST_PYTHON_PARAM = "-postpython"
+            VRED_CORE_ENV_VAR = "VREDCORE"
+            VRED_PRO_ENV_VAR = "VREDPRO"
+
+            # Invoke code found in VRED_PYTHON_BOOTSTRAP_CODE via CODE_PASSING_ENV_VAR without using import statements.
+            # Remove all spaces to prevent VRED from assuming non-intended arguments.
+            #
+            VRED_PYTHON_PRE_BOOTSTRAP_CODE = fr"""
+            load_module = getattr(__builtins__, '__import__');
+            os = load_module('os');
+            exec(os.environ.get('{CODE_PASSING_ENV_VAR}'));
+            """.replace(
+                "\n", ""
+            ).replace(
+                " ", ""
+            )
+            # Inject render parameters into render script, loading both of them at startup, enforce universal exit
+            #
+            VRED_PYTHON_BOOTSTRAP_CODE = r"""
+            import importlib;
+            import os;
+            import sys;
+            from vrController import terminateVred, vrLogError;
+            sys.path.extend([r'{{Param.JobScriptDir}}', os.path.dirname(r'{{Task.File.LoadRenderParameterValues}}')]);
+            render_module_name='VRED_RenderScript_DeadlineCloud';
+            render_param_module_name='load_render_parameter_values';
+            render_module = importlib.util.find_spec(render_module_name) is not None and importlib.import_module(
+            render_module_name) or None;
+            render_param_module = importlib.util.find_spec(render_param_module_name) is not None and importlib.import_module(
+            render_param_module_name) or None;
+            render_module.deadline_cloud_render(
+            render_param_module.get_vred_render_parameters()) if render_module and render_param_module else vrLogError(
+            'failed to import module for render script and/or render parameters');
+
+            terminateVred();
+            """.replace(
+                "\n", ""
+            ).replace(
+                "\\", "/"
+            )
+
+
+            def get_vred_executable() -> str:
+                """
+                Determine VRED binary to use based on environment variable state and binary availability
+                return: path to VRED binary
+                raise: OSError: if a valid binary can't be determined.
+                """
+                try:
+                    vred_executable = os.environ[VRED_CORE_ENV_VAR]
+                    if not os.path.isfile(vred_executable):
+                        raise FileNotFoundError(f"VREDCORE binary not found at: {vred_executable}")
+                except (KeyError, FileNotFoundError):
+                    try:
+                        vred_executable = os.environ[VRED_PRO_ENV_VAR]
+                        if not os.path.isfile(vred_executable):
+                            raise FileNotFoundError(f"VREDPRO binary not found at: {vred_executable}")
+                    except (KeyError, FileNotFoundError):
+                        raise OSError(ERROR_UNKNOWN_VRED_PATH)
+                return vred_executable
+
+
+            def setup_vred_environment() -> None:
+                """
+                Disable VRED's web interface, release license on idle, pass bootstrapping code via environment variable
+                """
+                os.environ[DISABLE_WEBINTERFACE_ENV_VAR] = DISABLE_WEBINTERFACE_VALUE
+                os.environ[LICENSE_RELEASE_TIME_ENV_VAR] = LICENSE_RELEASE_TIME_SECONDS_LIMIT
+                os.environ[CODE_PASSING_ENV_VAR] = VRED_PYTHON_BOOTSTRAP_CODE
+                os.environ[FLEXLM_DIAGNOSTICS_ENV_VAR] = FLEXLM_DIAGNOSTICS_HIGH_VALUE
+
+            def invoke_vred(vred_executable: str) -> None:
+                """
+                Invoke VRED binary, passing it parameters to run headless, grant script access, load scene file,
+                and execute code for the render process to complete
+                param: vred_executable: path to VRED binary
+                """
+                executable = f'"{vred_executable}"' if IS_WINDOWS else vred_executable
+                scene_file_path = r'"{{Param.SceneFile}}"' if IS_WINDOWS else r"{{Param.SceneFile}}"
+                command_and_arg_list: list[str] = [
+                    executable,
+                    scene_file_path,
+                    DISABLE_PYTHON_SANDBOX_PARAM,
+                    FAST_START_PARAM,
+                    HIDE_GUI_PARAM,
+                    POST_PYTHON_PARAM,
+                    VRED_PYTHON_PRE_BOOTSTRAP_CODE,
+                ]
+                try:
+                    invocation = " ".join(command_and_arg_list) if IS_WINDOWS else command_and_arg_list
+                    output = subprocess.run(invocation, stderr=subprocess.STDOUT, check=True, text=True)
+                    print(output)
+                except subprocess.CalledProcessError as error:
+                    print(f"Command: [{invocation}] failed: \n{error.output}\n with return code {error.returncode}")
+
+            setup_vred_environment()
+            invoke_vred(get_vred_executable())
+      actions:
+        onRun:
+          command: python
+          args: [ '{{Task.File.VREDInvocation}}' ]
+    hostRequirements:
+      amounts:
+        - name: amount.worker.gpu
+          min: 1
+      attributes:
+        - name: attr.worker.os.family
+          anyOf:
+            - linux
+            - windows
+  - name: Tile Assembly
+    description: Combines tiles into individual frames. (step can be excluded as needed.)
+    dependencies:
+    - dependsOn: VRED Render
+    script:
+      actions:
+        onRun:
+          command: python
+          args: [ "{{Task.File.Assembler}}"]
+      embeddedFiles:
+      - name: Assembler
+        type: TEXT
+        runnable: True
+        data: |-
+          import concurrent.futures
+          import os
+          import platform
+          import subprocess
+
+          IS_WINDOWS = platform.system().lower() == "windows"
+
+          # Path to the ImageMagick binary, either by using the "MAGICK" env variable if it's set, 
+          # or by defaulting to the "magick" command
+          MAGICK_BIN = os.path.normpath(os.environ.get("MAGICK") or "magick").replace("\\", "/")
+
+          EVALUATE_SEQUENCE_PARAM = "-evaluate-sequence"
+          EVALUATE_SEQUENCE_PARAM_VALUE = "max"
+          MIN_WORKERS_IF_UNKNOWN = 4
+          NUM_X_TILES = int("{{Param.NumXTiles}}")
+          NUM_Y_TILES = int("{{Param.NumYTiles}}")
+          OUTPUT_DIR = os.path.normpath(r"{{Param.OutputDir}}").replace("\\", "/")
+          OUTPUT_FILE_PREFIX = "{{Param.OutputFileNamePrefix}}"
+          OUTPUT_FORMAT = "{{Param.OutputFormat}}".lower()
+          START_FRAME = int("{{Param.StartFrame}}")
+          END_FRAME = int("{{Param.EndFrame}}")
+          IS_RENDER_ANIMATION = "{{Param.RenderAnimation}}".lower() == "true"
+
+          def assemble_frame(frame_num: int) -> None:
+              """
+              Assembles a given frame from the tiles that comprise it.
+              When "Render Animation" is enabled, VRED appends frame numbers to output filenames,
+              so we need to account for this in both input and output filename formats.
+
+              Filename formats:
+              - Single frame: prefix_YxX_AxB.suffix -> prefix.suffix
+              - Animation (multiple frames): prefix_YxX_AxB-NNNNN.suffix -> prefix-NNNNN.suffix
+              """
+
+              # Note: tile value is [columns count]x[rows count]
+              tile_value = f"{NUM_X_TILES}x{NUM_Y_TILES}"
+              frame_suffix = f"-{frame_num:05d}" if IS_RENDER_ANIMATION else ""
+              input_file_mask = f"{OUTPUT_DIR}/*_{tile_value}{frame_suffix}.{OUTPUT_FORMAT}"
+              output_file = f"{OUTPUT_DIR}/{OUTPUT_FILE_PREFIX}{frame_suffix}.{OUTPUT_FORMAT}"              
+
+              command_and_arg_list: list[str] = [
+                  MAGICK_BIN,
+                  input_file_mask,
+                  EVALUATE_SEQUENCE_PARAM,
+                  EVALUATE_SEQUENCE_PARAM_VALUE,
+                  output_file,
+              ]
+
+              try:
+                  invocation = " ".join(command_and_arg_list) if IS_WINDOWS else command_and_arg_list
+                  result = subprocess.run(invocation, capture_output=True, check=True, text=True)
+                  print(f"command invocation result: {result}")
+              except subprocess.CalledProcessError as error:
+                  print(f"Command: {invocation} failed with return code {error.returncode}")
+                  print(f"--------------- STDOUT ---------------\n{error.stdout}")
+                  print(f"--------------- STDERR ---------------\n{error.stderr}")
+
+          # Parallel processing of frames
+          max_workers = os.cpu_count() or MIN_WORKERS_IF_UNKNOWN
+          with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+              for frame in range(START_FRAME, END_FRAME + 1):
+                  future = executor.submit(assemble_frame, frame)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
AWS Deadline Cloud now supports Autodesk VRED rendering. We would like to provide users a sample job bundle template to submit VRED rendering jobs to render queues. 

### What was the solution? (How)
Added a VRED render job bundle containing:
- Job template (`template.yaml`)
- Job template with region/tile rendering feature (`template_tiling.yaml`): Extended template with tile assembly capabilities for large image rendering
- Render controller script (`VRED_RenderScript_DeadlineCloud.py`): Python script that interfaces with VRED's API to execute rendering operations
- `README.md`: setup requirements, usage instructions, and parameter descriptions

### What is the impact of this change?
Provide users a sample job bundle template to submit VRED rendering jobs

### How was this change tested?
1. Submitted the job bundle (including a lightweight scene file) with the GUI submitter:
```bash
deadline bundle gui-submit .
```
  - Submitted to the queue with GPU-based SMF associated.
  - Made sure to setup the Conda Queue Environment in order to use `vredcore` package that is available in `deadline-cloud` conda channel.
  - Made sure that BYOL is also enabled.
2. Confirmed that the job rendering was successful.

### Was this change documented?
Added a README in this new job bundle.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*