### PR TITLE
chore: add docs link to conda package list job

### DIFF
--- a/job_bundles/list_available_conda_packages/README.md
+++ b/job_bundles/list_available_conda_packages/README.md
@@ -1,3 +1,5 @@
 # List Available Conda Packages Job Bundle
 
 This job bundle lists all available conda packages in the deadline-cloud channel using `conda search -c deadline-cloud '*'` and prints the list into the logs.
+
+In the [AWS Deadline Cloud docs](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/create-queue-environment.html#conda-queue-environment), you can find a list of the available Conda packages with their major and minor versions and why pinning only up to the minor version is recommended.


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Someone interesting in listing conda packages might really be looking for the docs page.

### What was the solution? (How)
Add the link.

### What is the impact of this change?
Easier to find conda docs.

### How was this change tested?
n/a

### Was this change documented?
Yes
---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*