### PR TITLE
refactor: Add conda queue env samples with py-rattler

### DIFF
--- a/job_bundles/afterfx_render_one_task/README.md
+++ b/job_bundles/afterfx_render_one_task/README.md
@@ -5,7 +5,7 @@
 This is an After Effects job bundle that allows the user
 to submit a job that uses aerender to render a frame range
 as a single task. This means the entire workload will render
-on one worker.
+on one worker as one command.
 
 It accepts the following job parameters that modify the render:
 * Project file

--- a/job_bundles/afterfx_render_one_task/template.yaml
+++ b/job_bundles/afterfx_render_one_task/template.yaml
@@ -2,8 +2,11 @@ specificationVersion: jobtemplate-2023-09
 name: After Effects Render - one task
 description: >
   A simple job bundle that allows a user to select
-  a project and comp to render with aerender.
+  a project file and enter a comp to render with aerender.
+
 parameterDefinitions:
+
+# Project settings
 - name: ProjectFile
   type: PATH
   objectType: FILE
@@ -28,6 +31,8 @@ parameterDefinitions:
     label: Comp name
     groupLabel: Project settings
   description: Selected composition to render.
+
+# Inputs/outputs
 - name: InputDirectory
   type: PATH
   objectType: DIRECTORY
@@ -51,6 +56,8 @@ parameterDefinitions:
     label: Output directory
     groupLabel: Inputs/outputs
   description: The render output directory
+
+# Frame range
 - name: StartFrame
   type: INT
   userInterface:
@@ -68,20 +75,53 @@ parameterDefinitions:
   default: 50
   description: The last frame to render.
 
+# Software Environment
+- name: CondaPackages
+  type: STRING
+  userInterface:
+    # This parameter is for a queue environment, not used directly in the job,
+    # so leave the GUI for the queue environment to display.
+    control: HIDDEN
+  default: aftereffects
+  description: >
+    If you have a Queue Environment that creates a Conda environment from a parameter called CondaPackages, this
+    will set the default packages to use for the job.
+
 steps:
-- name: "{{Param.CompName}}"
+- name: RenderComp
   script:
     actions:
       onRun:
-        command: aerender
+        command: python
         args:
-        - "-project"
-        - "{{Param.ProjectFile}}"
-        - "-comp"
-        - "{{Param.CompName}}"
-        - "-output"
-        - "{{Param.OutputDirectory}}"
-        - "-s"
-        - "{{Param.StartFrame}}"
-        - "-e"
-        - "{{Param.EndFrame}}"
+          - "{{Task.File.Run}}"
+          - "{{Param.OutputDirectory}}"
+          - "aerender"
+          - "-project"
+          - "{{Param.ProjectFile}}"
+          - "-comp"
+          - "{{Param.CompName}}"
+          - "-output"
+          - "{{Param.OutputDirectory}}/output_[####].png"
+          - "-s"
+          - "{{Param.StartFrame}}"
+          - "-e"
+          - "{{Param.EndFrame}}"
+    embeddedFiles:
+      - name: Run
+        type: TEXT
+        data: |
+          import os
+          import sys
+          import subprocess
+
+          # Ensure the output directory exists
+          os.makedirs(sys.argv[1], exist_ok=True)
+
+          # Run the After Effects subprocess
+          subprocess.run(sys.argv[2:], check=True)
+  hostRequirements:
+    attributes:
+    - name: attr.worker.os.family
+      anyOf:
+      - windows

--- a/job_bundles/blender_render/template.yaml
+++ b/job_bundles/blender_render/template.yaml
@@ -59,19 +59,19 @@ parameterDefinitions:
 - name: CondaPackages
   type: STRING
   userInterface:
-    control: LINE_EDIT
-    label: Conda Packages
-    groupLabel: Software Environment
+    # This parameter is for a queue environment, not used directly in the job,
+    # so leave the GUI for the queue environment to display.
+    control: HIDDEN
   default: blender
   description: >
-    If you have a Queue Environment that creates a Conda environment from a parameter called CondaPackages, this will
-    tell it to install blender.
+    If you have a Queue Environment that creates a Conda environment from a parameter called CondaPackages, this
+    will set the default packages to use for the job.
 - name: RezPackages
   type: STRING
   userInterface:
-    control: LINE_EDIT
-    label: Rez Packages
-    groupLabel: Software Environment
+    # This parameter is for a queue environment, not used directly in the job,
+    # so leave the GUI for the queue environment to display.
+    control: HIDDEN
   default: blender
   description: >
     If you have a Queue Environment that creates a Rez environment from a parameter called RezPackages, this will

--- a/job_bundles/cli_job/template.yaml
+++ b/job_bundles/cli_job/template.yaml
@@ -44,6 +44,7 @@ steps:
         set -euo pipefail
 
         echo 'Data Dir is {{Param.DataDir}}'
+        mkdir -p '{{Param.DataDir}}'
         cd '{{Param.DataDir}}'
 
         # Echo each command before running it.

--- a/job_bundles/copy_s3_prefix_to_job_attachments/template.yaml
+++ b/job_bundles/copy_s3_prefix_to_job_attachments/template.yaml
@@ -29,7 +29,7 @@ parameterDefinitions:
     control: LINE_EDIT
     groupLabel: Software
   type: STRING
-  default: python boto3 python-xxhash
+  default: python pip boto3 python-xxhash
 - name: CondaChannels
   description: A list of conda channels to get packages from. The job expects a Queue Environment to handle this.
   userInterface:
@@ -77,6 +77,11 @@ steps:
         - '{{Param.Parallelism}}'
         - '--copy-source'
         - '{{Param.S3CopySource}}'
+  hostRequirements:
+    attributes:
+    - name: attr.worker.os.family
+      anyOf:
+      - linux
 
 - name: HashObjects
   description: |
@@ -102,6 +107,11 @@ steps:
         - '{{Task.Param.Index}}'
         - '--copy-source'
         - '{{Param.S3CopySource}}'
+  hostRequirements:
+    attributes:
+    - name: attr.worker.os.family
+      anyOf:
+      - linux
 
 - name: CopyObjects
   description: |
@@ -126,6 +136,11 @@ steps:
         - '{{Task.Param.Index}}'
         - '--copy-source'
         - '{{Param.S3CopySource}}'
+  hostRequirements:
+    attributes:
+    - name: attr.worker.os.family
+      anyOf:
+      - linux
 
 - name: SaveManifest
   description: |
@@ -145,3 +160,8 @@ steps:
         - '{{Param.Parallelism}}'
         - '--copy-source'
         - '{{Param.S3CopySource}}'
+  hostRequirements:
+    attributes:
+    - name: attr.worker.os.family
+      anyOf:
+      - linux

--- a/job_bundles/gsplat_pipeline/template.yaml
+++ b/job_bundles/gsplat_pipeline/template.yaml
@@ -142,7 +142,7 @@ parameterDefinitions:
     control: LINE_EDIT
     label: Conda Packages
     groupLabel: Software Environment
-  default: ffmpeg colmap=*=gpu* glomap nerfstudio
+  default: ffmpeg colmap glomap nerfstudio
 
 # Hidden
 - name: JobScriptDir

--- a/job_bundles/houdini_husk_usd_render/template.yaml
+++ b/job_bundles/houdini_husk_usd_render/template.yaml
@@ -79,18 +79,18 @@ parameterDefinitions:
     control: DROPDOWN_LIST
     label: Husk Render Delegate
     groupLabel: Render Parameters
-  description: Choose the renderer you wish to use. BRAY_HdKarma uses the CPU while BRAY_HdKarmaXPU requires a GPU fleet. If you select BRAY_HdKarmaXPU your queue must be associated with a GPU fleet. 
+  description: Choose the renderer you wish to use. BRAY_HdKarma uses the CPU while BRAY_HdKarmaXPU requires a GPU fleet. If you select BRAY_HdKarmaXPU your queue must be associated with a GPU fleet.
   default: BRAY_HdKarma
   allowedValues: [BRAY_HdKarma, BRAY_HdKarmaXPU]
 - name: CondaPackages
   type: STRING
   userInterface:
-    control: LINE_EDIT
-    label: Conda Packages
-    groupLabel: Software Environment
+    # This parameter is for a queue environment, not used directly in the job,
+    # so leave the GUI for the queue environment to display.
+    control: HIDDEN
   default: "houdini=20.5"
   description: >
-    This parameter assumes the presence of the default Conda environment. By default, Houdini 20.5 is installed to provide the husk executable.
+    This parameter provides a default value Conda environment, specifying Houdini 20.5 to provide the husk executable.
 steps:
 - name: HuskRender
   parameterSpace:

--- a/job_bundles/job_dev_progression/stage_4_bundled_python_package/template.yaml
+++ b/job_bundles/job_dev_progression/stage_4_bundled_python_package/template.yaml
@@ -30,7 +30,7 @@ parameterDefinitions:
 - name: CondaPackages
   description: A list of conda packages to install. The job expects a Queue Environment to handle this.
   type: STRING
-  default: polars pyarrow seaborn
+  default: pip polars pyarrow seaborn
 - name: CondaChannels
   description: A list of conda channels to get packages from. The job expects a Queue Environment to handle this.
   type: STRING

--- a/job_bundles/keyshot_standalone/template.yaml
+++ b/job_bundles/keyshot_standalone/template.yaml
@@ -4,7 +4,10 @@ description: |
   A simple job bundle that allows the user to select a KeyShot scene file, the
   frames to render, the output file path and render via the keyshot_headless
   command on Windows.
+
 parameterDefinitions:
+
+# KeyShot Scene Settings
 - name: KeyShotFile
   description: The KeyShot scene file to render.
   type: PATH
@@ -29,6 +32,8 @@ parameterDefinitions:
     label: Frames
     groupLabel: KeyShot Scene Settings
   minLength: 1
+
+# KeyShot Output Settings
 - name: OutputName
   description: The file name prefix to save out each frame with
   type: STRING
@@ -49,7 +54,7 @@ parameterDefinitions:
 - name: OutputFormat
   description: The render output format
   type: STRING
-  allowedValues: 
+  allowedValues:
     [
       "PNG",
       "JPEG",
@@ -65,6 +70,19 @@ parameterDefinitions:
     control: DROPDOWN_LIST
     label: Output Format
     groupLabel: KeyShot Output Settings
+
+# Software Environment
+- name: CondaPackages
+  type: STRING
+  userInterface:
+    # This parameter is for a queue environment, not used directly in the job,
+    # so leave the GUI for the queue environment to display.
+    control: HIDDEN
+  default: keyshot
+  description: >
+    If you have a Queue Environment that creates a Conda environment from a parameter called CondaPackages, this
+    will set the default packages to use for the job.
+
 steps:
 - name: Render
   parameterSpace:
@@ -76,7 +94,7 @@ steps:
     actions:
       onRun:
         command: keyshot_headless
-        args: 
+        args:
         - -progress
         - -floating_feature
         - keyshot2
@@ -109,3 +127,8 @@ steps:
           print(f"Output Format: {output_format_code}")
           lux.renderImage(path=output_path, opts=opts, format=output_format_code)
           print("Finished Rendering")
+  hostRequirements:
+    attributes:
+    - name: attr.worker.os.family
+      anyOf:
+      - windows

--- a/job_bundles/maya_cli_render/template.yaml
+++ b/job_bundles/maya_cli_render/template.yaml
@@ -85,9 +85,9 @@ parameterDefinitions:
 - name: CondaPackages
   type: STRING
   userInterface:
-    control: LINE_EDIT
-    label: Conda Packages
-    groupLabel: Software Environment
+    # This parameter is for a queue environment, not used directly in the job,
+    # so leave the GUI for the queue environment to display.
+    control: HIDDEN
   description: Choose which conda packages to install for the render. Requires a conda queue environment to process the value.
   default: maya
 

--- a/job_bundles/nuke_render/template.yaml
+++ b/job_bundles/nuke_render/template.yaml
@@ -2,7 +2,7 @@ specificationVersion: 'jobtemplate-2023-09'
 name: Nuke Render
 description: |
   This job bundle renders Nuke scripts using Nuke's headless rendering mode.
-  
+
   To run it, you will need a Nuke installation available in the PATH in one of the following ways:
     * As a conda package when your queue has a conda queue environment set up to
       provide virtual environments for jobs.
@@ -63,19 +63,19 @@ parameterDefinitions:
 - name: CondaPackages
   type: STRING
   userInterface:
-    control: LINE_EDIT
-    label: Conda Packages
-    groupLabel: Software Environment
+    # This parameter is for a queue environment, not used directly in the job,
+    # so leave the GUI for the queue environment to display.
+    control: HIDDEN
   default: "nuke nuke-openjd"
   description: >
-    Conda packages to install for the render. 
+    Conda packages to install for the render.
     Example: "nuke=16.* nuke-openjd" or "nuke nuke-openjd"
 - name: RezPackages
   type: STRING
   userInterface:
-    control: LINE_EDIT
-    label: Rez Packages
-    groupLabel: Software Environment
+    # This parameter is for a queue environment, not used directly in the job,
+    # so leave the GUI for the queue environment to display.
+    control: HIDDEN
   default: "nuke"
   description: >
     If you have a Queue Environment that creates a Rez environment from a parameter called RezPackages, this will
@@ -101,13 +101,13 @@ steps:
       data: |
         # Configure the task to fail if any individual command fails.
         set -xeuo pipefail
-        
+
         echo "Nuke script is {{Param.NukeScript}}"
         cd '{{Param.ProjectPath}}'
-        
+
         # Create output directory if it doesn't exist
         mkdir -p '{{Param.OutputDir}}'
-        
+
         # Render the frame using Nuke
         nuke -F {{Task.Param.Frame}} \
              --sro -V 2 \

--- a/job_bundles/redshift-2025/template.yaml
+++ b/job_bundles/redshift-2025/template.yaml
@@ -57,9 +57,9 @@ parameterDefinitions:
 - name: CondaPackages
   type: STRING
   userInterface:
-    control: LINE_EDIT
-    label: Conda Packages
-    groupLabel: Software Environment
+    # This parameter is for a queue environment, not used directly in the job,
+    # so leave the GUI for the queue environment to display.
+    control: HIDDEN
   default: "cinema4d=2025"
   description: >
     Conda package for Cinema 4D 2025 that includes Redshift.
@@ -86,38 +86,38 @@ steps:
         data: |
           #!/bin/bash
           set -euo pipefail
-          
+
           # Disable MinGW path conversion on Windows
           export MSYS_NO_PATHCONV=1
-          
+
           echo "Starting Redshift render using redshiftCmdLine..."
-          
+
           # Create output directory if it doesn't exist
           mkdir -p '{{Param.OutputDir}}'
-          
+
           # Check if scene file exists
           if [[ ! -f '{{Param.SceneFile}}' ]]; then
             echo "openjd_fail: Scene file not found: {{Param.SceneFile}}"
             exit 1
           fi
-          
+
           C4D_LOCATION="${CONDA_PREFIX}/cinema4d"
           REDSHIFT_EXE="${CONDA_PREFIX}/cinema4d/RedshiftData/bin/redshiftCmdLine.exe"
-          
+
           # Set Cinema 4D and Redshift environment variables
           export REDSHIFT_COREDATAPATH="${C4D_LOCATION}/RedshiftData"
           export REDSHIFT_LOCALDATAPATH="${C4D_LOCATION}/RedshiftData"
-          
+
           # Check if redshiftCmdLine executable exists
           if [[ ! -f "$REDSHIFT_EXE" ]]; then
             echo "openjd_fail: redshiftCmdLine executable not found at: $REDSHIFT_EXE"
             echo "Please verify the installed conda packages includes Redshift"
             exit 1
           fi
-          
+
           # Use redshiftCmdLine to render the scene
           echo "Running redshiftCmdLine with scene: {{Param.SceneFile}}"
-          
+
           "$REDSHIFT_EXE" '{{Param.SceneFile}}' -ores {{Param.Width}}x{{Param.Height}} -oip '{{Param.OutputDir}}'
-          
+
           exit 0

--- a/job_bundles/tile_render_with_maya_arnold/template.yaml
+++ b/job_bundles/tile_render_with_maya_arnold/template.yaml
@@ -180,9 +180,9 @@ parameterDefinitions:
   description: Choose which Conda packages to install for the render. Requires a conda queue environment to process the value.
   default: maya=2025 maya-mtoa maya-openjd=0.14 ffmpeg
   userInterface:
-    control: LINE_EDIT
-    label: Conda Packages
-    groupLabel: Software Environment
+    # This parameter is for a queue environment, not used directly in the job,
+    # so leave the GUI for the queue environment to display.
+    control: HIDDEN
 
 steps:
 - name: Render Tile Regions

--- a/job_bundles/turntable_with_maya_arnold/template.yaml
+++ b/job_bundles/turntable_with_maya_arnold/template.yaml
@@ -190,9 +190,9 @@ parameterDefinitions:
   description: Choose which Conda packages to install for the render. Requires a conda queue environment to process the value.
   default: maya>=2024 maya-mtoa maya-openjd=0.14 ffmpeg
   userInterface:
-    control: LINE_EDIT
-    label: Conda Packages
-    groupLabel: Software Environment
+    # This parameter is for a queue environment, not used directly in the job,
+    # so leave the GUI for the queue environment to display.
+    control: HIDDEN
 
 # Hidden
 - name: WorkspacePath

--- a/job_bundles/vray_render/template.yaml
+++ b/job_bundles/vray_render/template.yaml
@@ -55,9 +55,9 @@ parameterDefinitions:
 - name: CondaPackages
   type: STRING
   userInterface:
-    control: LINE_EDIT
-    label: Conda Packages
-    groupLabel: Software Environment
+    # This parameter is for a queue environment, not used directly in the job,
+    # so leave the GUI for the queue environment to display.
+    control: HIDDEN
   default: vray
   description: >
     If you have a Queue Environment that creates a Conda environment from a parameter called CondaPackages, this will

--- a/queue_environments/README.md
+++ b/queue_environments/README.md
@@ -119,6 +119,19 @@ repeatedly re-download the same applications, but each session will have the ove
 packages into the virtual environment. Look at the sample with improved caching to reuse virtual
 environments across multiple jobs.
 
+### Conda queue environment using the py-rattler library
+
+The file [conda_queue_env_pyrattler.yaml](conda_queue_env_pyrattler.yaml) provides the same functionality as
+the above Conda queue environments, but uses the [py-rattler library](https://conda.github.io/rattler/py-rattler/).
+Rattler is a library that provides common functionality used within the conda ecosystem. It's written
+in Rust and tries to provide a clean API to its functionalities. The environments it creates are almost the same,
+but we found that py-rattler does not include 'pip' alongside 'python' by default, so if you need pip you must
+add it explicitly. It also raises an error for a subset of syntax that conda accepts, such as 'colmap=*=gpu*'.
+
+Testing has shown that this queue environment generally runs faster than the above when on the same instance types,
+but the error messages it produces when failing to solve for a virtual environment do not include as
+much detail to help diagnose what happened.
+
 ### Rez queue environment
 
 The file [rez_queue_env.yaml](rez_queue_env.yaml) provides the same functionality as

--- a/queue_environments/conda_queue_env_pyrattler.yaml
+++ b/queue_environments/conda_queue_env_pyrattler.yaml
@@ -1,0 +1,251 @@
+specificationVersion: "environment-2023-09"
+parameterDefinitions:
+- name: CondaPackages
+  type: STRING
+  description: >
+    This is a space-separated list of Conda package match specifications to
+    install for the job. E.g. "blender=4.5" for a job that renders frames in
+    Blender 4.5.
+  default: ""
+  userInterface:
+    control: LINE_EDIT
+    label: Conda Packages
+- name: CondaChannels
+  type: STRING
+  description: >
+    This is a space-separated list of Conda channels from which to install
+    packages. Deadline Cloud SMF packages are installed from the
+    "deadline-cloud" channel that is configured by Deadline Cloud.
+
+    Add "conda-forge" to get packages from the https://conda-forge.org/
+    community, and "defaults" to get packages from Anaconda Inc (make sure
+    your usage complies with https://legal.anaconda.com/policies).
+  default: "deadline-cloud"
+  userInterface:
+    control: LINE_EDIT
+    label: Conda Channels
+- name: ChannelPriority
+  type: STRING
+  description: >
+    Defines how channel priority functions during package solving. If "Strict",
+    the channel that a package is first found in will be used as the only
+    channel for that package. If "Disabled", packages can be retrieved from
+    any channel as package version takes precedence.
+  default: "Strict"
+  allowedValues: ["Strict", "Disabled"]
+  userInterface:
+    control: DROPDOWN_LIST
+    label: Channel Priority
+
+environment:
+  name: Conda
+  script:
+    actions:
+      onEnter:
+        command: "python"
+        args:
+          - "{{Env.File.Enter}}"
+          - "{{Param.CondaPackages}}"
+          - "{{Param.CondaChannels}}"
+          - "{{Param.ChannelPriority}}"
+          - "{{Session.WorkingDirectory}}"
+          - "{{Env.File.OpenJDVarsCapture}}"
+    embeddedFiles:
+    - name: Enter
+      filename: conda-queue-env-enter.sh
+      type: TEXT
+      data: |
+        import asyncio
+        import json
+        import os
+        import shlex
+        import subprocess
+        import sys
+        import tempfile
+        import textwrap
+
+        # Collect the arguments
+        conda_packages = sys.argv[1].strip()
+        conda_channels = sys.argv[2].strip()
+        channel_priority = sys.argv[3].strip()
+        working_directory = sys.argv[4]
+        vars_capture_script = sys.argv[5]
+
+        # Exit quickly if there are no packages
+        if conda_packages == "":
+            print("Skipping conda env as the CondaPackages parameter was empty.")
+            sys.exit(0)
+
+        # Turn off multi-line buffering in stdout
+        sys.stdout = os.fdopen(sys.stdout.fileno(), "w", buffering=1)
+
+        # Import https://conda.github.io/rattler/py-rattler/, installing it in a cache dir if necessary
+        try:
+            import rattler
+            import yaml
+        except ModuleNotFoundError:
+            cache_dir = os.path.expanduser(
+                f"~/.cache/conda-queue-env/{'.'.join(str(v) for v in sys.version_info)}/site-packages/"
+            )
+            os.makedirs(cache_dir, exist_ok=True)
+            sys.path.insert(0, cache_dir)
+            subprocess.check_call(
+                [
+                    sys.executable,
+                    "-m",
+                    "pip",
+                    "install",
+                    "--upgrade",
+                    "--upgrade-strategy",
+                    "only-if-needed",
+                    "--target",
+                    cache_dir,
+                    "py-rattler>=0.16,<0.17",
+                    "pyyaml>=6,<7",
+                ]
+            )
+            import rattler
+            import yaml
+        import rattler.shell
+
+        def load_channel_aliases():
+            # py-rattler does not support loading and applying condarc configuration, so
+            # we must load it by hand.
+
+            # The following is only checking the global condarc locations used in Deadline Cloud
+            # service-managed fleets. If you need a more complete list, see the following docs:
+            # https://docs.conda.io/projects/conda/en/stable/user-guide/configuration/use-condarc.html#searching-for-condarc
+            channel_aliases = {}
+
+            for condarc in ["/etc/conda/condarc", "C:/ProgramData/conda/condarc"]:
+                try:
+                    with open(condarc, encoding="utf8") as f:
+                        config = yaml.safe_load(f)
+                        for channel, alias in config.get("custom_channels", {}).items():
+                            channel_aliases[channel] = f"{alias.rstrip('/')}/{channel}/"
+                except FileNotFoundError:
+                    # Skip any condarc that's missing
+                    pass
+
+            return channel_aliases
+
+
+        def save_env_snapshot(snapshot_file):
+            """Save the environment to a file for later diff capture."""
+            # Exclude the env var "_" as it has special meaning to shells
+            before = dict(os.environ)
+            if "_" in before:
+                del before["_"]
+
+            with open(snapshot_file, "w", encoding="utf8") as f:
+                json.dump(before, f)
+
+
+        async def main():
+            env_dir = tempfile.mkdtemp(prefix=".env-", dir=working_directory)
+
+            print("Creating a conda environment in the session directory...")
+
+            channel_aliases = load_channel_aliases()
+            channels = conda_channels.split()
+            specs = conda_packages.split()
+
+            print(f"channels:")
+            for channel in channels:
+                print(f"  - {channel}")
+            print(f"specs:")
+            for spec in specs:
+                print(f"  - {spec}")
+            print()
+
+            print("Solving the environment...")
+            # This list is copied from https://github.com/conda/rattler/blob/7d36fe334c14ddf6227dc0ec0982379d062c5915/crates/rattler-bin/src/commands/create.rs#L162-L172
+            middlewares = [
+                rattler.networking.AuthenticationMiddleware(),
+                ## OciMiddleware not available in py-rattler 0.16.0
+                # rattler.networking.OciMiddleware(),
+                rattler.networking.S3Middleware(),
+                rattler.networking.GCSMiddleware(),
+            ]
+            client = rattler.networking.Client(middlewares)
+            gateway = rattler.repo_data.Gateway(client=client)
+            solved_records = await rattler.solve(
+                channels=[channel_aliases.get(c, c) for c in channels],
+                specs=specs,
+                gateway=gateway,
+                virtual_packages=rattler.VirtualPackage.detect(),
+                channel_priority=getattr(rattler.ChannelPriority, channel_priority),
+            )
+
+            for record in solved_records:
+                print(f"  - {record.url}")
+            print()
+
+            print("Installing packages...")
+            await rattler.install(
+                records=solved_records,
+                target_prefix=env_dir,
+                client=client,
+            )
+
+            print("Installation complete")
+            print("Activating the environment...")
+
+            # We're using bash for activation on all operating systems, including Windows.
+            # This means the host machine needs bash installed, e.g. from Git for Windows.
+            shell = rattler.shell.Shell.bash
+
+            actvars = rattler.shell.ActivationVariables(
+                current_path=os.environ["PATH"].split(os.pathsep)
+            )
+            activation = rattler.shell.activate(env_dir, actvars, shell)
+
+            print("Running activation script:")
+            print(textwrap.indent(activation.script, prefix="  "))
+            print()
+
+            with tempfile.TemporaryDirectory() as tmpdir:
+                vars_file = os.path.join(tmpdir, "vars.json")
+                capture_script = os.path.join(tmpdir, "capture.sh")
+
+                save_env_snapshot(vars_file)
+                with open(capture_script, "w", encoding="utf8") as f:
+                    f.write(activation.script)
+                    f.write("\n")
+                    f.write(shlex.join([sys.executable, vars_capture_script, vars_file]))
+                    f.write("\n")
+
+                # This command will print out the environment variable changes from activation
+                env = dict(os.environ)
+                env["PATH"] = os.pathsep.join(str(p) for p in activation.path)
+                subprocess.check_call(["bash", capture_script], env=env)
+
+
+        asyncio.run(main())
+
+    - name: OpenJDVarsCapture
+      filename: openjd-vars-capture.py
+      type: TEXT
+      data: |
+        import json
+        import os
+        import sys
+
+        # Get the snapshot from `openjd-vars-start.py`, and the current environment state.
+        with open(sys.argv[1], "r", encoding="utf8") as f:
+            before = json.load(f)
+        after = dict(os.environ)
+        # Exclude the env var "_" as it has special meaning to shells
+        if "_" in after:
+            del after["_"]
+
+        # Identify the modified and deleted environment variables
+        vars_to_put = {k: v for k, v in after.items() if v != before.get(k)}
+        vars_to_delete = {k for k in before if k not in after}
+
+        # Print the env var changes following the Open Job Description specification
+        for k, v in vars_to_put.items():
+            kv = json.dumps(f"{k}={v}", ensure_ascii=True)
+            print(f"openjd_env: {kv}")
+        for k in vars_to_delete:
+            print(f"openjd_unset_env: {k}")


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The [rattler library](https://github.com/conda/rattler#readme) now supports the default AWS credentials configuration, so can be used to provide conda environments just like the samples we have using the conda command.

In the progress of testing, found some small tweaks necessary in other sample jobs.

### What was the solution? (How)

Implement a conda queue environment that uses the [py-rattler library](https://conda.github.io/rattler/py-rattler/). A lot of it was straightforward, but the library doesn't use the default configuration that tools like `pixi` apply, so the code had to manually read `.condarc` configuration and enable S3 channel support.

* Tested with a variety of the job bundle samples, and updated them.
  Some updates, like adding 'pip' to CondaPackages, are for py-rattler,
  and others are to increase the clarity and reliability of the samples.
  * Change the control for CondaPackages parameters to HIDDEN. If
    there's a conda queue environment, it will show a GUI for this
    parameter, and if there isn't a conda queue environment, the
    parameter is unused so it's better to hide it.
  * Update the stage 4 job dev progression sample to include 'pip' in
    CondaPackages for compatibility with rattler env creation.
  * Update the cli_job sample so that it works when the input/output
    directory doesn't exist.
  * Update the afterfx_render_onetask sample to format the parameter
    grouping in the template, set the default package to 'aftereffects',
    set the default host requirements to specify windows, and add an
    output filename as the aerender command needs for '-output'. Switch
    to running a Python script that ensures the output directory exists.
  * Update copy_s3_prefix_to_job_attachments with host requirements for
    linux, and add 'pip' to CondaPackages.
  * Update CondaPackages for gsplat_pipeline to use 'colmap' instead of
    'colmap=*=gpu*'. Py-rattler gave a message like
    'exceptions.InvalidMatchSpecException: the build string '=gpu*' is
    not valid', and conda no longer needs this workaround.
  * Update keyshot_standalone to include keyshot in the default
    CondaPackages and to use a windows host requirement.

### What is the impact of this change?

Another option for providing conda environments to Deadline Cloud jobs. Because the result often runs faster, we may want to make this the default approach after sufficient validation.

I performed some measurements of environment creation of this new queue environment compared to [conda_queue_env_console_equivalent.yaml](https://github.com/aws-deadline/deadline-cloud-samples/blob/mainline/queue_environments/conda_queue_env_console_equivalent.yaml). The job I used is [turntable_with_maya_arnold](https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/job_bundles/turntable_with_maya_arnold), and I fixed the test to use identical instance types.

When running the first time:
```
Conda:  1:28.22
Pyrattler:  55.70
```

When running again, using the package cache from the previous time:
```
Conda: 20.73
Pyrattler: 4.98
```

### How was this change tested?

Configured the queue environment on a queue that has both Linux and Windows associated fleets. Ran a variety of jobs.

### Was this change documented?

Added a description to the README.md for the queue environments.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*