### PR TITLE
feat: add fast build optimization and extra args for conda builds

### DIFF
--- a/conda_recipes/README.md
+++ b/conda_recipes/README.md
@@ -131,7 +131,7 @@ $ ./submit-package-job blender-4.2 --s3-channel s3://<another-s3-bucket>/channel
 ### Enabling fast build optimizations
 
 You can enable fast build optimizations to create faster builds
-by adding the `--fast-build` flag:
+by adding the `--fast-build` or `-f` flag:
 
 ```
 $ ./submit-package-job blender-4.2 --fast-build
@@ -143,6 +143,20 @@ This enables:
 
 The fast build optimization is particularly beneficial for packages with many files or large binaries,
 as it reduces package size and can speed up both the build process and package installation.
+
+### Adding custom build arguments
+
+You can pass additional arguments to the conda-build or rattler-build command using the `--extra-build-tool-args` or `-a` option:
+
+```
+$ ./submit-package-job blender-4.2 --extra-build-tool-args "--no-test --quiet"
+```
+
+This allows you to customize the build process with any supported conda-build or rattler-build arguments:
+- **conda-build**: Examples include `--no-test`, `--quiet`, `--debug`
+- **rattler-build**: Examples include `--quiet`, `--debug`, `--skip-existing`
+
+The build arguments are parsed as space-separated values and added to the build command. Use quotes to group arguments that contain spaces.
 
 ## Recipe directory structure for `submit-package-build`
 

--- a/conda_recipes/README.md
+++ b/conda_recipes/README.md
@@ -138,7 +138,7 @@ $ ./submit-package-job blender-4.2 --fast-build
 ```
 
 This enables:
-- **conda-build**: Uses `--zstd-compression-level 1` for faster compression with good compression ratio
+- **conda-build**: Uses `--zstd-compression-level 1` for faster compression with a larger package size
 - **rattler-build**: Uses `--package-format conda:min` for optimized package format
 
 The fast build optimization is particularly beneficial for packages with many files or large binaries,

--- a/conda_recipes/README.md
+++ b/conda_recipes/README.md
@@ -128,6 +128,22 @@ IAM role of the queue you're submitting to includes permissions for the S3 bucke
 $ ./submit-package-job blender-4.2 --s3-channel s3://<another-s3-bucket>/channel/prefix
 ```
 
+### Enabling fast build optimizations
+
+You can enable fast build optimizations to create faster builds
+by adding the `--fast-build` flag:
+
+```
+$ ./submit-package-job blender-4.2 --fast-build
+```
+
+This enables:
+- **conda-build**: Uses `--zstd-compression-level 1` for faster compression with good compression ratio
+- **rattler-build**: Uses `--package-format conda:min` for optimized package format
+
+The fast build optimization is particularly beneficial for packages with many files or large binaries,
+as it reduces package size and can speed up both the build process and package installation.
+
 ## Recipe directory structure for `submit-package-build`
 
 The `submit-package-build` command expects conda build recipes in a specific directory structure. It's inspired by the

--- a/conda_recipes/conda_build_linux_package/scripts/build-package.py
+++ b/conda_recipes/conda_build_linux_package/scripts/build-package.py
@@ -109,6 +109,7 @@ def main():
     parser.add_argument("--override-source-archive2")
     parser.add_argument("--override-source-dir")
     parser.add_argument("--variant-config-file")
+    parser.add_argument("--enable-fast-build", choices=("true", "false"), default="false")
     args = parser.parse_args()
 
     session = boto3.Session()
@@ -276,8 +277,8 @@ def main():
             sys.exit(1)
         prefix_length_option = ["--prefix-length", f"{args.override_prefix_length}"]
 
-    # Check for fast build optimization environment variable
-    enable_fast_build = os.environ.get("CONDA_BUILD_ENABLE_FAST_BUILD", "false").lower() == "true"
+    # Check for fast build optimization from CLI argument
+    enable_fast_build = args.enable_fast_build == "true"
 
     # Run the package build tool
     if args.build_tool == "conda-build":

--- a/conda_recipes/conda_build_linux_package/scripts/build-package.py
+++ b/conda_recipes/conda_build_linux_package/scripts/build-package.py
@@ -110,6 +110,7 @@ def main():
     parser.add_argument("--override-source-dir")
     parser.add_argument("--variant-config-file")
     parser.add_argument("--enable-fast-build", choices=("true", "false"), default="false")
+    parser.add_argument("--extra-build-tool-args", default="")
     args = parser.parse_args()
 
     session = boto3.Session()
@@ -280,6 +281,11 @@ def main():
     # Check for fast build optimization from CLI argument
     enable_fast_build = args.enable_fast_build == "true"
 
+    # Parse additional build arguments
+    extra_build_tool_args = []
+    if args.extra_build_tool_args:
+        extra_build_tool_args = shlex.split(args.extra_build_tool_args)
+
     # Run the package build tool
     if args.build_tool == "conda-build":
         fast_build_opts = ["--zstd-compression-level", "1"] if enable_fast_build else []
@@ -294,6 +300,7 @@ def main():
             "--clobber-file",
             "recipe_clobber.yaml",
             *fast_build_opts,
+            *extra_build_tool_args,
             args.recipe_dir,
         ]
     else:
@@ -309,6 +316,7 @@ def main():
             args.conda_bld_dir,
             "--verbose",
             *fast_build_opts,
+            *extra_build_tool_args,
             *prefix_length_option,
             *channel_options,
         ]

--- a/conda_recipes/conda_build_linux_package/scripts/build-package.py
+++ b/conda_recipes/conda_build_linux_package/scripts/build-package.py
@@ -276,8 +276,13 @@ def main():
             sys.exit(1)
         prefix_length_option = ["--prefix-length", f"{args.override_prefix_length}"]
 
+    # Check for fast build optimization environment variable
+    enable_fast_build = os.environ.get("CONDA_BUILD_ENABLE_FAST_BUILD", "false").lower() == "true"
+
     # Run the package build tool
     if args.build_tool == "conda-build":
+        fast_build_opts = ["--zstd-compression-level", "1"] if enable_fast_build else []
+        
         command = [
             "conda",
             "build",
@@ -287,9 +292,12 @@ def main():
             *channel_options,
             "--clobber-file",
             "recipe_clobber.yaml",
+            *fast_build_opts,
             args.recipe_dir,
         ]
     else:
+        fast_build_opts = ["--package-format", "conda:min"] if enable_fast_build else []
+        
         command = [
             "rattler-build",
             "build",
@@ -299,6 +307,7 @@ def main():
             "--output-dir",
             args.conda_bld_dir,
             "--verbose",
+            *fast_build_opts,
             *prefix_length_option,
             *channel_options,
         ]

--- a/conda_recipes/conda_build_linux_package/template.yaml
+++ b/conda_recipes/conda_build_linux_package/template.yaml
@@ -109,6 +109,15 @@ parameterDefinitions:
     control: CHOOSE_INPUT_FILE
     label: Variant config YAML file
     groupLabel: Conda Package Recipe
+- name: EnableFastBuild
+  description: Enable build optimizations for faster package creation.
+  type: STRING
+  userInterface:
+    control: CHECK_BOX
+    label: Enable Fast Build
+    groupLabel: Conda Package Recipe
+  default: "false"
+  allowedValues: ["true", "false"]
 
 # Group: Conda Channel
 - name: CondaChannelName
@@ -259,7 +268,8 @@ steps:
             --override-source-archive1 '{{Param.OverrideSourceArchive1}}' \
             --override-source-archive2 '{{Param.OverrideSourceArchive2}}' \
             --override-source-dir '{{Param.OverrideSourceDir}}' \
-            --variant-config-file '{{Param.VariantConfigFile}}'
+            --variant-config-file '{{Param.VariantConfigFile}}' \
+            --enable-fast-build '{{Param.EnableFastBuild}}'
 
   hostRequirements:
     # Host requirements for the linux-64 conda platform

--- a/conda_recipes/conda_build_linux_package/template.yaml
+++ b/conda_recipes/conda_build_linux_package/template.yaml
@@ -118,6 +118,14 @@ parameterDefinitions:
     groupLabel: Conda Package Recipe
   default: "false"
   allowedValues: ["true", "false"]
+- name: ExtraBuildToolArgs
+  description: Additional arguments to pass to the conda-build or rattler-build command.
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Additional Build Arguments
+    groupLabel: Conda Package Recipe
+  default: ""
 
 # Group: Conda Channel
 - name: CondaChannelName
@@ -269,7 +277,8 @@ steps:
             --override-source-archive2 '{{Param.OverrideSourceArchive2}}' \
             --override-source-dir '{{Param.OverrideSourceDir}}' \
             --variant-config-file '{{Param.VariantConfigFile}}' \
-            --enable-fast-build '{{Param.EnableFastBuild}}'
+            --enable-fast-build '{{Param.EnableFastBuild}}' \
+            --extra-build-tool-args '{{Param.ExtraBuildToolArgs}}'
 
   hostRequirements:
     # Host requirements for the linux-64 conda platform

--- a/conda_recipes/submit-package-job-script.py
+++ b/conda_recipes/submit-package-job-script.py
@@ -359,12 +359,12 @@ def create_job_bundle(
     It then reindexes the channel.
     """
 
-    # Add fast build environment variable if enabled
+    # Add fast build parameter if enabled
     if enable_fast_build:
         print("Enabling fast build optimizations")
-        if "variables" not in package_build_env["entity"]:
-            package_build_env["entity"]["variables"] = {}
-        package_build_env["entity"]["variables"]["CONDA_BUILD_ENABLE_FAST_BUILD"] = "true"
+        parameter_values["EnableFastBuild"] = "true"
+    else:
+        parameter_values["EnableFastBuild"] = "false"
 
     # Assemble the job template
     job_template = {
@@ -423,7 +423,7 @@ def main():
         "--all-platforms", action="store_true", help="Submit all the platforms specified by the recipe's deadline-cloud.yaml."
     )
     parser.add_argument(
-        "--fast-build", action="store_true", help="Enable build optimizations for faster package creation."
+        "-f", "--fast-build", action="store_true", help="Enable build optimizations by reduing the amount of compression performed for faster package creation."
     )
     args = parser.parse_args()
 

--- a/conda_recipes/submit-package-job-script.py
+++ b/conda_recipes/submit-package-job-script.py
@@ -213,6 +213,7 @@ def create_job_bundle(
     s3_channel_bucket,
     s3_channel_prefix,
     conda_platforms,
+    enable_fast_build,
 ):
     # Read the conda_build_linux_package template, and then decompose it into pieces
     build_linux_package_bundle_dir = Path(__file__).parent / "conda_build_linux_package"
@@ -358,6 +359,13 @@ def create_job_bundle(
     It then reindexes the channel.
     """
 
+    # Add fast build environment variable if enabled
+    if enable_fast_build:
+        print("Enabling fast build optimizations")
+        if "variables" not in package_build_env["entity"]:
+            package_build_env["entity"]["variables"] = {}
+        package_build_env["entity"]["variables"]["CONDA_BUILD_ENABLE_FAST_BUILD"] = "true"
+
     # Assemble the job template
     job_template = {
         "specificationVersion": "jobtemplate-2023-09",
@@ -414,6 +422,9 @@ def main():
     parser.add_argument(
         "--all-platforms", action="store_true", help="Submit all the platforms specified by the recipe's deadline-cloud.yaml."
     )
+    parser.add_argument(
+        "--fast-build", action="store_true", help="Enable build optimizations for faster package creation."
+    )
     args = parser.parse_args()
 
     if args.conda_platform and args.all_platforms:
@@ -456,6 +467,7 @@ def main():
         s3_channel_bucket=s3_channel_bucket,
         s3_channel_prefix=s3_channel_prefix,
         conda_platforms=conda_platforms,
+        enable_fast_build=args.fast_build,
     )
     print(f"Wrote job bundle:\n  '{job_bundle_dir}'")
     print()

--- a/conda_recipes/submit-package-job-script.py
+++ b/conda_recipes/submit-package-job-script.py
@@ -214,6 +214,7 @@ def create_job_bundle(
     s3_channel_prefix,
     conda_platforms,
     enable_fast_build,
+    extra_build_tool_args,
 ):
     # Read the conda_build_linux_package template, and then decompose it into pieces
     build_linux_package_bundle_dir = Path(__file__).parent / "conda_build_linux_package"
@@ -366,6 +367,14 @@ def create_job_bundle(
     else:
         parameter_values["EnableFastBuild"] = "false"
 
+    # Add build args parameter if provided
+    if extra_build_tool_args:
+        print(f"Adding custom build arguments: {extra_build_tool_args}")
+        parameter_values["ExtraBuildToolArgs"] = extra_build_tool_args
+    else:
+        parameter_values["ExtraBuildToolArgs"] = ""
+
+
     # Assemble the job template
     job_template = {
         "specificationVersion": "jobtemplate-2023-09",
@@ -425,6 +434,9 @@ def main():
     parser.add_argument(
         "-f", "--fast-build", action="store_true", help="Enable build optimizations by reduing the amount of compression performed for faster package creation."
     )
+    parser.add_argument(
+        "-a", "--extra-build-tool-args", help="Additional arguments to pass to the conda-build or rattler-build command, space-separated."
+    )
     args = parser.parse_args()
 
     if args.conda_platform and args.all_platforms:
@@ -468,6 +480,7 @@ def main():
         s3_channel_prefix=s3_channel_prefix,
         conda_platforms=conda_platforms,
         enable_fast_build=args.fast_build,
+        extra_build_tool_args=args.extra_build_tool_args,
     )
     print(f"Wrote job bundle:\n  '{job_bundle_dir}'")
     print()


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Conda/rattler builds were taking a long time.

### What was the solution? (How)
Can add parameters when submitting conda/rattler builds to skip compression, speeding up build times. This speeds up builds by up to 40%.

Also, added an option to add extra arguments to the conda/rattler builds

### What is the impact of this change?
When running `submit-package-job`, users can add the `--fast-build` flag to speed up package job builds.
Users can also add the `--extra-build-tool-args` option to add additional arguments to the conda/rattler builds.

### How was this change tested?
Tested with and without `--fast-build` flag, and with conda and rattler builds. Made sure that the builds were faster with the flag, and everything worked as expected when the flag was not included.

### Was this change documented?
Yes, added to the readme.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*