### PR TITLE
chore: Updated READMEs for houdini 20.5 and houdini redshift 2025.

### DIFF
--- a/conda_recipes/houdini-20.5/README.md
+++ b/conda_recipes/houdini-20.5/README.md
@@ -1,36 +1,166 @@
-# Houdini 20.5 Conda Recipe
+# Houdini 20.5 Conda Recipe for AWS Deadline Cloud
 
-## Download the archive file for Linux
+## Overview
 
-Download the houdini-20.5.654-linux_x86_64_gcc11.2.tar.gz file from SideFX.
-Place the file in the `conda_recipes/archive_files` directory in your git clone
-of the [https://github.com/aws-deadline/deadline-cloud-samples](deadline-cloud-samples)
-repository for submitting package build jobs.
+This directory contains a conda build recipe for Houdini 20.5.654, specifically configured for use with AWS Deadline Cloud. This package enables you to run Houdini rendering and processing jobs on Deadline Cloud service-managed fleets.
 
-## Building the package
+## Package Information
 
-Follow this [README](https://github.com/aws-deadline/deadline-cloud-samples/blob/mainline/conda_recipes/README.md) to get everything set
-up to submit pacakge build jobs.
+- **Application**: Houdini 20.5.654
+- **Supported Platforms**: linux-64
+- **Source**: SideFX Houdini downloads page
+- **License**: SideFXEULA
+- **Build Tool**: rattler-build
 
-To submit a package build job for Houdini 20.5, enter the `conda_recipes` directory and run the following
-from your shell:
+## Prerequisites
+
+Before building this package, ensure you have:
+
+1. **AWS Deadline Cloud infrastructure** set up with:
+   - A farm configured for package building. See https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/cloudformation/farm_templates/starter_farm for instructions to create a Farm.
+   - A queue named "Package Build Queue". See https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/configure-jobs-s3-channel.html for instructions on creating a package building queue. 
+   - Linux-64 fleet for building linux packages
+
+2. **Deadline Cloud CLI** installed on your workstation
+
+3. **SideFX account** for downloading Houdini installer
+
+4. **Source archive** (see [Archive File Instructions](#archive-file-instructions) below)
+
+## Archive File Instructions
+
+### Linux
+
+#### Download from SideFX
+1. Download the `houdini-20.5.654-linux_x86_64_gcc11.2.tar.gz` from SideFX Houdini's downloads page
+2. Verify the SHA256 hash matches: `05e877c06216e102a040e11b6b7fd8364dc699ed01b9386fc407564ce722c454`
+3. Clone this repository locally.
+4. Place the downloaded file in the `conda_recipes/archive_files` directory 
+ 
+
+## Plugin Integration
+
+### Plugins
+
+Houdini supports plugins through the use of package files. A package is a json file that tells Houdini where to find plugins. 
+[Houdini Plugin Reference](https://www.sidefx.com/docs/houdini/ref/plugins.html).
+
+Create your package files in `$PREFIX/opt/houdini/packages` and point them to the location of your plugins. See our Redshift for
+Houdini recipe as [an example](conda_recipes/houdini-redshift-2025).
+
+### Plugin Installation Paths
+
+The conda recipe configures the following environment variables and paths for plugin discovery:
+
+```bash
+# Environment variables set by this package
+export HOUDINI_LOCATION=$PREFIX/opt/houdini
+
+# Plugin search paths (in order of precedence)
+$PREFIX/opt/houdini/packages
+```
+
+### Creating Plugin Packages
+
+1. **Plugin Package Structure**
+   ```
+   my-houdini-plugin/
+   ├── recipe/
+   │   ├── recipe.yaml
+   │   ├── build.sh
+   │   └── bld.bat
+   ├── deadline-cloud.yaml
+   └── README.md
+   ```
+
+2. **Plugin Installation Script Example**
+
+   NOTE: Your plugin files can be anywhere as long as your package file points to their directory.
+
+   ```bash
+   # In build.sh
+   mkdir -p $PREFIX/opt/houdini/packages
+   cp my-plugin.json $PREFIX/opt/houdini/packages/
+   cp -r plugin-files/ $PREFIX/opt/houdini/plugin/
+   ```
+
+3. **Plugin Dependencies**
+   - Add this Houdini package as a dependency in your plugin's `recipe.yaml`
+   - Specify version constraints: `houdini >=20.5,<21`
+
+## Application-Specific Requirements
+
+### Licensing
+
+See the [AWS Deadline Cloud licensing documentation](https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/license.html) for detailed guidance on license configuration. Houdini requires proper licensing configuration for rendering operations.
+
+### System Requirements
+
+- Linux x86_64 with GCC 11.2 compatibility
+- Sufficient memory for scene processing
+- Optional: GPU acceleration may be needed for certain workloads
+
+## Adapting to Other Versions
+
+### Version Update Checklist
+
+To adapt this recipe for Houdini 20.0 or 19.5:
+
+1. **Update Version Information**
+   ```yaml
+   # In recipe/recipe.yaml
+   context:
+     version: "20.0.xxx"  # or desired version
+   
+   # In deadline-cloud.yaml
+   sourceArchiveFilename: houdini-[version]-linux_x86_64_gcc11.2.tar.gz
+   ```
+
+2. **Update Source Archives**
+   - Download new version archives from SideFX
+   - Update SHA256 hashes in `recipe.yaml`
+   - Update source filename in `deadline-cloud.yaml`
+
+3. **Check Dependencies**
+   - Review and update dependency versions
+   - Update minimum system requirements
+
+4. **Update Build Scripts**
+   - Check for changes in installation directory structure
+   - Update file copy operations in build scripts
+   - Verify environment variable paths
+
+5. **Test Plugin Compatibility**
+   - Verify plugin paths haven't changed
+   - Test with existing plugin packages like Redshift
+   - Update plugin integration documentation
+
+
+### Common Version Migration Issues
+
+- **Path Changes**: Installation directories may change between versions
+- **Dependency Updates**: New versions may require different dependencies
+- **Plugin API Changes**: Plugin interfaces may be incompatible between major versions
+- **License Changes**: Licensing requirements may change
+
+## Recipe Structure
 
 ```
-./submit-package-job houdini-20.5
+houdini-20.5/
+├── README.md                    # This file
+├── deadline-cloud.yaml          # Deadline Cloud configuration
+└── recipe/
+    ├── recipe.yaml             # Rattler-build recipe
+    └── build.sh                # Linux build script
 ```
 
-## Instructions for Houdini plugin packages
+## Resources
 
-When creating a plugin package for Houdini, place its package file in the following
-location so that Houdini loads the plugin at startup. Refer to the Houdini
-[plugins documentation](https://www.sidefx.com/docs/houdini/ref/plugins.html) page
-for more details on creating package files.
+- **Houdini Documentation**: https://www.sidefx.com/docs/houdini/
+- **AWS Deadline Cloud Developer Guide**: https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/
+- **Rattler Build Documentation**: https://prefix-dev.github.io/rattler-build/
+- **Plugin Development**: https://www.sidefx.com/docs/houdini/ref/plugins.html
 
-* `$PREFIX/opt/houdini/packages`
+---
 
-## Adapting for other Houdini versions
-This recipe is written for Houdini 20.5.654, but should be able to be adapted
-for any 20.5 patch release or even modified to work with older Houdini versions
-such as 19.5 or 20.0. At minimum you would need to grab the specific installers
-for a different version and modify the `sourceArchiveFilename` in `deadline-cloud.yaml`
-and the version string and archive hash in `recipe.yaml`.
+**Note**: This recipe is specifically configured for Houdini 20.5.654 on Linux x86_64 platforms.

--- a/conda_recipes/houdini-redshift-2025/README.md
+++ b/conda_recipes/houdini-redshift-2025/README.md
@@ -1,43 +1,173 @@
-# Redshift for Houdini Conda Recipe
+# Redshift for Houdini 2025 Conda Recipe for AWS Deadline Cloud
 
-## Download the installer for Linux
+## Overview
 
-Download the Redshift installer `redshift_2025.6.0_1924545106_linux_x64.run` from Maxon.
-Place the file in the `conda_recipes/archive_files` directory in your git clone
-of the [https://github.com/aws-deadline/deadline-cloud-samples](deadline-cloud-samples)
-repository for submitting package build jobs.
+This directory contains a conda build recipe for Redshift for Houdini 2025.6.0, specifically configured for use with AWS Deadline Cloud. This package enables you to run Redshift rendering jobs with Houdini on Deadline Cloud service-managed fleets.
 
-## Building the package
+## Package Information
 
-Follow this [README](https://github.com/aws-deadline/deadline-cloud-samples/blob/mainline/conda_recipes/README.md) to get everything set
-up to submit package build jobs.
+- **Application**: Redshift for Houdini 2025.6.0_1924545106
+- **Supported Platforms**: linux-64
+- **Source**: Maxon website
+- **License**: LicenseRef-MaxonEULA
+- **Build Tool**: rattler-build
 
-To submit a package build job for Redshift for Houdini, enter the `conda_recipes` directory and run the following
-from your shell:
+## Prerequisites
+
+Before building this package, ensure you have:
+
+1. **AWS Deadline Cloud infrastructure** set up with:
+   - A farm configured for package building
+   - A queue named "Package Build Queue" (or specify with `-q` option)
+   - Linux-64 fleet for building linux packages
+
+2. **Deadline Cloud CLI** installed on your workstation
+
+3. **Source archive** (see [Archive File Instructions](#archive-file-instructions) below)
+
+4. **Maxon account** for downloading Redshift installer
+
+5. **A Houdini conda package** as this is a plugin dependency
+
+## Archive File Instructions
+
+### Linux
+
+#### Download from Maxon
+1. Download the `redshift_2025.6.0_1924545106_linux_x64.run` installer from the Maxon website
+2. Place the downloaded file in the `conda_recipes/archive_files` directory
+3. Verify the SHA256 hash matches: `bdf0d787b3c991f1401bb31e2037a52a7ef686445812abed2d162882eb048039`
+
+## Plugin Integration
+
+### Plugin Architecture
+
+Redshift integrates with Houdini through a plugin system that requires version-specific compatibility. This package automatically detects the installed Houdini version and configures the appropriate Redshift plugin version.
+This recipe creates a package in `"$PREFIX/opt/houdini/packages"` which points to the plugin. For more information about Houdini packages, see the [Houdini Packages documentation](https://www.sidefx.com/docs/houdini/ref/plugins.html).
+
+### Plugin Installation Paths
+
+The conda recipe configures Redshift to integrate with Houdini installations:
+
+```bash
+# Environment variables set by this package
+export REDSHIFT_LOCATION=$PREFIX/opt/redshift
+
+# Integration with Houdini
+# Redshift plugins are installed to match Houdini version requirements
+```
+
+### Version Compatibility Logic
+
+This package implements intelligent version matching:
+
+1. **Exact Match**: Looks for an exact match between the Houdini version and available Redshift plugin versions
+2. **Major.Minor Match**: If no exact match is found, uses a plugin version that matches the major.minor version of Houdini
+3. **Fallback**: If no matching major.minor version is found, the package will exit and not configure Redshift
+4. **Version Detection**: If the `houdini --version` call doesn't print a valid version string, the package will exit
+
+### Creating Related Plugin Packages
+
+1. **Plugin Package Structure**
+   ```
+   my-redshift-extension/
+   ├── recipe/
+   │   ├── recipe.yaml
+   │   ├── build.sh
+   │   └── bld.bat
+   ├── deadline-cloud.yaml
+   └── README.md
+   ```
+
+2. **Plugin Dependencies**
+   - Add both Houdini and Redshift packages as dependencies in your plugin's `recipe.yaml`
+   - Specify version constraints: `houdini >=20.5,<21` and `houdini-redshift >=2025.6.0`
+
+## Application-Specific Requirements
+
+### Licensing
+
+See the [AWS Deadline Cloud licensing documentation](https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/license.html) for detailed guidance on license configuration. Redshift requires proper licensing configuration for rendering operations.
+
+### GPU Requirements
+
+Redshift is a GPU-accelerated renderer with specific requirements. See the [Redshift documentation](https://www.maxon.net/en/requirements/redshift-requirements) for full list.:
+- NVIDIA GPU with CUDA support
+- Minimum 8GB VRAM 
+- CUDA compute capability 6.0 or higher
+
+### System Requirements
+
+- Linux x86_64 compatibility
+- Compatible Houdini installation (20.5+, <21)
+- NVIDIA drivers with CUDA support
+
+## Adapting to Other Versions
+
+### Version Update Checklist
+
+To adapt this recipe for other Redshift versions:
+
+1. **Update Version Information**
+   ```yaml
+   # In recipe/recipe.yaml
+   context:
+     version: "2025.x.x_xxxxxxxx"  # new version
+   
+   # In deadline-cloud.yaml
+   sourceArchiveFilename: redshift_[version]_linux_x64.run
+   ```
+
+2. **Update Source Archives**
+   - Download new version installer from Maxon
+   - Update SHA256 hash in `recipe.yaml`
+   - Update source filename in `deadline-cloud.yaml`
+
+3. **Check Houdini Compatibility**
+   - Verify supported Houdini versions for the new Redshift release
+   - Update dependency constraints in `recipe.yaml`
+   - Test version detection logic
+
+4. **Update Build Scripts**
+   - Check for changes in installer structure
+   - Update file extraction and installation paths
+
+5. **Test Integration**
+   - Verify Redshift loads correctly in Houdini
+   - Test rendering functionality
+   - Validate version matching logic
+
+6. **Update Documentation**
+   - Update version numbers throughout README
+   - Update Houdini compatibility information
+   - Update any version-specific requirements
+
+### Common Version Migration Issues
+
+- **Houdini Compatibility**: New Redshift versions may drop support for older Houdini versions
+- **Plugin Structure Changes**: Installation directory structure may change
+- **Dependency Updates**: New versions may require different system dependencies
+- **License Changes**: Licensing requirements may change between versions
+
+## Recipe Structure
 
 ```
-./submit-package-job houdini-redshift-2025
+houdini-redshift-2025/
+├── README.md                    # This file
+├── deadline-cloud.yaml          # Deadline Cloud configuration
+└── recipe/
+    ├── recipe.yaml             # Rattler-build recipe
+    └── build.sh                # Linux build script with version detection
 ```
 
-## Integration with Houdini
+## Resources
 
-This package is designed to work with the [Houdini conda package](../houdini-20.5/README.md). It automatically detects the
-installed Houdini version by calling `houdini --version` and configures the appropriate Redshift plugin version. 
+- **Redshift Documentation**: https://help.maxon.net/r3d/houdini/en-us/
+- **Houdini Plugin Configuration**: https://help.maxon.net/r3d/houdini/en-us/Content/html/Houdini+Plugin+Configuration.html
+- **AWS Deadline Cloud Developer Guide**: https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/
+- **Rattler Build Documentation**: https://prefix-dev.github.io/rattler-build/
+- **Maxon Redshift**: https://www.maxon.net/en/redshift
 
-Redshift plugins for Houdini are versioned to the exact patch release of Houdini. Using a Redshift plugin version that
-isn't for the exact same Houdini version can result in instability. This package will attempt to use the best Redshift
-plugin version to match the version of Houdini provided by:
-1. Looking for an exact match between the Houdini version and available Redshift plugin versions
-2. If no exact match is found, it will use a plugin version that matches the major.minor version of Houdini
-3. If no matching major.minor version is found, the package will exit and not configure Redshift
-4. If the `houdini --version` call doesn't print a valid version string, the package will exit and not configure Redshift
+---
 
-## Adapting for other Redshift versions
-
-This recipe can be adapted for other Redshift versions by modifying the `sourceArchiveFilename` in `deadline-cloud.yaml`
-and the version string in `recipe.yaml`. You may also need to update the build script if the Redshift installer structure
-changes between versions.
-
-> **Warning**: When changing the Redshift version, be sure to check what versions of Houdini it supports due to how the
-plugin [integrates with Houdini](#integration-with-houdini). Details on Redshift version support for Houdini can be
-found [here](https://help.maxon.net/r3d/houdini/en-us/Content/html/Houdini+Plugin+Configuration.html).
+**Warning**: When changing the Redshift version, be sure to check what versions of Houdini it supports due to the strict version compatibility requirements. This package includes automatic version detection to prevent incompatible combinations.


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

We want to update our READMEs with a consistent format with additional instructions. 

### What was the solution? (How)

Updated the READMEs for Houdini and Redshift for Houdini. 

They now include:
- General Package Information
- Prerequisites
- Instructions to generate the archive files
- How to add Plugins
- Application specific details 
- How to update the recipe for different versions
- Outline of the package structure
- Links to additional resources

### What is the impact of this change?

README should be clearer and more comprehensive. 

### How was this change tested?

N/A

### Was this change documented?

N/A

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*