### PR TITLE
docs: minor AE docs update for plugin documentation

### DIFF
--- a/conda_recipes/aftereffects-25.1/README.md
+++ b/conda_recipes/aftereffects-25.1/README.md
@@ -43,3 +43,9 @@ install Adobe After Effects 25 on a freshly created EC2 instance as Administrato
       `Write-S3Object -BucketName MY_BUCKET_NAME -Key Adobe_AfterEffects_25_1_Windows_installation.zip -File Adobe_AfterEffects_25_1_Windows_installation.zip`.
 4. From the AWS EC2 management console, select the instance you used and terminate it.
 5. Download the zip file to the `conda_recipes/archive_files` directory in your git clone of the [deadline-cloud-samples](https://github.com/aws-deadline/deadline-cloud-samples) repository for submitting package build jobs, and update the Windows source artifact hash in the aftereffects-25 conda build recipe meta.yaml.
+
+
+## Plugin Support
+To add After Effects plugins support in addition to the base AE conda package, see the following:
+- Sample AE plugin recipe using Saber: https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/conda_recipes/aftereffects-saber
+- Sample AE plugin bundle recipe for multiple plugins: https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/conda_recipes/aftereffects-plugin-bundle

--- a/conda_recipes/aftereffects-plugin-bundle/README.md
+++ b/conda_recipes/aftereffects-plugin-bundle/README.md
@@ -6,6 +6,12 @@ This package build recipe creates a conda package that bundles together all the 
 you provide in an input folder. Note that if your plugins require network licenses, you will have to
 handle that separately.
 
+### How the Plugin Bundle Works
+
+This recipe takes all the `.aex` plugin files you place in the `archive_files/aftereffects-plugin-bundle/win-64/` directory and packages them into a single conda package. When this package is installed in a conda environment (like on SMF or CMF render nodes), it automatically copies all the `.aex` files into the `%PREFIX%\aftereffects\Plug-ins` directory where After Effects expects to find them.
+
+The workflow is straightforward: you collect your plugin files locally (typically from `C:\Program Files\Adobe\Adobe After Effects <version>\Support Files\Plug-ins`), the conda build process bundles them together, and when installed on render farm nodes alongside the After Effects conda package, all your custom plugins become immediately available without any manual setup on each machine.
+
 To understand how After Effects plugins work in a conda package, see the instructions for plugin
 packages in the [After Effects recipe README](../aftereffects-25.1/README.md).
 

--- a/host_configuration_scripts/aftereffects/aftereffects_redgiant/README.md
+++ b/host_configuration_scripts/aftereffects/aftereffects_redgiant/README.md
@@ -111,7 +111,7 @@ This allows the host config script to pull down the installers from your S3 buck
 
 ## Usage
 
-### 1. Configure Installation Script
+### 1. Configure Host Config Installation Script
 
 Before running the installation script, you need to update the configuration variables at the top of the script. All configurable settings are located in the "Script Configuration Variables" section:
 
@@ -148,10 +148,12 @@ This will set the `redshift_LICENSE` environment variable to `7055@$vpc_endpoint
 You will also need to install your own Nvidia GPU driver to your CMF instance to support GPU rendering with Red Giant. Otherwise, you will most likely experience hanging or failing jobs.
 
 
-### 2. Run Installation Script
+### 2. Add Host Config Script to Windows GPU Fleet
 
-The contents of the script `.\install-software.ps1` should go in your Configuration Scripts for your fleet, which you can add to your fleet when you go to Fleets, select your fleet, go under Configurations, and add your script under Worker configuration script. For more information, see the [AWS Deadline Cloud SMF administration guide](https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/smf-admin.html).
+The contents of the script `.\install-software.ps1` should go in your Configuration Scripts for your fleet, which you can add to your fleet when you go to Fleets, select your fleet, go under Configurations, and add your script under Worker configuration script. Once pasted, scroll down and set the script timeout to **3600 seconds**. For more information, see the [AWS Deadline Cloud SMF administration guide](https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/smf-admin.html).
 
+
+## Local Dev Testing
 To test the script locally, run Powershell with Admin privileges on a Windows machine, add the credentials to your AWS account in the Powershell windows, and then run the following:
 
 ```powershell


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Our existing AE docs for conda recipes don't point to plugin docs and we want the folder naming clarity to be better so that viewers don't see AE Saber and get dissuaded by it.

### What was the solution? (How)
Update docs

### What is the impact of this change?
Better docs

### How was this change tested?
No need

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*