### PR TITLE
feat: Add conda rattler-build recipe for Vray 7 with Maya 2026 for Linux64

### DIFF
--- a/conda_recipes/maya-vray-2026/README.md
+++ b/conda_recipes/maya-vray-2026/README.md
@@ -1,0 +1,51 @@
+# V-Ray conda build recipe
+Use this recipe to create a V-Ray for Maya conda package to use with AWS Deadline Cloud. Conda packages let you customize the software you can use with your Deadline Cloud deployment. Read more about how to host a conda channel for these custom conda packages [here](https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/conda_recipes#infrastructure-setup-prerequisites).
+
+## Requirement
+### Download the archive file
+- Download the `vray_adv_71002_maya2026_rhel8` full download file from [Chaos](https://download.chaos.com/downloads/23688/vray-maya-2026-71002-adv)\
+**_NOTE:_** Need to have a Chaos account to access the link
+- place the downloaded file in the `conda_recipes/archive_files` directory in your git clone of the
+[deadline-cloud-samples](https://github.com/aws-deadline/deadline-cloud-samples) repository.
+
+### Build required conda package(s)
+To use V-Ray for Maya, we need to build:
+1. Maya 2026 conda package by:
+    - Follow Maya 2026 [README](../maya-2026/README.md) for getting archive file
+    - running `./submit-package-job maya-2026` to build the package
+2. (_Optional - build this for Maya adaptor_) Maya adaptor conda package by running:
+    - [_Prerequisite_] Deadline Cloud package: `./submit-package-job deadline`
+    - [_Prerequisite_] OpenJD runtime adaptor package:`./submit-package-job openjd-adaptor-runtime`
+    - Maya adaptor package:`./submit-package-job maya-openjd`
+    
+    **_NOTE:_** Need to also add `conda-forge` to list of conda channel since Maya adaptor and prerequisite packages depend on it to run successful.
+
+## Build Conda Package
+- Follow this [README](https://github.com/aws-deadline/deadline-cloud-samples/blob/mainline/conda_recipes/README.md) to submit a job building V-Ray for Maya conda package.
+
+## Customization for Different Versions
+To adapt this recipe for different Maya or V-Ray versions:
+
+### Update Version Numbers
+1. **Edit `recipe/recipe.yaml`**:
+   - Change `version_maya: "2026"` to your Maya version (e.g., "2025", "2024")
+   - Change `version_vray: "7.10.02"` to your V-Ray version (e.g., "6.20.01")
+   - Update the `sha256` hash to match your V-Ray installer file
+
+2. **Edit `recipe/build.sh`**:
+   - Update `MAYA_VERSION=2026` to match your Maya version
+   - Update the installer filename in `VRAY_INSTALLER` variable
+   - Update the sed command pattern to match your V-Ray module name (e.g., `VRayForMaya2025rhel8`)
+
+3. **Edit `deadline-cloud.yaml`**:
+   - Update `sourceArchiveFilename` to match your V-Ray installer filename
+   - Update download instructions with correct Chaos Group download link
+
+### Test End-to-End
+1. **Build the package**: `./submit-package-job maya-vray-[your-version]`
+2. **Test Maya integration**:
+   ```bash
+   mayapy -c "import maya.standalone; maya.standalone.initialize(); import vray; print('V-Ray loaded'); maya.standalone.uninitialize()"
+   ```
+3. **Test rendering**: Submit a V-Ray render job using your custom package
+4. **Verify output**: Check that rendered images are produced correctly

--- a/conda_recipes/maya-vray-2026/deadline-cloud.yaml
+++ b/conda_recipes/maya-vray-2026/deadline-cloud.yaml
@@ -1,0 +1,10 @@
+condaPlatforms:
+  - platform: linux-64
+    defaultSubmit: true
+    sourceArchiveFilename: vray_adv_71002_maya2026_rhel8
+    sourceDownloadInstructions: 'Download the vray_adv_71002_maya2026_rhel8 full download file from Chaos Group. You will need a Chaos Group account to access the V-Ray downloads.'
+    buildTool: rattler-build
+jobParameters:
+  # conda-forge is used to get patchelf on Linux
+  - name: CondaChannels
+    value: conda-forge

--- a/conda_recipes/maya-vray-2026/recipe/build.sh
+++ b/conda_recipes/maya-vray-2026/recipe/build.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+set -xeuo pipefail
+
+MAYA_VERSION=2026
+
+# Where we will install V-Ray for Maya
+MAYA_VRAY_ROOT="$PREFIX/opt/chaos/maya-vray-$MAYA_VERSION"
+MAYA_VRAY_VRAY_ROOT="$MAYA_VRAY_ROOT/vray"
+MAYA_VRAY_MAYA_ROOT="$MAYA_VRAY_ROOT/maya_vray"
+mkdir -p $MAYA_VRAY_ROOT
+cd $MAYA_VRAY_ROOT
+
+# Run the installer to extract the files
+chmod u+x $SRC_DIR/vray*
+$SRC_DIR/vray* -unpackInstall .
+
+# Remove the samples, they're not needed on the farm
+rm -rf "$MAYA_VRAY_VRAY_ROOT/samples"
+# Remove the docs, they're not needed on the farm
+rm -rf "$MAYA_VRAY_VRAY_ROOT/docs"
+
+# Add relative RPATHs for the vray executable and the plugins using patchelf. This is so we can
+# follow the recommendation of https://docs.conda.io/projects/conda-build/en/latest/resources/use-shared-libraries.html
+# to never use LD_LIBRARY_PATH in Conda environments.
+for FILE in "$MAYA_VRAY_MAYA_ROOT"/lib/*.so; do
+    patchelf --add-rpath '$ORIGIN/.' "$FILE"
+done
+for FILE in "$MAYA_VRAY_VRAY_ROOT"/lib/*.so.*; do
+    patchelf --add-rpath '$ORIGIN/.:$ORIGIN/../../lib/aux' "$FILE"
+done
+
+patchelf --add-rpath '$ORIGIN/../../vray/lib' $MAYA_VRAY_MAYA_ROOT/plug-ins/vrayformaya.so
+
+# Install dependencies not available on Deadline Cloud service-managed fleets
+mkdir -p $SRC_DIR/download
+cd $SRC_DIR/download
+dnf download --resolve -y xcb-util-image xcb-util-renderutil xcb-util-cursor \
+    xcb-util-wm xcb-util-keysyms libxkbcommon-x11 xcb-util
+
+for rpm_file in $(realpath $SRC_DIR/download/*.rpm); do
+    rpm2cpio "$rpm_file" | cpio -idm
+done
+
+# Copy .so's to the V-Ray installation. We place these in a separate auxiliary directory so they're clearly
+# separated from what came with V-Ray.
+mkdir -p "$MAYA_VRAY_ROOT/lib/aux"
+find . -iname "*.so.*" -exec cp -P -r {} "$MAYA_VRAY_ROOT/lib/aux/" \;
+
+for FILE in "$MAYA_VRAY_ROOT"/lib/aux/*.so.*; do
+    patchelf --add-rpath '$ORIGIN/.' "$FILE"
+done
+
+mkdir -p "$PREFIX/usr/autodesk/modules/maya/$MAYA_VERSION"
+cp $MAYA_VRAY_ROOT/maya_root/modules/VRayForMaya.module $PREFIX/usr/autodesk/modules/maya/$MAYA_VERSION
+sed -i "s|+ VRayForMaya2026rhel8 0.9 ../../maya_vray|+ VRayForMaya2026rhel8 0.9 $MAYA_VRAY_MAYA_ROOT|" $PREFIX/usr/autodesk/modules/maya/$MAYA_VERSION/VRayForMaya.module
+if grep -q "$MAYA_VRAY_MAYA_ROOT" "$PREFIX/usr/autodesk/modules/maya/$MAYA_VERSION/VRayForMaya.module"; then
+    echo "Changing maya_root/VRayForMaya.module file path to $MAYA_VRAY_MAYA_ROOT succeeded"
+else
+    echo "Failed to change maya_root/VRayForMaya.module file path "
+    exit 1
+fi
+
+# Script to set environment variables during activation
+mkdir -p $PREFIX/etc/conda/activate.d
+cat <<EOF > $PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.sh
+export "VRAY_EULA=https://docs.chaos.com/display/VNS/End+User+License+Agreement"
+EOF
+
+mkdir -p $PREFIX/etc/conda/deactivate.d
+cat <<EOF > $PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.sh
+if ! [ -z \$VRAY ]; then 
+    unset VRAY_EULA
+fi
+EOF

--- a/conda_recipes/maya-vray-2026/recipe/recipe.yaml
+++ b/conda_recipes/maya-vray-2026/recipe/recipe.yaml
@@ -1,0 +1,40 @@
+# Recipe in rattler-build format.
+# See https://prefix-dev.github.io/rattler-build/latest/
+
+context:
+  version_maya: "2026"
+  version_vray: "7.10.02"
+
+package:
+  name: maya-vray
+  version: ${{ version_maya + "." + version_vray }}
+
+source:
+  url: file://archive_files/vray_adv_${{ version_vray | replace(".", "") }}_maya${{ version_maya }}_rhel8
+  sha256: 9d47b14d261d09958bab94bf26244ee70385a5a39a6c217446373611d6f554e8
+
+build:
+  number: 0
+  # These build options for repackaging an application
+  # https://prefix-dev.github.io/rattler-build/latest/build_options/#prefix-detection-replacement-options
+  prefix_detection:
+    ignore_binary_files: True
+  # https://prefix-dev.github.io/rattler-build/latest/build_options/#dynamic-linking-configuration
+  dynamic_linking:
+    binary_relocation: False
+    missing_dso_allowlist:
+    - "**"
+
+requirements:
+  build:
+    - patchelf
+  run:
+    - maya ${{ version_maya }}.*
+
+about:
+  homepage: https://www.chaos.com/vray/maya
+  documentation: https://docs.chaos.com/display/VMAYA
+  license: LicenseRef-ChaosEULA
+  summary: |
+    V-Ray is a 3D photorealistic ray-traced rendering plug-in.
+    V-Ray for Maya is a 3D rendering plugin for Maya that's used to create visual effects and animations for film, television, and other industries.


### PR DESCRIPTION
Fixes: N/A

### What was the problem/requirement? (What/Why)
We currently do not have a conda package for Vray with Maya2026. 

### What was the solution? (How)
Added the recipe.yaml that can be built with rattler and produces the Vray 7- Maya2026 conda package for Linux64.

### What is the impact of this change?
Customers can build the Vray7-Maya2026 conda package using instructions in the ReadME.md and test it using the starter_farm Cfn from the samples: https://github.com/aws-deadline/deadline-cloud-samples/blob/13d72858d5b789d0a230969c6ff75499df7de5d6/cloudformation/farm_templates/starter_farm/deadline-cloud-starter-farm-template.yaml#L4

### How was this change tested?

- If this is a sample, then please describe the steps that you took to test it. Built the conda package and successfully rendered a vray-maya scene using it and the starter_farm.
- Include output from your testing to demonstrate it working as expected if possible.

Rendered the scene from https://docs.chaos.com/display/VRSCANS/Sample+Scenes+V-Ray+for+Maya

<img width="1920" height="1080" alt="Leaves_Maya 0000" src="https://github.com/user-attachments/assets/02f4f4ab-c2d7-4f4a-8467-75324d77095a" />


### Was this change documented?

- For instance, if applicable, has the sample's description been updated? Documentation will follow.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*