### PR TITLE
feat: Added support for Maya2026 to Redshift2025 conda recipe

### DIFF
--- a/conda_recipes/maya-redshift-2025/README.md
+++ b/conda_recipes/maya-redshift-2025/README.md
@@ -1,5 +1,12 @@
 # Redshift for Maya conda build recipe
 
+This package provides Redshift 2025.4.2 support for Maya versions 2025, and 2026.
+
+## Supported Maya Versions
+
+- Maya 2025  
+- Maya 2026
+
 ## Download the installer file for Linux
 
 Download the redshift_2025.4.2_1782753868_linux_x64.run installer, or suitable alternate version from Maxon, and

--- a/conda_recipes/maya-redshift-2025/recipe/build.sh
+++ b/conda_recipes/maya-redshift-2025/recipe/build.sh
@@ -44,6 +44,15 @@ rm -r "${PREFIX}/${REDSHIFT_ROOT}"/redshift4solaris
 # prefix.
 
 for MAYA_VERSION in $MAYA_VERSIONS; do
+
+  # Add a relative RPATH from Redshift into Maya using patchelf, which is part of
+  # the conda-build virtual environment. This is so we can follow the recommendation
+  # of https://docs.conda.io/projects/conda-build/en/latest/resources/use-shared-libraries.html
+  # to never use LD_LIBRARY_PATH in Conda environments.
+
+  patchelf --add-rpath "\$ORIGIN/../../../../autodesk/maya${MAYA_VERSION}/lib" "${PREFIX}/${REDSHIFT_ROOT}/redshift4maya/${MAYA_VERSION}"/redshift4maya.so
+  patchelf --add-rpath "\$ORIGIN/../../../../autodesk/maya${MAYA_VERSION}/plug-ins/xgen/lib" "${PREFIX}/${REDSHIFT_ROOT}/redshift4maya/${MAYA_VERSION}"/redshift4maya.so
+
   # Generate the .mod file for this specific version
   mkdir -p "$PREFIX/usr/autodesk/modules/maya/$MAYA_VERSION"
   cat <<EOF > "$PREFIX/usr/autodesk/modules/maya/$MAYA_VERSION/redshift4maya.mod"

--- a/conda_recipes/maya-redshift-2025/recipe/recipe.yaml
+++ b/conda_recipes/maya-redshift-2025/recipe/recipe.yaml
@@ -27,7 +27,7 @@ build:
 
 requirements:
   run:
-    - maya >=2025, <2026
+    - maya >=2025, <2027
 
 
 about:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Redshift 2025 recipe does not support Maya2026

### What was the solution? (How)
Added support for Maya2026 in the Redshift recipe. Changes include adding a few required paths to the rpaths using patchelf

### What is the impact of this change?
Customers can use the redshift recipe with Maya2026

### How was this change tested?

- If this is a sample, then please describe the steps that you took to test it.
- Include output from your testing to demonstrate it working as expected if possible.

Built the conda packages for redshift 2025 and maya2026 using the starter farm on local and verified that a test render works successfully.

<img width="960" height="540" alt="redshiftmayascene 0001" src="https://github.com/user-attachments/assets/9f2b1f92-b790-461b-9a42-d0c89ffcb361" />

Built the conda packages for redshift 2025 and maya2025 too using the starter farm on local and verified that a test render works successfully for testing backwards compatibility :

<img width="960" height="540" alt="redshiftmayascene 0001" src="https://github.com/user-attachments/assets/63911ed5-6128-4385-8484-3fad13f293e0" />

### Was this change documented?

- For instance, if applicable, has the sample's description been updated? N/A

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*