### PR TITLE
chore: Added Keyshot sample conda-recipe.

### DIFF
--- a/conda_recipes/keyshot-2025/README.md
+++ b/conda_recipes/keyshot-2025/README.md
@@ -1,0 +1,104 @@
+# KeyShot 2025.2 Conda Recipe for AWS Deadline Cloud
+
+## Overview
+
+This directory contains a conda build recipe for KeyShot 2025.2, specifically configured for use with AWS Deadline Cloud. This package enables you to run KeyShot 3D visualization and rendering jobs on Deadline Cloud service-managed fleets.
+
+## Package Information
+
+- **Application**: KeyShot 2025.2
+- **Supported Platforms**: win-64
+- **Source**: KeyShot installer executable
+- **License**: Commercial
+- **Build Tool**: conda-build
+
+## Prerequisites
+
+Before building this package, ensure you have:
+
+1. **AWS Deadline Cloud infrastructure** set up with:
+   - A farm configured for package building
+   - A queue named "Package Build Queue" (or specify with `-q` option)
+   - Windows-64 fleet for building Windows packages
+
+2. **Deadline Cloud CLI** installed on your workstation
+
+3. **Source archive** Download the Keyshot Studio installer
+
+4. **Keyshot account** for downloading Keyshot installer
+
+5. **KeyShot license** for rendering operations. Available through Deadline Cloud Usage-Based Licensing
+
+## Application-Specific Information
+
+### Licensing
+
+See the [AWS Deadline Cloud licensing documentation](https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/license.html) for detailed guidance on license configuration. KeyShot requires proper licensing configuration for rendering operations.
+
+### Headless Rendering
+
+- KeyShot headless executable is available as `keyshot_headless.bat` in the conda environment
+- Registry configuration ensures proper resource discovery in headless mode
+- GPU acceleration may be beneficial for complex rendering tasks
+
+## Adapting to Other Versions
+
+### Version Update Checklist
+
+To adapt this recipe for KeyShot 2024 or 2026:
+
+1. **Update Version Information**
+   ```yaml
+   # In recipe/meta.yaml
+   {% set version_partial = "2026" %}
+   {% set version_minor = "1" %}
+   
+   # In deadline-cloud.yaml
+   sourceArchiveFilename: keyshot-2026.1-windows_x86_64.exe
+   ```
+
+2. **Update Source Archives**
+   - Download new version installer from Luxion
+   - Update SHA256 hash in `meta.yaml`
+   - Update source filename in `deadline-cloud.yaml`
+
+3. **Check Dependencies**
+   - Review system requirements for new version
+   - Test compatibility with existing materials and plugins
+   - Update minimum Windows version if required
+
+4. **Update Build Scripts**
+   - Check for changes in installation directory structure
+   - Verify registry key paths haven't changed
+   - Update executable names if changed
+
+### Common Version Migration Issues
+
+- **Registry Changes**: Registry key paths may change between versions
+- **Installation Structure**: Directory layout may be reorganized
+- **Plugin API Changes**: Plugin interfaces may be incompatible
+- **License Changes**: Licensing requirements may change
+
+## Recipe Structure
+
+```
+keyshot-2025/
+├── README.md                    # This file
+├── deadline-cloud.yaml          # Deadline Cloud configuration
+└── recipe/
+    ├── meta.yaml               # Conda package metadata
+    ├── bld.bat                 # Windows build script
+    └── run_test.py             # Optional test script
+```
+
+## Resources
+
+- **KeyShot Documentation**: https://www.keyshot.com/resources/
+- **KeyShot Scripting**: https://www.keyshot.com/scripting/
+- **AWS Deadline Cloud Developer Guide**: https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/
+- **Conda Build Documentation**: https://docs.conda.io/projects/conda-build/
+- **KeyShot Network Rendering**: https://www.keyshot.com/network-rendering/
+
+---
+
+**Note**: This recipe is specifically configured for KeyShot 2025.2 on Windows x86_64 platforms. The build process handles registry configuration for headless rendering environments and creates appropriate wrapper scripts for command-line access.

--- a/conda_recipes/keyshot-2025/deadline-cloud.yaml
+++ b/conda_recipes/keyshot-2025/deadline-cloud.yaml
@@ -1,0 +1,6 @@
+condaPlatforms:
+  - platform: win-64
+    defaultSubmit: true
+    sourceArchiveFilename: keyshot_studio_win64_2025.2_14.1.1.8.exe
+    sourceDownloadInstructions: 'Follow the instructions in README.md to construct the archive zip file.'
+    buildTool: conda-build

--- a/conda_recipes/keyshot-2025/recipe/bld.bat
+++ b/conda_recipes/keyshot-2025/recipe/bld.bat
@@ -1,0 +1,39 @@
+if not exist "%PREFIX%\keyshot\" mkdir "%PREFIX%\keyshot" || exit /b 1
+if not exist "%PREFIX%\keyshot_resources\" mkdir "%PREFIX%\keyshot_resources" || exit /b 1
+
+start /wait /b cmd /c "%SRC_DIR%\installer\keyshot_studio_win64_%PKG_VERSION%_%BUILD_NUMBER%.exe /S /USERNAME=%PREFIX%\keyshot_resources\ /D=%PREFIX%\keyshot\" || exit /b 1
+
+REM Symlinks on Windows require Admin privileges to create. So create batch files in the PATH instead.
+if not exist "%SCRIPTS%\" mkdir "%SCRIPTS%" || exit /b 1
+(
+    echo start /wait /b cmd /c "%%CONDA_PREFIX%%\keyshot\bin\keyshot_headless.exe %%*"
+) > "%SCRIPTS%\keyshot_headless.bat"
+
+if not exist "%PREFIX%\etc\conda\activate.d\" mkdir "%PREFIX%\etc\conda\activate.d" || exit /b 1
+if not exist "%PREFIX%\etc\conda\deactivate.d\" mkdir "%PREFIX%\etc\conda\deactivate.d" || exit /b 1
+
+(
+    echo set KEYSHOT_LOCATION="%%CONDA_PREFIX%%\keyshot"
+    echo set KEYSHOT_VERSION="%PKG_VERSION%"
+    echo reg add "HKCU\SOFTWARE\Luxion\KeyShot" /t REG_SZ /v Resources /d "%%CONDA_PREFIX%%\keyshot\resources" /f
+    echo reg add "HKCU\SOFTWARE\Luxion\KeyShot" /t REG_SZ /v ResourceFolder /d "%%CONDA_PREFIX%%\keyshot\resources" /f
+) > "%PREFIX%\etc\conda\activate.d\%PKG_NAME%-%PKG_VERSION%-vars.bat" || exit /b 1
+(
+    echo export KEYSHOT_LOCATION="$CONDA_PREFIX\\keyshot"
+    echo export KEYSHOT_VERSION="%PKG_VERSION%"
+    echo MSYS_NO_PATHCONV=1 reg add 'HKCU\SOFTWARE\Luxion\KeyShot' /t REG_SZ /v Resources /d "$CONDA_PREFIX\keyshot\resources" /f
+    echo MSYS_NO_PATHCONV=1 reg add 'HKCU\SOFTWARE\Luxion\KeyShot' /t REG_SZ /v ResourceFolder /d "$CONDA_PREFIX\keyshot\resources" /f
+) > "%PREFIX%\etc\conda\activate.d\%PKG_NAME%-%PKG_VERSION%-vars.sh" || exit /b 1
+
+(
+    echo set KEYSHOT_LOCATION=
+    echo set KEYSHOT_VERSION=
+    echo reg delete "HKCU\SOFTWARE\Luxion\KeyShot" /v Resources /f
+    echo reg delete "HKCU\SOFTWARE\Luxion\KeyShot" /v ResourceFolder /f
+) > "%PREFIX%\etc\conda\deactivate.d\%PKG_NAME%-%PKG_VERSION%-vars.bat" || exit /b 1
+(
+    echo unset KEYSHOT_LOCATION
+    echo unset KEYSHOT_VERSION
+    echo MSYS_NO_PATHCONV=1 reg delete 'HKCU\SOFTWARE\Luxion\KeyShot' /v Resources /f
+    echo MSYS_NO_PATHCONV=1 reg delete 'HKCU\SOFTWARE\Luxion\KeyShot' /v ResourceFolder /f
+) > "%PREFIX%\etc\conda\deactivate.d\%PKG_NAME%-%PKG_VERSION%-vars.sh" || exit /b 1

--- a/conda_recipes/keyshot-2025/recipe/meta.yaml
+++ b/conda_recipes/keyshot-2025/recipe/meta.yaml
@@ -1,0 +1,34 @@
+{% set name = "keyshot" %}
+{% set version_partial = "2025" %}
+{% set version_minor = "2" %}
+{% set version = version_partial + "." + version_minor %}
+{% set build_number = "14.1.1.8" %}
+
+{% set sha256 = "ea18bbc476b438dca4a9fdec578150a1d1675bcab503e47e666252fcdc08aa9b" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: file://archive_files/keyshot_studio_win64_{{ version }}_{{ build_number }}.exe
+  sha256: {{ sha256 }}
+  folder: installer
+
+build:
+  number: 0
+  binary_relocation: False
+  detect_binary_files_with_prefix: False
+  # The binary is built to be relocatable, so can ignore the warnings about DSOs.
+  missing_dso_whitelist:
+  - "*"
+  ignore_prefix_files: True
+  script_env:
+  - BUILD_NUMBER = {{ build_number }}
+
+about:
+  home: https://www.keyshot.com
+  license: Commercial
+  summary: >
+    KeyShot is a suite of 3D visualization tools preferred by industrial designers, graphic designers, engineers, CG specialists, photographers, and marketing professionals around the world.
+    KeyShot's intuitive software breaks down the complexity of making photo-realistic images and animations from 3D digital data.


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

There isn't a sample Keyshot package.

### What was the solution? (How)

Added a sample Keyshot package for Keyshot 2025.2.

### What is the impact of this change?

Having more DCC samples will help people create their own recipes and packages.

### How was this change tested?

Deployed the build farm as described in the recipe sample instructions. Built the package in my own custom conda channel. Rendered a simple Keyshot scene (from their sample scenes). Verified in the logs that it was pulling the package from my conda channel.

### Was this change documented?

Added a README along side the recipe.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*