### PR TITLE
fix(vred): expose HIDDEN parameters to GUI and remove unused parameters

### DIFF
--- a/job_bundles/vred_render/template.yaml
+++ b/job_bundles/vred_render/template.yaml
@@ -248,7 +248,7 @@ parameterDefinitions:
   - name: IncludeAlphaChannel
     type: STRING
     userInterface:
-      control: HIDDEN
+      control: DROPDOWN_LIST
       label: Include Alpha Channel
       groupLabel: Render Options
     default: 'false'
@@ -291,7 +291,7 @@ parameterDefinitions:
   - name: OverrideRenderPass
     type: STRING
     userInterface:
-      control: HIDDEN
+      control: DROPDOWN_LIST
       label: Override Render Pass
       groupLabel: Render Options
     default: 'false'
@@ -304,7 +304,7 @@ parameterDefinitions:
   - name: PremultiplyAlpha
     type: STRING
     userInterface:
-      control: HIDDEN
+      control: DROPDOWN_LIST
       label: Premultiply Alpha
       groupLabel: Render Options
     default: 'false'
@@ -315,7 +315,7 @@ parameterDefinitions:
   - name: TonemapHDR
     type: STRING
     userInterface:
-      control: HIDDEN
+      control: DROPDOWN_LIST
       label: Tone map HDR
       groupLabel: Render Options
     default: 'false'
@@ -326,7 +326,7 @@ parameterDefinitions:
   - name: JobType
     type: STRING
     userInterface:
-      control: HIDDEN
+      control: DROPDOWN_LIST
       label: Job Type
       groupLabel: Render Options
     default: 'Render'
@@ -337,7 +337,7 @@ parameterDefinitions:
   - name: SequenceName
     type: STRING
     userInterface:
-      control: HIDDEN
+      control: LINE_EDIT
       label: Sequence Name
       groupLabel: Render Options
     default: ""
@@ -358,48 +358,6 @@ parameterDefinitions:
     description: >
       A list of conda packages to install. If a queue accepts this parameter, then it will create a conda virtual
       environment.
-  - name: submitter_name
-    type: STRING
-    userInterface:
-      control: HIDDEN
-    default: 'VRED'
-    description: >
-      The type of submitter that is used to submit the render job.
-  - name: name
-    type: STRING
-    userInterface:
-      control: HIDDEN
-    default: ''
-    description: >
-      The name of the render job.
-  - name: description
-    type: STRING
-    userInterface:
-      control: HIDDEN
-    default: ''
-    description: >
-      The description of the render job.
-  - name: input_filenames
-    type: STRING
-    userInterface:
-      control: HIDDEN
-    default: ''
-    description: >
-      Input filenames.
-  - name: input_directories
-    type: STRING
-    userInterface:
-      control: HIDDEN
-    default: ''
-    description: >
-      Input directories.
-  - name: output_directories
-    type: STRING
-    userInterface:
-      control: HIDDEN
-    default: ''
-    description: >
-      Output directories.
 
 steps:
   - name: VRED Render

--- a/job_bundles/vred_render/template_tiling.yaml
+++ b/job_bundles/vred_render/template_tiling.yaml
@@ -248,7 +248,7 @@ parameterDefinitions:
   - name: IncludeAlphaChannel
     type: STRING
     userInterface:
-      control: HIDDEN
+      control: DROPDOWN_LIST
       label: Include Alpha Channel
       groupLabel: Render Options
     default: 'false'
@@ -291,7 +291,7 @@ parameterDefinitions:
   - name: OverrideRenderPass
     type: STRING
     userInterface:
-      control: HIDDEN
+      control: DROPDOWN_LIST
       label: Override Render Pass
       groupLabel: Render Options
     default: 'false'
@@ -304,7 +304,7 @@ parameterDefinitions:
   - name: PremultiplyAlpha
     type: STRING
     userInterface:
-      control: HIDDEN
+      control: DROPDOWN_LIST
       label: Premultiply Alpha
       groupLabel: Render Options
     default: 'false'
@@ -315,7 +315,7 @@ parameterDefinitions:
   - name: TonemapHDR
     type: STRING
     userInterface:
-      control: HIDDEN
+      control: DROPDOWN_LIST
       label: Tone map HDR
       groupLabel: Render Options
     default: 'false'
@@ -326,7 +326,7 @@ parameterDefinitions:
   - name: JobType
     type: STRING
     userInterface:
-      control: HIDDEN
+      control: DROPDOWN_LIST
       label: Job Type
       groupLabel: Render Options
     default: 'Render'
@@ -337,7 +337,7 @@ parameterDefinitions:
   - name: SequenceName
     type: STRING
     userInterface:
-      control: HIDDEN
+      control: LINE_EDIT
       label: Sequence Name
       groupLabel: Render Options
     default: ""
@@ -358,48 +358,6 @@ parameterDefinitions:
     description: >
       A list of conda packages to install. If a queue accepts this parameter, then it will create a conda virtual
       environment.
-  - name: submitter_name
-    type: STRING
-    userInterface:
-      control: HIDDEN
-    default: 'VRED'
-    description: >
-      The type of submitter that is used to submit the render job.
-  - name: name
-    type: STRING
-    userInterface:
-      control: HIDDEN
-    default: ''
-    description: >
-      The name of the render job.
-  - name: description
-    type: STRING
-    userInterface:
-      control: HIDDEN
-    default: ''
-    description: >
-      The description of the render job.
-  - name: input_filenames
-    type: STRING
-    userInterface:
-      control: HIDDEN
-    default: ''
-    description: >
-      Input filenames.
-  - name: input_directories
-    type: STRING
-    userInterface:
-      control: HIDDEN
-    default: ''
-    description: >
-      Input directories.
-  - name: output_directories
-    type: STRING
-    userInterface:
-      control: HIDDEN
-    default: ''
-    description: >
-      Output directories.
 
 steps:
   - name: VRED Render


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The VRED sample job bundle could not be submitted using `deadline bundle gui-submit` due to a validation error:
```
Job bundle validation failed: Hidden parameters "SequenceName", "name", "description", "input_filenames", "input_directories", "output_directories" are missing values. Hidden parameters must have either a default value in the template or a value in parameter_values.yaml.
```
This issue arose after enhanced validation for `HIDDEN` parameters (https://github.com/aws-deadline/deadline-cloud/pull/843/) was released with [deadline-cloud 0.53.1](https://github.com/aws-deadline/deadline-cloud/blob/mainline/CHANGELOG.md). The validation now requires that all `HIDDEN` parameters must have non-empty string default values, but several parameters in the VRED template had empty string defaults.

### What was the solution? (How)
1. **Exposed previously hidden parameters to the GUI:**
   - Rendering options: `IncludeAlphaChannel`, `OverrideRenderPass`, `PremultiplyAlpha`, `TonemapHDR`)
   - Job type selection: `JobType` and `SequenceName`

2. **Removed unused metadata parameters:**
   - Deleted `submitter_name`, `name`, `description`, `input_filenames`, `input_directories`, `output_directories`
   - These parameters were not actually used by the job template logic and served no functional purpose

3. **Kept HIDDEN parameters:**
  - `JobScriptDir` and `CondaPackages` remain hidden as these parameters already had non-empty default values, so they did not cause validation errors

### What is the impact of this change?
Users can now submit a VRED job using this sample template via the GUI submitter (`deadline bundle gui-submit`) without hitting the validation error.

### How was this change tested?
- Verified that `deadline bundle gui-submit vred_render/` opens the GUI without validation errors
- Tested that all exposed parameters appear correctly in the submission GUI
- The job rendering was successful.

### Was this change documented?
No.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*