### PR TITLE
chore: Added FLIP Fluids Blender plugin sample.

### DIFF
--- a/conda_recipes/blender-flipfluids/README.md
+++ b/conda_recipes/blender-flipfluids/README.md
@@ -1,0 +1,13 @@
+# FLIP Fluids addon conda build recipe for Blender
+
+## About
+This recipe installs the demo version of the FLIP Fluids addon to Blender. To write conda recipes to add more addons to your Blender Deadline Cloud setup, use this recipe as a template to guide your development.
+
+## Addon Solution for Blender
+When adding addons to Blender on SMF, we use the activate and deactivate scripts to install/uninstall the addon with Blenders API. If your addon needs additional dependencies, we don't recommend installing them there.
+Install your Python dependencies in the build script, then move them into Blender's Python in the activate script. 
+
+## Creating an archive file for Blender Addons
+Blender addons are typically contained in a zip archive. One would think that it'd be simple enough to use that archive as the source file for our rattler build, however, rattler will automatically extract the contents
+of source files during build. In this case we want to use the zip archive directly instead of having all the files extracted. To solve for this, we've added the addon to a zip archive. It's a zip of a zip. During the build, rattler will
+extract the FLIP Fluid addon into the `$SRC_DIR/flipfluids/` directory. From there we can include it in the installation directory and have Blender install it. 

--- a/conda_recipes/blender-flipfluids/deadline-cloud.yaml
+++ b/conda_recipes/blender-flipfluids/deadline-cloud.yaml
@@ -1,0 +1,7 @@
+condaPlatforms:
+  - platform: linux-64
+    defaultSubmit: true
+    sourceArchiveFilename: FLIP-Fluids.zip
+    # These instructions show you how to get the free demo version of FLIP Fluids. Using the paid version would involve different steps depending on where you purchased it from.
+    sourceDownloadInstructions: 'Run "curl -LO https://github.com/rlguy/Blender-FLIP-Fluids/releases/download/v1.8.4/FLIP_Fluids_addon_1.8.4_demo_.2025-07-17.zip --output-dir archive_files && zip -r archive_files/FLIP-Fluids.zip archive_files/FLIP_Fluids_addon_1.8.4_demo_.2025-07-17.zip"'
+    buildTool: rattler-build

--- a/conda_recipes/blender-flipfluids/recipe/build.sh
+++ b/conda_recipes/blender-flipfluids/recipe/build.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+set -xeuo pipefail
+
+
+INSTALL_DIR="$PREFIX/flipfluids"
+mkdir -p $INSTALL_DIR
+
+mv $SRC_DIR/flipfluids/* $INSTALL_DIR
+
+# If your plugin needs extra dependencies, download them here and move them into 
+# the Blender install in the appropriate location. 
+#
+# For example, you can download python modules with dnf download. In the activate script,
+# you'll want to move the modules into Blender's python. Remove those dependencies in the 
+# deactivate script.
+
+mkdir -p $PREFIX/etc/conda/activate.d
+mkdir -p $PREFIX/etc/conda/deactivate.d
+
+# This python script installs the addon, enables it and saves the user preferences.
+cat <<EOF > "$INSTALL_DIR/install_addon.py"
+import bpy
+
+print("Installing Addon")
+bpy.ops.preferences.addon_install(enable_on_install=True, filepath=r"$INSTALL_DIR/FLIP_Fluids_addon_${PKG_VERSION}_demo_.2025-07-17.zip")
+print("Saving Preferences")
+bpy.ops.wm.save_userpref()
+print("Complete")
+EOF
+
+# This python script uninstalls the addon and saves the user preferences.
+cat <<EOF > "$INSTALL_DIR/uninstall_addon.py"
+import bpy
+
+print("Uninstalling Addon")
+bpy.ops.preferences.addon_remove(module="FLIP Fluids")
+print("Saving Preferences")
+bpy.ops.wm.save_userpref()
+print("Complete")
+EOF
+
+
+# When activating the environment, we run the addon install script.
+cat <<EOF > "$PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.sh"
+echo "Adding preferences..."
+"\$BLENDER_LOCATION/blender" --background --python "$INSTALL_DIR/install_addon.py"
+EOF
+
+# When deactivating the environment, we run the uninstall script.
+cat <<EOF > "$PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.sh"
+echo "Adding preferences..."
+"\$BLENDER_LOCATION/blender" --background --python "$INSTALL_DIR/uninstall_addon.py"
+EOF
+

--- a/conda_recipes/blender-flipfluids/recipe/recipe.yaml
+++ b/conda_recipes/blender-flipfluids/recipe/recipe.yaml
@@ -1,0 +1,52 @@
+# Recipe in rattler-build format.
+# See https://prefix-dev.github.io/rattler-build/latest/
+
+context:
+  # This sample uses the free demo version of FLIP Fluids. If you want to use the paid version you'll need to change
+  # the sha256sum in the section below and the filepath in the build.sh script to match that version's naming.
+  version: "1.8.4"
+
+package:
+  name: blender-flipfluids
+  version: ${{ version }}
+
+source:
+  - if: linux
+    then:
+      # This zip file contains the FLIP Fluids Demo addon archive. Rattler build
+      # automatically extracts source files. In this case, we don't want the contents of the addon to
+      # be extracted, so we've placed the addon into it's own archive. 
+      url: file://archive_files/FLIP-Fluids.zip
+      sha256: d0afeb07d4ba19936eff3c040d5541b68202d1cd9b7ddfdf2da62d869f2d0f6c
+      target_directory: flipfluids
+
+build:
+  number: 0
+  # These build options for repackaging an application
+  # https://prefix-dev.github.io/rattler-build/latest/build_options/#prefix-detection-replacement-options
+  prefix_detection:
+    ignore_binary_files: True
+  # https://prefix-dev.github.io/rattler-build/latest/build_options/#dynamic-linking-configuration
+  dynamic_linking:
+    binary_relocation: false
+    missing_dso_allowlist:
+      - "**"
+
+requirements:
+  run:
+    - blender
+
+tests:
+  - script:
+    - |
+      cat <<EOF > test.py
+      import bpy
+      for addon in bpy.context.preferences.addons:
+          print(addon)
+      EOF
+    - blender --background --python test.py | grep flip_fluids_addon
+
+about:
+  homepage: https://flipfluids.com/
+  license: MIT AND GPL-3.0-only
+  summary: The FLIP Fluids addon is a tool that helps you set up, run, and render liquid simulation effects.


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We want to have sample conda recipes for Blender addons.

### What was the solution? (How)

This sample recipe is for [FLIP Fluids](https://flipfluids.com/). It is a tool for rendering liquid simulations using their custom built fluid engine. 

It demonstrates how a user can bring any Blender .zip addon and create a conda package for it. The recipe creates activate and deactivate scripts that install/uninstall the addon using the Blender addon api. It also includes instructions in the build script for installing any additional dependencies that other addons might need.  

### What is the impact of this change?

Provides a straightforward sample that others can use as an example for how to bring Blender addons to Deadline Cloud with conda.

### How was this change tested?

I built the package in my own Deadline Cloud build farm following the instructions in this repo. I then submitted a custom Job Template that baked a sample simulation following [these instructions](https://github.com/rlguy/Blender-FLIP-Fluids/wiki/Baking-from-the-Command-Line) from FLIP Fluid.  

### Was this change documented?

Includes a README. I will also update the main Blender sample with information about how to make an addon recipe.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*