### PR TITLE
chore: Added sample recipe for Nuke and Nuke OFX Plugin.

### DIFF
--- a/conda_recipes/nuke-16.0/README.md
+++ b/conda_recipes/nuke-16.0/README.md
@@ -1,0 +1,105 @@
+# Nuke 16.0 Conda Recipe for AWS Deadline Cloud
+
+## Overview
+
+This directory contains a conda build recipe for Nuke 16.0.1, specifically configured for use with AWS Deadline Cloud. With this package you can run Nuke compositing and processing jobs on Deadline Cloud service-managed fleets.
+
+## Package Information
+
+- **Application**: Nuke 16.0.1
+- **Supported Platforms**: linux-64
+- **Source**: Foundry website downloads
+- **License**: Commercial
+- **Build Tool**: rattler-build
+
+## Prerequisites
+
+Before building this package, ensure you have:
+
+1. **AWS Deadline Cloud infrastructure** set up with:
+   - A farm configured for package building
+   - A queue. If you followed the [setup instructions](../README.md#infrastructure-setup-prerequisites) it will be named "Package Build Queue"  (or specify the queue name with `-q`)
+   - Linux-64 fleet for building linux packages
+
+2. **Deadline Cloud CLI** installed on your workstation
+
+3. **Source archive** (see [Archive File Instructions](#archive-file-instructions) below)
+
+4. **Foundry account** for downloading Nuke installer
+
+## Archive File Instructions
+
+### Download from Foundry (Required)
+1. Download the `Nuke16.0v1-linux-x86_64.tgz` from the Foundry website.
+2. You will need a Foundry account to access the Nuke downloads.
+3. Place the downloaded file in the `conda_recipes/archive_files` directory.
+4. Conda uses the a checksum to verify the integrity of the source file. The SHA256 hash should match: `61b570ea6d4f8a7e2f0647952c8e039fc02df6f6649e9de1d2ee0543398ed92f`.
+   In bash, you can compute the checksum by running this command `sha256sum Nuke16.0v1-linux-x86_64.tgz`.
+
+## Plugins
+
+### OpenFX Plugins
+To use OpenFX Plugins with Nuke, place the `.bundle` files into a known directory in $PREFIX. Set the OFX_PLUGIN_PATH environment variable to that directory and install any required dependencies. 
+
+#### Example OFX Plugin
+- [Nuke - De:Noise](../nuke-denoise/)
+
+## Adapting to Other Versions
+
+### Version Update Checklist
+
+To adapt this recipe for Nuke 15.x or 17.x:
+
+1. **Update Version Information**
+   ```yaml
+   # In recipe/meta.yaml
+   {% set version_partial = "17.0" %}
+   {% set version_minor = "1" %}
+   
+   # In deadline-cloud.yaml
+   sourceArchiveFilename: Nuke17.0v1-linux-x86_64.tgz
+   ```
+
+2. **Update Source Archives**
+   - Download new version archives from Foundry
+   - Update SHA256 hashes in `meta.yaml`
+   - Update source filename in `deadline-cloud.yaml`
+
+3. **Check Dependencies**
+   - Review and update system dependency versions
+   - Test compatibility with existing plugins
+   - Update minimum system requirements
+
+4. **Update Build Scripts**
+   - Check for changes in installation directory structure
+   - Update file copy operations in build scripts
+   - Verify environment variable paths in activation scripts
+
+### Common Version Migration Issues
+
+- **Path Changes**: Installation directories may change between versions
+- **Dependency Updates**: New versions may require different system libraries
+- **Plugin API Changes**: Plugin interfaces may be incompatible between major versions
+- **License Changes**: Licensing requirements may change
+
+## Recipe Structure
+
+```
+nuke-16.0/
+├── README.md                    # This file
+├── deadline-cloud.yaml          # Deadline Cloud configuration
+└── recipe/
+    ├── recipe.yaml               # Conda package metadata
+    └── build.sh                # Linux build script
+```
+
+## Resources
+
+- **Nuke Documentation**: https://learn.foundry.com/nuke/
+- **AWS Deadline Cloud Developer Guide**: https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/
+- **Conda Build Documentation**: https://docs.conda.io/projects/conda-build/
+- **Plugin Development**: https://learn.foundry.com/nuke/developers/
+
+---
+
+**Note**: This recipe is specifically configured for Nuke 16.0.1 on Linux x86_64 platforms. The build process automatically handles EULA acceptance and system dependency installation.

--- a/conda_recipes/nuke-16.0/deadline-cloud.yaml
+++ b/conda_recipes/nuke-16.0/deadline-cloud.yaml
@@ -1,0 +1,6 @@
+condaPlatforms:
+  - platform: linux-64
+    defaultSubmit: true
+    sourceArchiveFilename: Nuke16.0v1-linux-x86_64.tgz
+    sourceDownloadInstructions: 'Download the Nuke16.0v1-linux-x86_64 full download file from the Foundry. You will need a Foundry account to access the Nuke downloads.'
+    buildTool: rattler-build

--- a/conda_recipes/nuke-16.0/recipe/build.sh
+++ b/conda_recipes/nuke-16.0/recipe/build.sh
@@ -1,0 +1,87 @@
+#!/bin/sh
+set -xeuo pipefail
+
+mkdir -p $PREFIX/opt
+cd $PREFIX/opt
+
+# Install Nuke into $PREFIX/opt
+INSTALLER=$SRC_DIR/installer/*.run
+env -u SRC_DIR -u PREFIX $INSTALLER --prefix $PREFIX/opt --accept-foundry-eula
+
+NUKE_DIR=$PREFIX/opt/Nuke*
+NUKE_BIN=$(basename $NUKE_DIR/Nuke*)
+NUKE_VERSION=${NUKE_BIN#Nuke}
+
+# Remove the documentation, it's not needed on the farm
+rm -r $NUKE_DIR/Documentation
+
+# Create symlinks
+mkdir -p $PREFIX/bin
+ln -r -s $NUKE_DIR/$NUKE_BIN $PREFIX/bin/$NUKE_BIN
+ln -r -s $NUKE_DIR/$NUKE_BIN $PREFIX/bin/nuke
+
+# Install Nuke dependencies from local package manager
+mkdir -p $SRC_DIR/download
+cd $SRC_DIR/download
+dnf download --resolve -y alsa-lib libglvnd-opengl
+for rpm_file in $(realpath $SRC_DIR/download/*.rpm); do
+    rpm2cpio "$rpm_file" | cpio -idm
+done
+
+# Copy .so's to Nuke installation
+for so_file in $(find . -iname "*.so.*"); do
+    cp $so_file $NUKE_DIR/.
+done
+
+# Script to set environment variables during activation
+mkdir -p $PREFIX/etc/conda/activate.d
+cat <<EOF > $PREFIX/etc/conda/activate.d/nuke-$NUKE_VERSION-vars.sh
+internal_package_add_to_search_path () {
+    # Add a path to a new or existing environment variable.
+    # For example, we use this to add a plugin path to the NUKE_PATH 
+    # Usage: internal_package_add_to_search_path VAR_NAME /seach/path/value
+    eval "CURRENT_VALUE=\\\${\$1:-}"
+    if [ "\$CURRENT_VALUE" = "" ]; then
+        eval "export \"\$1=\\\$2\""
+    else
+        NEW_VALUE="\$CURRENT_VALUE:\$2"
+        eval "export \"\$1=\\\$NEW_VALUE\""
+    fi
+}
+
+export "NUKE_LOCATION=\$CONDA_PREFIX/opt/$(basename $NUKE_DIR)"
+export "NUKE_VERSION=$NUKE_VERSION"
+export "NUKE_BINARY_PATH=\$NUKE_LOCATION/bin"
+export "NUKE_INCLUDE_PATH=\$NUKE_LOCATION/include"
+export "NUKE_LIBRARY_PATH=\$NUKE_LOCATION/lib"
+internal_package_add_to_search_path NUKE_PATH "\$NUKE_LOCATION/plugins"
+
+unset -f internal_package_add_to_search_path
+EOF
+
+mkdir -p $PREFIX/etc/conda/deactivate.d
+cat <<EOF > $PREFIX/etc/conda/deactivate.d/nuke-$NUKE_VERSION-vars.sh
+internal_package_remove_from_search_path () {
+    # Removes the given path from the given environment variable.
+    # For example, we use this to clean up the NUKE_PATH we changed in the activate script.
+    # Usage: internal_package_remove_from_search_path VAR_NAME /seach/path/value
+    eval "CURRENT_VALUE=\\\$\$1"
+    if [ "\$CURRENT_VALUE" = "\$2" ]; then
+        eval "unset \$1"
+    else
+        NEW_VALUE="\$(echo ":\$CURRENT_VALUE:" | sed -e "s|:\$2:|:|")"
+        NEW_VALUE="\${NEW_VALUE%:}"
+        NEW_VALUE="\${NEW_VALUE#:}"
+        eval "export \"\$1=\\\$NEW_VALUE\""
+    fi
+}
+
+internal_package_remove_from_search_path NUKE_PATH "\$NUKE_LOCATION/plugins"
+unset NUKE_LIBRARY_PATH
+unset NUKE_INCLUDE_PATH
+unset NUKE_BINARY_PATH
+unset NUKE_VERSION
+unset NUKE_LOCATION
+
+unset -f internal_package_remove_from_search_path
+EOF

--- a/conda_recipes/nuke-16.0/recipe/recipe.yaml
+++ b/conda_recipes/nuke-16.0/recipe/recipe.yaml
@@ -1,0 +1,27 @@
+context:
+  version_partial: "16.0"
+  version_minor: "1"
+
+package:
+  name: nuke
+  version: ${{ version_partial + "." + version_minor }}
+
+source:
+  url: file://archive_files/Nuke{{ version_partial }}v{{ version_minor }}-linux-x86_64.tgz
+  sha256: 61b570ea6d4f8a7e2f0647952c8e039fc02df6f6649e9de1d2ee0543398ed92f
+  target_directory: installer
+
+build:
+  number: 0
+  dynamic_linking:
+    binary_relocation: False
+    missing_dso_allowlist:
+    - "*"
+  prefix_detection:
+    ignore_binary_files: True
+  # The binary is built to be relocatable, so can ignore the warnings about DSOs.
+  
+about:
+  homepage: https://www.foundry.com/products/nuke-family/nuke
+  license: LicenseRef-FoundryEULA
+  summary: Nuke is the powerful node-based compositing tool at the heart of the Nuke family.

--- a/conda_recipes/nuke-denoise/README.md
+++ b/conda_recipes/nuke-denoise/README.md
@@ -1,0 +1,120 @@
+# Nuke DENoise 3.6.9 Conda Recipe for AWS Deadline Cloud
+
+## Overview
+
+This directory contains a conda build recipe for Nuke DENoise 3.6.9, specifically configured for use with AWS Deadline Cloud. With this package you can use the DENoise plugin for noise reduction in Nuke compositing jobs on Deadline Cloud service-managed fleets.
+
+## Package Information
+
+- **Application**: DENoise 3.6.9
+- **Supported Platforms**: linux-64
+- **Source**: Revisionfx
+- **License**: Commercial
+- **Build Tool**: rattler-build
+
+## Prerequisites
+
+Before building this package, ensure you have:
+
+1. **AWS Deadline Cloud infrastructure** set up with:
+   - A farm configured for package building
+   - A queue named "Package Build Queue" (or specify with `-q` option)
+   - Linux-64 fleet for building linux packages
+
+2. **Deadline Cloud CLI** installed on your workstation
+
+3. **Source archive** (see [Archive File Instructions](#archive-file-instructions) below)
+
+4. **Nuke conda package** as this is a plugin dependency
+
+## Archive File Instructions
+
+### Download from Revisionfx (Required)
+1. Download the `DENoise3OFXInstaller.tar.gz` archive from the Revisionfx website
+2. Extract the installer from the archive.
+3. Run the installer. It will create `.bundle` files in the `/usr/OFX/Plugins/DENoise3OFX/`directory.
+4. Archive that directory: `tar czf DENoise.tar.gz /usr/OFX/Plugins/DENoise3OFX/`
+5. Place the archive file in the `conda_recipes/archive_files` directory
+6. Conda uses the a checksum to verify the integrity of the source file. The SHA256 hash should match: `ecbe1b40a19bf6f9ec05aca3d09428386292c57d4cd968b8f1ac767778642ebc`
+   In bash, you can compute the checksum by running this command `sha256sum DENoise.tar.gz`.
+
+## Plugin Integration
+
+### Plugin Architecture
+
+DENoise integrates with Nuke through the OpenFX (OFX) plugin standard. This conda recipe installs DENoise as an OFX plugin that Nuke can automatically discover and load.
+
+### OpenFX Plugin Installation Paths
+
+The conda recipe configures the following environment variables and paths for plugin discovery:
+
+```bash
+# Environment variables set by this package
+export OFX_PLUGIN_PATH=$CONDA_PREFIX/OFX/Plugins/
+
+# Plugin installation paths
+$PREFIX/OFX/Plugins/
+```
+## Licensing
+
+See the [AWS Deadline Cloud licensing documentation](https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/license.html) for detailed guidance on license configuration. DENoise requires proper licensing configuration. This recipe will create a watermarked version without a license.
+
+## Adapting to Other Versions
+
+### Version Update Checklist
+
+To adapt this recipe for other DENoise versions:
+
+1. **Update Version Information**
+   ```yaml
+   # In recipe/meta.yaml
+   {% set version = "3.7.0" %}
+   
+   # In deadline-cloud.yaml
+   # Update if archive filename changes
+   ```
+
+2. **Update Source Archives**
+   - Download new version archives from Foundry
+   - Update SHA256 hashes in `meta.yaml`
+   - Update source filename in `deadline-cloud.yaml` if changed
+
+3. **Check Dependencies**
+   - Review Nuke version compatibility
+   - Test with target Nuke versions
+   - Update system dependency requirements
+
+4. **Update Build Scripts**
+   - Check for changes in plugin bundle structure
+   - Verify OFX plugin paths
+   - Test RPATH settings for new binaries
+
+### Common Version Migration Issues
+
+- **OFX Compatibility**: Newer versions may require different OFX standards
+- **Nuke Compatibility**: Plugin may require specific Nuke versions
+- **Dependency Changes**: System library requirements may change
+- **Bundle Structure**: Plugin bundle organization may change
+
+## Recipe Structure
+
+```
+nuke-denoise/
+├── README.md                    # This file
+├── deadline-cloud.yaml          # Deadline Cloud configuration
+└── recipe/
+    ├── recipe.yaml               # Conda package metadata
+    └── build.sh                # Linux build script
+```
+
+## Resources
+
+- **DENoise Documentation**: https://help.revisionfx.com/album/25/
+- **OpenFX Standard**: http://openeffects.org/
+- **AWS Deadline Cloud Developer Guide**: https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/
+- **Conda Build Documentation**: https://docs.conda.io/projects/conda-build/
+- **Nuke Plugin Development**: https://learn.foundry.com/nuke/developers/
+
+---
+
+**Note**: This recipe is specifically configured for DENoise 3.6.9 as an OFX plugin for Nuke on Linux x86_64 platforms. The plugin requires a valid Nuke/Foundry license to function.

--- a/conda_recipes/nuke-denoise/deadline-cloud.yaml
+++ b/conda_recipes/nuke-denoise/deadline-cloud.yaml
@@ -1,0 +1,10 @@
+condaPlatforms:
+  - platform: linux-64
+    defaultSubmit: true
+    sourceArchiveFilename: DENoise.tar.gz
+    sourceDownloadInstructions: 'Follow the instructions in README.md to construct the archive file.'
+    buildTool: rattler-build
+jobParameters:
+  # conda-forge is used to get patchelf
+  - name: CondaChannels
+    value: conda-forge

--- a/conda_recipes/nuke-denoise/recipe/build.sh
+++ b/conda_recipes/nuke-denoise/recipe/build.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+set -xeuo pipefail
+
+OFX_PLUGIN_PATH=$PREFIX/OFX/Plugins
+mkdir -p $OFX_PLUGIN_PATH
+
+INSTALLER=$SRC_DIR/installer/*
+cp -r $INSTALLER $OFX_PLUGIN_PATH
+
+# When creating your own conda package, a common issue you may run into with
+# your package is that it will be unable to find libraries when you go to run the application.
+# Likely, that's caused by the Deadline Cloud service-managed fleet instances
+# not having the libraries installed. To fix this, you will need to install them
+# in this script, like this.
+mkdir -p $SRC_DIR/download
+cd $SRC_DIR/download
+dnf download --resolve -y libXft 
+
+for rpm_file in $(realpath $SRC_DIR/download/*.rpm); do
+    rpm2cpio "$rpm_file" | cpio -idm
+done
+
+# On Linux, OFX files are distributed as dynamic shared objects. 
+# Here we're adding $ORIGIN to the RPATH so that the OFX files can find
+# libraries in the same directory as itself.
+for FILE in $(find "$PREFIX/OFX/" -iname "*.ofx"); do 
+    patchelf --set-rpath '$ORIGIN' "$FILE"
+done
+
+# Copy .so's to all Denoise bundles
+for so_file in $(find . -iname "*.so.*"); do
+    patchelf --set-rpath '$ORIGIN' "$so_file"
+    for bundle in $(find $OFX_PLUGIN_PATH -iname "*.ofx.bundle"); do
+        # Learn more about the structure of OpenFX Plugins by
+        # going to the OpenFX Plugin packaging reference.
+        # https://openfx.readthedocs.io/en/main/Reference/ofxPackaging.html 
+        cp -P $so_file $bundle/Contents/Linux-x86-64/
+    done
+done
+
+# Script to set environment variables during activation
+mkdir -p "$PREFIX/etc/conda/activate.d"
+cat <<EOF > "$PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.sh"
+export OFX_PLUGIN_PATH="\$CONDA_PREFIX/OFX/Plugins/"
+EOF
+
+
+mkdir -p "$PREFIX/etc/conda/deactivate.d"
+cat <<EOF > "$PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.sh"
+unset OFX_PLUGIN_PATH
+EOF

--- a/conda_recipes/nuke-denoise/recipe/recipe.yaml
+++ b/conda_recipes/nuke-denoise/recipe/recipe.yaml
@@ -1,0 +1,29 @@
+package:  
+  name: nuke-denoise
+  version: 3.6.9
+
+source:
+  url: file://archive_files/DENoise.tar.gz
+  sha256: ecbe1b40a19bf6f9ec05aca3d09428386292c57d4cd968b8f1ac767778642ebc
+  target_directory: installer
+
+build:
+  number: 0
+  prefix_detection:
+    ignore_binary_files: True
+  # The binary is built to be relocatable, so can ignore the warnings about DSOs.
+  dynamic_linking:
+    binary_relocation: False
+    missing_dso_allowlist:
+    - "*"
+
+requirements:
+  build:
+    - patchelf
+  run:
+    - nuke
+
+about:
+  homepage: https://revisionfx.com/products/denoise/nuke/
+  license: LicenseRef-REVisionFXEULA
+  summary: DE:Noise handles spurious frame-to-frame defects ranging from fine digital/electronic noise to blotchy spots like dirt on film.


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

No samples for Nuke or Nuke plugins.

### What was the solution? (How)

I've added a sample for Nuke and a sample for a Nuke plugin.

### What is the impact of this change?

More samples will help people create their own recipes/packages.

### How was this change tested?

I deployed a conda build farm as described in the instructions. I built both packages into my custom conda channel. I made a scene locally using a video and a De:Noise node. To make sure that the De:Noise node was working, I changed some settings on it (an obvious tell was changing the preprocessing contrast up super high and then not restoring it in the post process settings). Rendered the scene in my farm and verified in the logs that the Worker was pulling from my custom channel.  

### Was this change documented?

READMEs are included with both recipes.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*