### PR TITLE
feat: add Cinema 4D V-Ray conda build sample

### DIFF
--- a/conda_recipes/cinema4d-vray-2025/README.md
+++ b/conda_recipes/cinema4d-vray-2025/README.md
@@ -15,6 +15,26 @@ provide in an input folder.
 (The default installation location on Windows is C:\Program Files\Maxon Cinema 4D 2025\plugins\V-Ray)
 
 
+### Build the package on Deadline Cloud
+
+If you create a package build queue as described in the Deadline Cloud developer guide page
+[Create a conda channel using S3](https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/configure-jobs-s3-channel.html),
+you can submit the package to build on your farm.
+
+Note that this approach automatically determines a new build number each time you run
+the package build job, you do not have to handle that yourself like when building locally.
+
+```
+C:\Dev\deadline-cloud-samples\conda_recipes>submit-package-job cinema4d-vray-2025
+No channel URL was provided, using a default prefix on the queue's job attachments bucket
+Building packages into channel s3://<MY_S3_CHANNEL_BUCKET>/Conda/Default
+...
+```
+
+On Service Mangaged Fleets V-Ray licensing should work with no setup required.
+On Customer Managed Fleets follow this [licensing guide](https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/cmf-ubl.html).
+
+
 ### Build the package locally
 
 
@@ -76,22 +96,3 @@ Here's an example of doing this for the package that was built by rattler-build:
     upload: temp-local-channel\win-64\repodata.json to s3://<MY_S3_CHANNEL_BUCKET>/Conda/Default/win-64/repodata.json
     ...
     ```
-
-### Build the package on Deadline Cloud
-
-If you create a package build queue as described in the Deadline Cloud developer guide page
-[Create a conda channel using S3](https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/configure-jobs-s3-channel.html),
-you can submit the package to build on your farm.
-
-Note that this approach automatically determines a new build number each time you run
-the package build job, you do not have to handle that yourself like when building locally.
-
-```
-C:\Dev\deadline-cloud-samples\conda_recipes>submit-package-job cinema4d-vray-2025
-No channel URL was provided, using a default prefix on the queue's job attachments bucket
-Building packages into channel s3://<MY_S3_CHANNEL_BUCKET>/Conda/Default
-...
-```
-
-On Service Mangaged Fleets V-Ray licensing should work with no setup required.
-On Customer Managed Fleets follow this [licensing guide](https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/cmf-ubl.html).

--- a/conda_recipes/cinema4d-vray-2025/README.md
+++ b/conda_recipes/cinema4d-vray-2025/README.md
@@ -10,14 +10,10 @@ provide in an input folder.
 
 1. Install the V-Ray for Cinema 4D plugin by [following instructions here](https://docs.chaos.com/display/VC4D/Installation).
   i. Choose "Workstation" install
-2. Copy the "V-Ray" folder from your installation directory to conda_recipes/archive_files/cinema4d-vray-2025/win-64.
+2. [Optional] Verify that "V-Ray" works with Cinema 4D locally. You can test this using any of the sample scenes available [here](https://www.chaos.com/cloud/scenes?srsltid=AfmBOorJmV6Bugw1DTiIyfiA1gxANUxdp1tUaHOTdyZLJnBGJxLON8Xi#cinema-4d).
+3. Copy the "V-Ray" folder from your installation directory to conda_recipes/archive_files/cinema4d-vray-2025/win-64.
 (The default installation location on Windows is C:\Program Files\Maxon Cinema 4D 2025\plugins\V-Ray)
 
-[Install](https://docs.chaos.com/display/VC4D/Installation) V-Ray for Cinema 4D.
-
-Copy C:\Program Files\Maxon Cinema 4D 2025\plugins\V-Ray into
-[`conda_recipes/archive_files/cinema4d-vray-2025/win-64`](../archive_files/cinema4d-vray-2025/win-64/)
-You can find the plugin locally in your Cinema 4D preferences folder.
 
 ### Build the package locally
 

--- a/conda_recipes/cinema4d-vray-2025/README.md
+++ b/conda_recipes/cinema4d-vray-2025/README.md
@@ -8,6 +8,11 @@ provide in an input folder.
 
 ## Building the package for Windows
 
+1. Install the V-Ray for Cinema 4D plugin by [following instructions here](https://docs.chaos.com/display/VC4D/Installation).
+  i. Choose "Workstation" install
+2. Copy the "V-Ray" folder from your installation directory to conda_recipes/archive_files/cinema4d-vray-2025/win-64.
+(The default installation location on Windows is C:\Program Files\Maxon Cinema 4D 2025\plugins\V-Ray)
+
 [Install](https://docs.chaos.com/display/VC4D/Installation) V-Ray for Cinema 4D.
 
 Copy C:\Program Files\Maxon Cinema 4D 2025\plugins\V-Ray into
@@ -33,6 +38,9 @@ C:\Dev\deadline-cloud-samples\conda_recipes>dir C:\...\conda-bld\win-64
 04/10/2025  02:21 PM           232,806 cinema4d-vray-2025-0.conda
 ...
 ```
+
+Note: The `--no-test` skips a build error locating cinema4d package only
+required at runtime and already provided by the SMF default Conda environment.
 
 ### Publish the locally built package to an S3 conda channel
 

--- a/conda_recipes/cinema4d-vray-2025/README.md
+++ b/conda_recipes/cinema4d-vray-2025/README.md
@@ -8,7 +8,9 @@ provide in an input folder.
 
 ## Building the package for Windows
 
-Copy the vray plugin folder into
+[Install](https://docs.chaos.com/display/VC4D/Installation) V-Ray for Cinema 4D.
+
+Copy C:\Program Files\Maxon Cinema 4D 2025\plugins\V-Ray into
 [`conda_recipes/archive_files/cinema4d-vray-2025/win-64`](../archive_files/cinema4d-vray-2025/win-64/)
 You can find the plugin locally in your Cinema 4D preferences folder.
 
@@ -86,3 +88,6 @@ No channel URL was provided, using a default prefix on the queue's job attachmen
 Building packages into channel s3://<MY_S3_CHANNEL_BUCKET>/Conda/Default
 ...
 ```
+
+On Service Mangaged Fleets V-Ray licensing should work with no setup required.
+On Customer Managed Fleets follow this [licensing guide](https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/cmf-ubl.html).

--- a/conda_recipes/cinema4d-vray-2025/README.md
+++ b/conda_recipes/cinema4d-vray-2025/README.md
@@ -1,0 +1,88 @@
+# Conda build recipe for Cinema 4D V-Ray
+
+## About
+
+This package build recipe creates a conda package for the vray plugin you
+provide in an input folder.
+
+
+## Building the package for Windows
+
+Copy the vray plugin folder into
+[`conda_recipes/archive_files/cinema4d-vray-2025/win-64`](../archive_files/cinema4d-vray-2025/win-64/)
+You can find the plugin locally in your Cinema 4D preferences folder.
+
+### Build the package locally
+
+
+From the `conda_recipes` directory, run:
+
+```
+C:\Dev\deadline-cloud-samples\conda_recipes>conda build cinema4d-vray-2025/recipe --no-test
+Adding in variants from internal_defaults
+...
+####################################################################################
+Source and build intermediates have been left in C:\...\conda-bld.
+There are currently 1 accumulated.
+To remove them, you can run the ```conda build purge``` command
+
+C:\Dev\deadline-cloud-samples\conda_recipes>dir C:\...\conda-bld\win-64
+...
+04/10/2025  02:21 PM           232,806 cinema4d-vray-2025-0.conda
+...
+```
+
+### Publish the locally built package to an S3 conda channel
+
+To publish your package to an S3 conda channel, two things need to happen:
+
+1. Copy the Windows package into the `win-64` subdirectory of the channel.
+2. Update the channel index (`repodata.json` and some other files) so that they
+   include metadata about the new package.
+
+You can accomplish this with the AWS CLI to synchronize S3 data and the `conda index`
+command that is available when you install [conda-build](https://docs.conda.io/projects/conda-build).
+
+Here's an example of doing this for the package that was built by rattler-build:
+
+1. Synchronize the `win-64` subdirectory of the channel locally.
+    ```
+    C:\Dev\deadline-cloud-samples\conda_recipes>set CHANNEL_BUCKET=<MY_S3_CHANNEL_BUCKET>
+
+    C:\Dev\deadline-cloud-samples\conda_recipes>aws s3 sync s3://%CHANNEL_BUCKET%/Conda/Default/win-64 ./temp-local-channel/win-64
+    ...
+    ```
+2. Copy the package you built into the `win-64` subdirectory.
+    ```
+    C:\Dev\deadline-cloud-samples\conda_recipes>copy output\win-64\cinema4d-vray-2025-h9490d1a_0.conda temp-local-channel\win-64
+            1 file(s) copied.
+    ...
+    ```
+3. Update the channel index with the new package.
+    ```
+    C:\Dev\deadline-cloud-samples\conda_recipes>conda index --subdir win-64 --zst ./temp-local-channel
+    Indexing ['win-64'] does not include 'noarch'
+    ...
+    ```
+4. Synchronize the local copy of the `win-64` subdirectory back to S3.
+    ```
+    C:\Dev\deadline-cloud-samples\conda_recipes>aws s3 sync ./temp-local-channel/win-64 s3://%CHANNEL_BUCKET%/Conda/Default/win-64
+    upload: temp-local-channel\win-64\repodata.json to s3://<MY_S3_CHANNEL_BUCKET>/Conda/Default/win-64/repodata.json
+    ...
+    ```
+
+### Build the package on Deadline Cloud
+
+If you create a package build queue as described in the Deadline Cloud developer guide page
+[Create a conda channel using S3](https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/configure-jobs-s3-channel.html),
+you can submit the package to build on your farm.
+
+Note that this approach automatically determines a new build number each time you run
+the package build job, you do not have to handle that yourself like when building locally.
+
+```
+C:\Dev\deadline-cloud-samples\conda_recipes>submit-package-job cinema4d-vray-2025
+No channel URL was provided, using a default prefix on the queue's job attachments bucket
+Building packages into channel s3://<MY_S3_CHANNEL_BUCKET>/Conda/Default
+...
+```

--- a/conda_recipes/cinema4d-vray-2025/deadline-cloud.yaml
+++ b/conda_recipes/cinema4d-vray-2025/deadline-cloud.yaml
@@ -1,0 +1,5 @@
+condaPlatforms:
+  - platform: win-64
+    defaultSubmit: true
+    sourceArchiveDirectory: cinema4d-vray-2025/win-64/
+    buildTool: conda-build

--- a/conda_recipes/cinema4d-vray-2025/recipe/bld.bat
+++ b/conda_recipes/cinema4d-vray-2025/recipe/bld.bat
@@ -1,0 +1,5 @@
+set "C4D_PLUGINS_DIRECTORY=%PREFIX%\cinema4d\plugins"
+mkdir "%C4D_PLUGINS_DIRECTORY%"
+
+xcopy "%SRC_DIR%" "%C4D_PLUGINS_DIRECTORY%" /E /I /H /Y
+

--- a/conda_recipes/cinema4d-vray-2025/recipe/bld.bat
+++ b/conda_recipes/cinema4d-vray-2025/recipe/bld.bat
@@ -2,5 +2,5 @@ rem To install the plugin we copy it into the Cinema 4D plugins dir
 set "C4D_PLUGINS_DIRECTORY=%PREFIX%\cinema4d\plugins"
 mkdir "%C4D_PLUGINS_DIRECTORY%"
 
+rem /E recursive, /I assume destintion dir, /H copy hidden, /Y suppress prompt
 xcopy "%SRC_DIR%" "%C4D_PLUGINS_DIRECTORY%" /E /I /H /Y
-

--- a/conda_recipes/cinema4d-vray-2025/recipe/bld.bat
+++ b/conda_recipes/cinema4d-vray-2025/recipe/bld.bat
@@ -1,3 +1,4 @@
+rem To install the plugin we copy it into the Cinema 4D plugins dir
 set "C4D_PLUGINS_DIRECTORY=%PREFIX%\cinema4d\plugins"
 mkdir "%C4D_PLUGINS_DIRECTORY%"
 

--- a/conda_recipes/cinema4d-vray-2025/recipe/meta.yaml
+++ b/conda_recipes/cinema4d-vray-2025/recipe/meta.yaml
@@ -1,0 +1,22 @@
+
+package:
+  name: cinema4d-vray
+  version: "2025"
+
+source:
+- path: ../../archive_files/cinema4d-vray-2025/win-64 # [win64]
+
+build:
+  number: 0
+  binary_relocation: false
+  detect_binary_files_with_prefix: false
+  ignore_prefix_files: true
+  missing_dso_whitelist:
+    - "**"
+
+requirements:
+  run:
+    - cinema4d >=2025
+
+about:
+  license: LicenseRef-Multiple

--- a/conda_recipes/cinema4d-vray-2025/recipe/meta.yaml
+++ b/conda_recipes/cinema4d-vray-2025/recipe/meta.yaml
@@ -19,4 +19,9 @@ requirements:
     - cinema4d >=2025
 
 about:
-  license: LicenseRef-Multiple
+  homepage: https://www.chaos.com/vray/maya
+  documentation: https://docs.chaos.com/display/VMAYA
+  license: LicenseRef-ChaosEULA
+  summary: |
+    V-Ray is a 3D photorealistic ray-traced rendering plug-in.
+    V-Ray for Maya is a 3D rendering plugin for Maya that's used to create visual effects and animations for film, television, and other industries.


### PR DESCRIPTION
Fixes: *V-Ray Support*

### What was the problem/requirement? (What/Why)

V-Ray example conda package

### What was the solution? (How)

New example package instructions

### How was this change tested?

On Windows SMF 
```

2025/08/29 17:25:34-07:00  
2025/08/29 17:25:34-07:00 ==============================================
2025/08/29 17:25:34-07:00 --------- Running Task
2025/08/29 17:25:34-07:00 ==============================================
2025/08/29 17:25:34-07:00 Parameter values:
2025/08/29 17:25:34-07:00 Frame(INT) = 0
2025/08/29 17:25:34-07:00 ----------------------------------------------
2025/08/29 17:25:34-07:00 Phase: Setup
2025/08/29 17:25:34-07:00 ----------------------------------------------
2025/08/29 17:25:34-07:00 Writing embedded files for Task to disk.
2025/08/29 17:25:34-07:00 Mapping: Task.File.runData -> C:\Sessions\session-70211a30d89842668c604f974e462eb3aqf0max4\embedded_filesitoea6yx\run-data.yaml
2025/08/29 17:25:34-07:00 Wrote: runData -> C:\Sessions\session-70211a30d89842668c604f974e462eb3aqf0max4\embedded_filesitoea6yx\run-data.yaml
2025/08/29 17:25:34-07:00 ----------------------------------------------
2025/08/29 17:25:34-07:00 Phase: Running action
2025/08/29 17:25:34-07:00 ----------------------------------------------
2025/08/29 17:25:34-07:00 Running command C:\Users\job-user\.conda\envs\hashname_058bc53593e0f2777b994183\Scripts\cinema4d-openjd.BAT daemon run --connection-file C:\Sessions\session-70211a30d89842668c604f974e462eb3aqf0max4/connection.json --run-data file://C:\Sessions\session-70211a30d89842668c604f974e462eb3aqf0max4\embedded_filesitoea6yx\run-data.yaml
2025/08/29 17:25:34-07:00 Command started as pid: 4548
2025/08/29 17:25:34-07:00 Output:
2025/08/29 17:25:34-07:00  
2025/08/29 17:25:34-07:00 (hashname_058bc53593e0f2777b994183) C:\Sessions\session-70211a30d89842668c604f974e462eb3aqf0max4>python C:\Users\job-user\.conda\envs\hashname_058bc53593e0f2777b994183\Scripts\\cinema4d-openjd-script.py daemon run --connection-file C:\Sessions\session-70211a30d89842668c604f974e462eb3aqf0max4/connection.json --run-data file://C:\Sessions\session-70211a30d89842668c604f974e462eb3aqf0max4\embedded_filesitoea6yx\run-data.yaml 
2025/08/29 17:25:34-07:00 INFO: Applying user-level configuration: C:\Users\job-user\.openjd\adaptors\runtime\configuration.json
2025/08/29 17:25:34-07:00 INFO: Applying user-level configuration: C:\Users\job-user\.openjd\adaptors\Cinema4DAdaptor\Cinema4DAdaptor.json
2025/08/29 17:25:35-07:00 ADAPTOR_OUTPUT: 
2025/08/29 17:25:35-07:00 ADAPTOR_OUTPUT: STDOUT: Performing action: {"name": "frame", "args": {"frame": 0}}
2025/08/29 17:25:35-07:00 ADAPTOR_OUTPUT: STDOUT: Performing action: {"name": "start_render", "args": {"frame": 0}}
2025/08/29 17:25:35-07:00 ADAPTOR_OUTPUT: STDOUT: Using normal path mapping (non-POSIX): 'C:\Sessions\session-70211a30d89842668c604f974e462eb3aqf0max4\assetroot-525f05cb3c90ebe46d6d\vray_v001' -> 'C:\Sessions\session-70211a30d89842668c604f974e462eb3aqf0max4\assetroot-525f05cb3c90ebe46d6d\vray_v001'
2025/08/29 17:25:36-07:00 ADAPTOR_OUTPUT: STDOUT: Analytics error: 1003 - Generic
2025/08/29 17:25:43-07:00 ADAPTOR_OUTPUT: STDOUT: Rendering frame 0 at <Sat Aug 30 00:25:42 2025>
2025/08/29 17:25:47-07:00 ADAPTOR_OUTPUT: STDOUT: Finished Rendering
2025/08/29 17:25:47-07:00 INFO: Done Cinema4DAdaptor main
2025/08/29 17:25:47-07:00 Process pid 4548 exited with code: 0 (unsigned) / 0x0 (hex)
2025/08/29 17:25:47-07:00 ----------------------------------------------
2025/08/29 17:25:47-07:00 Uploading output files to Job Attachments
2025/08/29 17:25:47-07:00 ----------------------------------------------
2025/08/29 17:25:47-07:00 Started syncing outputs using Job Attachments
2025/08/29 17:25:47-07:00 Found 1 file totaling 2.79 MB in output directory: C:\Sessions\session-70211a30d89842668c604f974e462eb3aqf0max4\assetroot-525f05cb3c90ebe46d6d
2025/08/29 17:25:47-07:00 Uploading output manifest to DeadlineCloud/Manifests/farm-a658bf7ce8694040a9a540f16afe84f5/queue-7f848b75a09b4b05bb0624343a9571e9/job-fef684e2d35d446f81c7f930774701c1/step-ccceb5392060473bb26ddef0f506f4b9/task-ccceb5392060473bb26ddef0f506f4b9-0/2025-08-30T00:25:34.495718Z_sessionaction-70211a30d89842668c604f974e462eb3-5/ea721f65346661e30ea94fc051b9eda1_output
2025/08/29 17:25:47-07:00 Uploading 1 output file to S3: gp-deadline-stack-farm/DeadlineCloud/Data
2025/08/29 17:25:47-07:00 Uploaded 1.05 MB / 2.79 MB of 1 file (Transfer rate: 0 B/s)
2025/08/29 17:25:47-07:00 Uploaded 2.1 MB / 2.79 MB of 1 file (Transfer rate: 209.72 MB/s)
2025/08/29 17:25:47-07:00 Uploaded 2.79 MB / 2.79 MB of 1 file (Transfer rate: 139.52 MB/s)
2025/08/29 17:25:47-07:00 Summary Statistics for file uploads:
Processed 1 file totaling 2.79 MB.
Skipped re-processing 0 files totaling 0 B.
Total processing time of 0.14696 seconds at 18.99 MB/s.

2025/08/29 17:25:47-07:00 Finished syncing outputs using Job Attachments

```

### Was this change documented?

Yes
---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*