### PR TITLE
fix: update licensing path for Maya 2026

### DIFF
--- a/conda_recipes/maya-2026/recipe/build.sh
+++ b/conda_recipes/maya-2026/recipe/build.sh
@@ -29,7 +29,7 @@ mkdir -p "$SRC_DIR/download"
 cd "$SRC_DIR/download"
 dnf download --resolve -y freetype alsa-lib fontconfig harfbuzz libbrotli graphite2 \
     libxkbfile xcb-util-cursor xcb-util-wm xcb-util-keysyms libxkbcommon-x11 \
-    libva libvdpau pciutils-libs fontconfig
+    libva libvdpau pciutils-libs
 
 for RPM_FILE in *.rpm; do
     rpm2cpio "$RPM_FILE" | cpio -idm
@@ -74,7 +74,7 @@ ln -r -s $PREFIX/$MAYA_ROOT/bin/Render $PREFIX/bin/Render
 # and the Arnold support tip "error: (44) Product key not found"
 # at https://arnoldsupport.com/2022/02/02/error-44-product-key-not-found/.
 
-unzip -j "$SRC_DIR/installer/Packages/package.zip" bin/ProductInformation.pit -d "$INSTALL_DIR"
+unzip -j "$SRC_DIR/installer/Packages/package.zip" bin/ProductInformation.pit -d "$INSTALL_DIR/lib"
 
 cat <<EOF > "$INSTALL_DIR"/AdlmThinClientCustomEnv.xml
 <?xml version="1.0"encoding="utf-8"?>


### PR DESCRIPTION
Fixes: *<insert link to GitHub issue here>*

### What was the problem/requirement? (What/Why)
When submitting a render with mtoa, the job failed since it could not find the license ProductInformation.pit file. 

### What was the solution? (How)
Fixed this by unzipping it into $INSTALL_DIR/lib folder, which allows it to be found, and the job to succeed.

Also, removed a package that was installed twice.

### What is the impact of this change?
Using this conda script and the mtoa sceript, users can successfully render an scene using mtoa.

### How was this change tested?

- Submitted a job using Maya and MayatoArnold, and verified that the job succeeded and no licensing issues were showing up.
<img width="775" height="201" alt="image" src="https://github.com/user-attachments/assets/2ef9dfbd-b85c-4ead-b93e-b139f2cc77d9" />

```
2025/08/11 11:40:42-07:00 ADAPTOR_OUTPUT: STDERR: Updating Arnold Scene...
2025/08/11 11:40:42-07:00 ADAPTOR_OUTPUT: STDOUT: 00:00:03   833MB         | log started Mon Aug 11 18:40:41 2025
2025/08/11 11:40:42-07:00 ADAPTOR_OUTPUT: STDOUT: 00:00:03   833MB         | Arnold 7.4.0.0 [516ade3d] linux x86_64 clang-15.0.7 oiio-2.6.3 osl-1.13.3 vdb-11.0.0 adlsdk-9.5.0.53 clmhub-3.1.1.43 rlm-14.2.5 optix-8.0.0 2025/02/04 21:52:37
2025/08/11 11:40:42-07:00 ADAPTOR_OUTPUT: STDOUT: 00:00:03   833MB         | host application: MtoA 5.5.0 6b6ae951 (HEAD) Maya 2026
2025/08/11 11:40:42-07:00 ADAPTOR_OUTPUT: STDOUT: 00:00:03   833MB         | running on ip-100-100-44-154.us-west-2.compute.internal, pid=13951
2025/08/11 11:40:42-07:00 ADAPTOR_OUTPUT: STDOUT: 00:00:03   833MB         |  1 x AMD EPYC 7R13 Processor (1 cores, 2 logical) with 15611MB
2025/08/11 11:40:42-07:00 ADAPTOR_OUTPUT: STDOUT: 00:00:03   833MB         |  Amazon Linux 2023, Linux kernel 6.1.144-170.251.amzn2023.x86_64
2025/08/11 11:40:42-07:00 ADAPTOR_OUTPUT: STDOUT: 00:00:03   833MB         |  soft limit for open files is set at 65533
2025/08/11 11:40:42-07:00 ADAPTOR_OUTPUT: STDOUT: 00:00:03   833MB         |  
2025/08/11 11:40:42-07:00 ADAPTOR_OUTPUT: STDOUT: 00:00:03   833MB         | 
2025/08/11 11:40:42-07:00 ADAPTOR_OUTPUT: STDOUT: 00:00:03   833MB         | authorizing with default license managers: rlm, network, user ...
2025/08/11 11:40:42-07:00 ADAPTOR_OUTPUT: STDOUT: 00:00:04   842MB         | [network] authorized for "88169ARNOL_2026_0F" in 0:00.58
2025/08/11 11:40:42-07:00 ADAPTOR_OUTPUT: STDOUT: 00:00:04   842MB         | [network] expiration date: 2026/04/30, in use: 2/5000
```

### Was this change documented?

- N/A

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*