### PR TITLE
chore: Added links between the C4D base sample and its plugins.

### DIFF
--- a/conda_recipes/cinema4d-2024/README.md
+++ b/conda_recipes/cinema4d-2024/README.md
@@ -49,3 +49,10 @@ for use by the conda build recipe.
        `Write-S3Object -BucketName MY_BUCKET_NAME -Key Cinema4D_2024_2024.5.1_Win.zip -File Cinema4D_2024_2024.5.1_Win.zip`.
 4. From the AWS EC2 management console, select the instance you used and terminate it.
 5. Download the zip file to the `conda_recipes/archive_files` directory in your git clone of the [deadline-cloud-samples](https://github.com/aws-deadline/deadline-cloud-samples) repository for submitting package build jobs, and update the Windows source artifact hash in the Cinema 4D-2024 conda build recipe meta.yaml.
+
+## Instructions for Cinema4D plugin packages
+This repository contains examples for how to create plugin conda packages for Cinema4D (DISCLAIMER: These samples were only tested with 2025):
+
+* [Cinema4D to Arnold](../cinema4d-c4dtoa-2025/)
+* [Cinema4D - Insydium](../cinema4d-insydium-2025/)
+* [Cinema4D - Vray](../cinema4d-vray-2025/)

--- a/conda_recipes/cinema4d-2025/README.md
+++ b/conda_recipes/cinema4d-2025/README.md
@@ -58,3 +58,11 @@ for use by the conda build recipe.
        `Write-S3Object -BucketName MY_BUCKET_NAME -Key Cinema4D_2025_2025.1.3_Win.zip -File Cinema4D_2025_2025.1.3_Win.zip`.
 8. From the AWS EC2 management console, select the instance you used and terminate it.
 9. Download the zip file to the `conda_recipes/archive_files` directory in your git clone of the [deadline-cloud-samples](https://github.com/aws-deadline/deadline-cloud-samples) repository for submitting package build jobs, and update the Windows source artifact hash in the Cinema 4D-2025 conda build recipe meta.yaml.
+
+
+## Instructions for Cinema4D plugin packages
+This repository contains examples for how to create plugin conda packages for Cinema4D:
+
+* [Cinema4D to Arnold](../cinema4d-c4dtoa-2025/)
+* [Cinema4D - Insydium](../cinema4d-insydium-2025/)
+* [Cinema4D - Vray](../cinema4d-vray-2025/)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The Cinema4D base recipe doesn't mention plugins and should link to the plugin samples.

### What was the solution? (How)

Added a brief section to the README that links to the plugin samples.

### What is the impact of this change?

Better discoverability of the plugin samples.

### How was this change tested?

N/A

### Was this change documented?

No.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*