### PR TITLE
feat: add C4DtoA conda build sample

### DIFF
--- a/conda_recipes/cinema4d-c4dtoa-2025/README.md
+++ b/conda_recipes/cinema4d-c4dtoa-2025/README.md
@@ -11,11 +11,6 @@ automatically.
 
 ## Building the package for Windows
 
-[Install](https://help.autodesk.com/view/ARNOL/ENU/?guid=arnold_for_cinema_4d_ci_Installation_ci_Installing_Arnold_for_Cinema_4D_on_Windows_html)
-C4DtoA and copy C:\Program Files\Maxon Cinema 4D 2025\plugins\C4DtoA into
-[`conda_recipes/archive_files/cinema4d-c4dtoa-2025/win-64`](../archive_files/cinema4d-c4dtoa-2025/win-64/)
-
-
 To build the c4dtoA package, follow these instructions:
 
 1. Install the Cinema 4D to Arnold plugin by following [instructions here](https://help.autodesk.com/view/ARNOL/ENU/?guid=arnold_for_cinema_4d_ci_Installation_ci_Installing_Arnold_for_Cinema_4D_on_Windows_html).
@@ -26,9 +21,21 @@ To build the c4dtoA package, follow these instructions:
 3. Copy the "C4DtoA" folder from your installation directory to `conda_recipes/archive_files/cinema4d-c4dtoa-2025/win-64`.
   (The default installation location on Windows is `C:\Program Files\Maxon Cinema 4D 2025\plugins\C4DtoA`)
 
-### Build the package on a Deadline Cloud build queue
+### Build the package on Deadline Cloud
 
-Follow [this guide](https://aws.amazon.com/blogs/media/create-a-conda-package-and-channel-for-aws-deadline-cloud/) to build the package on Deadline Cloud.
+If you create a package build queue as described in the Deadline Cloud developer guide page
+[Create a conda channel using S3](https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/configure-jobs-s3-channel.html),
+you can submit the package to build on your farm.
+
+Note that this approach automatically determines a new build number each time you run
+the package build job, you do not have to handle that yourself like when building locally.
+
+```
+C:\Dev\deadline-cloud-samples\conda_recipes>submit-package-job cinema4d-c4dtoa-2025
+No channel URL was provided, using a default prefix on the queue's job attachments bucket
+Building packages into channel s3://<MY_S3_CHANNEL_BUCKET>/Conda/Default
+...
+```
 
 ### Build the package locally
 
@@ -91,19 +98,3 @@ Here's an example of doing this for the package that was built by rattler-build:
     upload: temp-local-channel\win-64\repodata.json to s3://<MY_S3_CHANNEL_BUCKET>/Conda/Default/win-64/repodata.json
     ...
     ```
-
-### Build the package on Deadline Cloud
-
-If you create a package build queue as described in the Deadline Cloud developer guide page
-[Create a conda channel using S3](https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/configure-jobs-s3-channel.html),
-you can submit the package to build on your farm.
-
-Note that this approach automatically determines a new build number each time you run
-the package build job, you do not have to handle that yourself like when building locally.
-
-```
-C:\Dev\deadline-cloud-samples\conda_recipes>submit-package-job cinema4d-c4dtoa-2025
-No channel URL was provided, using a default prefix on the queue's job attachments bucket
-Building packages into channel s3://<MY_S3_CHANNEL_BUCKET>/Conda/Default
-...
-```

--- a/conda_recipes/cinema4d-c4dtoa-2025/README.md
+++ b/conda_recipes/cinema4d-c4dtoa-2025/README.md
@@ -5,12 +5,19 @@
 This package build recipe creates a conda package for the C4DtoA plugin you
 provide in an input folder.
 
+Usage based licensing is available on [Deadline Cloud SMF](https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/cmf-ubl.html)
+automatically.
+
 
 ## Building the package for Windows
 
-Copy the c4dtoa plugin folder into
+[Install](https://help.autodesk.com/view/ARNOL/ENU/?guid=arnold_for_cinema_4d_ci_Installation_ci_Installing_Arnold_for_Cinema_4D_on_Windows_html)
+C4DtoA and copy C:\Program Files\Maxon Cinema 4D 2025\plugins\C4DtoA into
 [`conda_recipes/archive_files/cinema4d-c4dtoa-2025/win-64`](../archive_files/cinema4d-c4dtoa-2025/win-64/)
-You can find the plugin locally in your Cinema 4D preferences folder.
+
+### Build the package on a Deadline Cloud build queue
+
+Follow [this guide](https://aws.amazon.com/blogs/media/create-a-conda-package-and-channel-for-aws-deadline-cloud/) to build the package on Deadline Cloud.
 
 ### Build the package locally
 

--- a/conda_recipes/cinema4d-c4dtoa-2025/README.md
+++ b/conda_recipes/cinema4d-c4dtoa-2025/README.md
@@ -22,7 +22,7 @@ To build the c4dtoA package, follow these instructions:
   i. We have used "C4DtoA-4.8.3.2-windows-2025.exe" with "Cinema 4D 2025.3.3"
     in this example, but theoretically it should work with other versions as
     well. Ensure that the C4DtoA and Cinema 4D versions are compatible with each other.
-2. [Optional] Verify that "Arnold" works with Cinema 4D locally. You can test this using any of the sample scenes available here.
+2. [Optional] Verify that "Arnold" works with Cinema 4D locally. You can test this using any of the sample scenes available [here](https://help.autodesk.com/view/ARNOL/ENU/?guid=arnold_for_cinema_4d_ci_Tutorials_ci_Learning_Scenes_html).
 3. Copy the "C4DtoA" folder from your installation directory to `conda_recipes/archive_files/cinema4d-c4dtoa-2025/win-64`.
   (The default installation location on Windows is `C:\Program Files\Maxon Cinema 4D 2025\plugins\C4DtoA`)
 

--- a/conda_recipes/cinema4d-c4dtoa-2025/README.md
+++ b/conda_recipes/cinema4d-c4dtoa-2025/README.md
@@ -15,6 +15,17 @@ automatically.
 C4DtoA and copy C:\Program Files\Maxon Cinema 4D 2025\plugins\C4DtoA into
 [`conda_recipes/archive_files/cinema4d-c4dtoa-2025/win-64`](../archive_files/cinema4d-c4dtoa-2025/win-64/)
 
+
+To build the c4dtoA package, follow these instructions:
+
+1. Install the Cinema 4D to Arnold plugin by following [instructions here](https://help.autodesk.com/view/ARNOL/ENU/?guid=arnold_for_cinema_4d_ci_Installation_ci_Installing_Arnold_for_Cinema_4D_on_Windows_html).
+  i. We have used "C4DtoA-4.8.3.2-windows-2025.exe" with "Cinema 4D 2025.3.3"
+    in this example, but theoretically it should work with other versions as
+    well. Ensure that the C4DtoA and Cinema 4D versions are compatible with each other.
+2. [Optional] Verify that "Arnold" works with Cinema 4D locally. You can test this using any of the sample scenes available here.
+3. Copy the "C4DtoA" folder from your installation directory to `conda_recipes/archive_files/cinema4d-c4dtoa-2025/win-64`.
+  (The default installation location on Windows is `C:\Program Files\Maxon Cinema 4D 2025\plugins\C4DtoA`)
+
 ### Build the package on a Deadline Cloud build queue
 
 Follow [this guide](https://aws.amazon.com/blogs/media/create-a-conda-package-and-channel-for-aws-deadline-cloud/) to build the package on Deadline Cloud.
@@ -38,6 +49,9 @@ C:\Dev\deadline-cloud-samples\conda_recipes>dir C:\...\conda-bld\win-64
 04/10/2025  02:21 PM           232,806 cinema4d-c4dtoa-2025-0.conda
 ...
 ```
+
+Note: The `--no-test` skips a build error locating cinema4d package only
+required at runtime and already provided by the SMF default Conda environment.
 
 ### Publish the locally built package to an S3 conda channel
 

--- a/conda_recipes/cinema4d-c4dtoa-2025/README.md
+++ b/conda_recipes/cinema4d-c4dtoa-2025/README.md
@@ -1,0 +1,88 @@
+# Conda build recipe for Arnold C4DtoA
+
+## About
+
+This package build recipe creates a conda package for the C4DtoA plugin you
+provide in an input folder.
+
+
+## Building the package for Windows
+
+Copy the c4dtoa plugin folder into
+[`conda_recipes/archive_files/cinema4d-c4dtoa-2025/win-64`](../archive_files/cinema4d-c4dtoa-2025/win-64/)
+You can find the plugin locally in your Cinema 4D preferences folder.
+
+### Build the package locally
+
+
+From the `conda_recipes` directory, run:
+
+```
+C:\Dev\deadline-cloud-samples\conda_recipes>conda build cinema4d-c4dtoa-2025/recipe --no-test
+Adding in variants from internal_defaults
+...
+####################################################################################
+Source and build intermediates have been left in C:\...\conda-bld.
+There are currently 1 accumulated.
+To remove them, you can run the ```conda build purge``` command
+
+C:\Dev\deadline-cloud-samples\conda_recipes>dir C:\...\conda-bld\win-64
+...
+04/10/2025  02:21 PM           232,806 cinema4d-c4dtoa-2025-0.conda
+...
+```
+
+### Publish the locally built package to an S3 conda channel
+
+To publish your package to an S3 conda channel, two things need to happen:
+
+1. Copy the Windows package into the `win-64` subdirectory of the channel.
+2. Update the channel index (`repodata.json` and some other files) so that they
+   include metadata about the new package.
+
+You can accomplish this with the AWS CLI to synchronize S3 data and the `conda index`
+command that is available when you install [conda-build](https://docs.conda.io/projects/conda-build).
+
+Here's an example of doing this for the package that was built by rattler-build:
+
+1. Synchronize the `win-64` subdirectory of the channel locally.
+    ```
+    C:\Dev\deadline-cloud-samples\conda_recipes>set CHANNEL_BUCKET=<MY_S3_CHANNEL_BUCKET>
+
+    C:\Dev\deadline-cloud-samples\conda_recipes>aws s3 sync s3://%CHANNEL_BUCKET%/Conda/Default/win-64 ./temp-local-channel/win-64
+    ...
+    ```
+2. Copy the package you built into the `win-64` subdirectory.
+    ```
+    C:\Dev\deadline-cloud-samples\conda_recipes>copy output\win-64\cinema4d-c4dtoa-2025-h9490d1a_0.conda temp-local-channel\win-64
+            1 file(s) copied.
+    ...
+    ```
+3. Update the channel index with the new package.
+    ```
+    C:\Dev\deadline-cloud-samples\conda_recipes>conda index --subdir win-64 --zst ./temp-local-channel
+    Indexing ['win-64'] does not include 'noarch'
+    ...
+    ```
+4. Synchronize the local copy of the `win-64` subdirectory back to S3.
+    ```
+    C:\Dev\deadline-cloud-samples\conda_recipes>aws s3 sync ./temp-local-channel/win-64 s3://%CHANNEL_BUCKET%/Conda/Default/win-64
+    upload: temp-local-channel\win-64\repodata.json to s3://<MY_S3_CHANNEL_BUCKET>/Conda/Default/win-64/repodata.json
+    ...
+    ```
+
+### Build the package on Deadline Cloud
+
+If you create a package build queue as described in the Deadline Cloud developer guide page
+[Create a conda channel using S3](https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/configure-jobs-s3-channel.html),
+you can submit the package to build on your farm.
+
+Note that this approach automatically determines a new build number each time you run
+the package build job, you do not have to handle that yourself like when building locally.
+
+```
+C:\Dev\deadline-cloud-samples\conda_recipes>submit-package-job cinema4d-c4dtoa-2025
+No channel URL was provided, using a default prefix on the queue's job attachments bucket
+Building packages into channel s3://<MY_S3_CHANNEL_BUCKET>/Conda/Default
+...
+```

--- a/conda_recipes/cinema4d-c4dtoa-2025/deadline-cloud.yaml
+++ b/conda_recipes/cinema4d-c4dtoa-2025/deadline-cloud.yaml
@@ -1,0 +1,5 @@
+condaPlatforms:
+  - platform: win-64
+    defaultSubmit: true
+    sourceArchiveDirectory: cinema4d-c4dtoa-2025/win-64/
+    buildTool: conda-build

--- a/conda_recipes/cinema4d-c4dtoa-2025/recipe/bld.bat
+++ b/conda_recipes/cinema4d-c4dtoa-2025/recipe/bld.bat
@@ -1,0 +1,5 @@
+set "C4D_PLUGINS_DIRECTORY=%PREFIX%\cinema4d\plugins"
+mkdir "%C4D_PLUGINS_DIRECTORY%"
+
+xcopy "%SRC_DIR%" "%C4D_PLUGINS_DIRECTORY%" /E /I /H /Y
+

--- a/conda_recipes/cinema4d-c4dtoa-2025/recipe/bld.bat
+++ b/conda_recipes/cinema4d-c4dtoa-2025/recipe/bld.bat
@@ -1,5 +1,7 @@
+rem To install the plugin we copy it into the Cinema 4D plugins dir
 set "C4D_PLUGINS_DIRECTORY=%PREFIX%\cinema4d\plugins"
 mkdir "%C4D_PLUGINS_DIRECTORY%"
 
+rem /E recursive, /I assume destintion dir, /H copy hidden, /Y suppress prompt
 xcopy "%SRC_DIR%" "%C4D_PLUGINS_DIRECTORY%" /E /I /H /Y
 

--- a/conda_recipes/cinema4d-c4dtoa-2025/recipe/meta.yaml
+++ b/conda_recipes/cinema4d-c4dtoa-2025/recipe/meta.yaml
@@ -1,0 +1,22 @@
+
+package:
+  name: cinema4d-c4dtoa
+  version: "2025"
+
+source:
+- path: ../../archive_files/cinema4d-c4dtoa-2025/win-64 # [win64]
+
+build:
+  number: 0
+  binary_relocation: false
+  detect_binary_files_with_prefix: false
+  ignore_prefix_files: true
+  missing_dso_whitelist:
+    - "**"
+
+requirements:
+  run:
+    - cinema4d >=2025
+
+about:
+  license: LicenseRef-Multiple

--- a/conda_recipes/cinema4d-c4dtoa-2025/recipe/meta.yaml
+++ b/conda_recipes/cinema4d-c4dtoa-2025/recipe/meta.yaml
@@ -19,4 +19,6 @@ requirements:
     - cinema4d >=2025
 
 about:
+  home: https://help.autodesk.com/view/ARNOL/ENU/?guid=arnold_for_cinema_4d_ci_Arnold_for_Cinema_4D_User_Guide_html
   license: Commercial
+  summary: Autodesk Arnold is an advanced cross-platform rendering library, or API, developed by Solid Angle and used by a number of prominent organizations in film, television, and animation, including Sony Pictures Imageworks. It was developed as a photo-realistic, physically-based ray tracing alternative to traditional scanline-based rendering software for CG animation.

--- a/conda_recipes/cinema4d-c4dtoa-2025/recipe/meta.yaml
+++ b/conda_recipes/cinema4d-c4dtoa-2025/recipe/meta.yaml
@@ -19,4 +19,4 @@ requirements:
     - cinema4d >=2025
 
 about:
-  license: LicenseRef-Multiple
+  license: Commercial


### PR DESCRIPTION
Fixes: C4DtoA

### What was the problem/requirement? (What/Why)

Support Arnold

### What was the solution? (How)

C4DtoA example conda package

### What is the impact of this change?

New example package instructions

### How was this change tested?

- On a windows SMF


### Was this change documented?

- Yes README

```
2025/08/25 18:45:38-07:00  
2025/08/25 18:45:38-07:00 ==============================================
2025/08/25 18:45:38-07:00 --------- Running Task
2025/08/25 18:45:38-07:00 ==============================================
2025/08/25 18:45:38-07:00 Parameter values:
2025/08/25 18:45:38-07:00 Frame(INT) = 1
2025/08/25 18:45:38-07:00 ----------------------------------------------
2025/08/25 18:45:38-07:00 Phase: Setup
2025/08/25 18:45:38-07:00 ----------------------------------------------
2025/08/25 18:45:38-07:00 Writing embedded files for Task to disk.
2025/08/25 18:45:38-07:00 Mapping: Task.File.runData -> C:\Sessions\session-2a565fb6840c485a8a1889de363a751c51bw7syi\embedded_files7aursbu9\run-data.yaml
2025/08/25 18:45:38-07:00 Wrote: runData -> C:\Sessions\session-2a565fb6840c485a8a1889de363a751c51bw7syi\embedded_files7aursbu9\run-data.yaml
2025/08/25 18:45:38-07:00 ----------------------------------------------
2025/08/25 18:45:38-07:00 Phase: Running action
2025/08/25 18:45:38-07:00 ----------------------------------------------
2025/08/25 18:45:38-07:00 Running command C:\Users\job-user\.conda\envs\hashname_3b682ebf045e1be8d70602fb\Scripts\cinema4d-openjd.BAT daemon run --connection-file C:\Sessions\session-2a565fb6840c485a8a1889de363a751c51bw7syi/connection.json --run-data file://C:\Sessions\session-2a565fb6840c485a8a1889de363a751c51bw7syi\embedded_files7aursbu9\run-data.yaml
2025/08/25 18:45:38-07:00 Command started as pid: 3000
2025/08/25 18:45:38-07:00 Output:
2025/08/25 18:45:38-07:00  
2025/08/25 18:45:38-07:00 (hashname_3b682ebf045e1be8d70602fb) C:\Sessions\session-2a565fb6840c485a8a1889de363a751c51bw7syi>python C:\Users\job-user\.conda\envs\hashname_3b682ebf045e1be8d70602fb\Scripts\\cinema4d-openjd-script.py daemon run --connection-file C:\Sessions\session-2a565fb6840c485a8a1889de363a751c51bw7syi/connection.json --run-data file://C:\Sessions\session-2a565fb6840c485a8a1889de363a751c51bw7syi\embedded_files7aursbu9\run-data.yaml 
2025/08/25 18:45:38-07:00 INFO: Applying user-level configuration: C:\Users\job-user\.openjd\adaptors\runtime\configuration.json
2025/08/25 18:45:38-07:00 INFO: Applying user-level configuration: C:\Users\job-user\.openjd\adaptors\Cinema4DAdaptor\Cinema4DAdaptor.json
2025/08/25 18:45:38-07:00 ADAPTOR_OUTPUT: 
2025/08/25 18:45:38-07:00 ADAPTOR_OUTPUT: STDOUT: Performing action: {"name": "frame", "args": {"frame": 1}}
2025/08/25 18:45:38-07:00 ADAPTOR_OUTPUT: STDOUT: Performing action: {"name": "start_render", "args": {"frame": 1}}
2025/08/25 18:45:38-07:00 ADAPTOR_OUTPUT: STDOUT: Using normal path mapping (non-POSIX): 'C:\Sessions\session-2a565fb6840c485a8a1889de363a751c51bw7syi\assetroot-d174db6c29db7912a405\arnold_v001' -> 'C:\Sessions\session-2a565fb6840c485a8a1889de363a751c51bw7syi\assetroot-d174db6c29db7912a405\arnold_v001'
2025/08/25 18:45:39-07:00 ADAPTOR_OUTPUT: STDOUT: Analytics error: 1003 - Generic
2025/08/25 18:45:39-07:00 ADAPTOR_OUTPUT: STDOUT: Rendering frame 1 at <Tue Aug 26 01:45:39 2025>
2025/08/25 18:45:40-07:00 ADAPTOR_OUTPUT: STDOUT: Progress: 5%
2025/08/25 18:45:41-07:00 ADAPTOR_OUTPUT: STDOUT: Progress: 84%
2025/08/25 18:45:41-07:00 ADAPTOR_OUTPUT: STDOUT: Progress: 89%
2025/08/25 18:45:41-07:00 ADAPTOR_OUTPUT: STDOUT: Progress: 94%
2025/08/25 18:45:41-07:00 ADAPTOR_OUTPUT: STDOUT: Progress: 100%
2025/08/25 18:45:42-07:00 ADAPTOR_OUTPUT: STDOUT: Finished Rendering
2025/08/25 18:45:42-07:00 INFO: Done Cinema4DAdaptor main
2025/08/25 18:45:42-07:00 Process pid 3000 exited with code: 0 (unsigned) / 0x0 (hex)
2025/08/25 18:45:42-07:00 ----------------------------------------------
2025/08/25 18:45:42-07:00 Uploading output files to Job Attachments
2025/08/25 18:45:42-07:00 ----------------------------------------------
2025/08/25 18:45:42-07:00 Started syncing outputs using Job Attachments
2025/08/25 18:45:43-07:00 Found 1 file totaling 645.69 KB in output directory: C:\Sessions\session-2a565fb6840c485a8a1889de363a751c51bw7syi\assetroot-d174db6c29db7912a405
2025/08/25 18:45:43-07:00 Uploading output manifest to DeadlineCloud/Manifests/farm-a658bf7ce8694040a9a540f16afe84f5/queue-7f848b75a09b4b05bb0624343a9571e9/job-89cbfbd267f3477c8201c1bef97baa4b/step-89f2d403dbe84e579551a46951aa2bcb/task-89f2d403dbe84e579551a46951aa2bcb-0/2025-08-26T01:45:38.359038Z_sessionaction-2a565fb6840c485a8a1889de363a751c-5/4cd456f3ba8052e39ebf3294112f700d_output
2025/08/25 18:45:43-07:00 Uploading 1 output file to S3: gp-deadline-stack-farm/DeadlineCloud/Data
2025/08/25 18:45:43-07:00 Uploaded 645.69 KB / 645.69 KB of 1 file (Transfer rate: 0 B/s)
2025/08/25 18:45:43-07:00 Summary Statistics for file uploads:
Processed 1 file totaling 645.69 KB.
Skipped re-processing 0 files totaling 0 B.
Total processing time of 0.10062 seconds at 6.42 MB/s.

2025/08/25 18:45:43-07:00 Finished syncing outputs using Job Attachments
```

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*