### PR TITLE
feat: add sample for listing conda packages

### DIFF
--- a/job_bundles/list_available_conda_packages/README.md
+++ b/job_bundles/list_available_conda_packages/README.md
@@ -1,0 +1,3 @@
+# List Available Conda Packages Job Bundle
+
+This job bundle lists all available conda packages in the deadline-cloud channel using `conda search -c deadline-cloud '*'` and prints the list into the logs.

--- a/job_bundles/list_available_conda_packages/template.yaml
+++ b/job_bundles/list_available_conda_packages/template.yaml
@@ -1,0 +1,28 @@
+specificationVersion: 'jobtemplate-2023-09'
+name: List Available Conda Packages
+
+parameterDefinitions:
+- name: CondaChannel
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Conda Channel
+  description: "The conda channel to search for packages."
+  default: "deadline-cloud"
+steps:
+- name: ListPackages
+  script:
+    actions:
+      onRun:
+        command: bash
+        args: ['{{Task.File.Run}}']
+    embeddedFiles:
+    - name: Run
+      type: TEXT
+      runnable: true
+      data: |
+        #!/usr/bin/env bash
+
+        set -euxo pipefail
+
+        conda search -c '{{Param.CondaChannel}}' '*'


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
It's sometimes useful to see what conda packages are available.

### What was the solution? (How)
Add a quick job sample that prints the list of available packages from a channel.

### What is the impact of this change?
Helps exploring the service-managed packages and debugging conda.

### How was this change tested?
I submitted the job and looked at the package list.

### Was this change documented?
Yes
---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*