### PR TITLE
feat: add Houdini HtoA recipe

### DIFF
--- a/conda_recipes/houdini-htoa/README.md
+++ b/conda_recipes/houdini-htoa/README.md
@@ -1,0 +1,105 @@
+# Houdini Arnold (HtoA) Conda Recipe for AWS Deadline Cloud
+
+## Overview
+
+This directory contains the conda/rattler build recipe for Autodesk Arnold for Houdini (HtoA) 6.4.4.1 repackaged for Deadline Cloud managed fleets. The package installs the Houdini plugin, command‑line Arnold tools, and the Houdini package metadata required for Houdini 20.0 environments.
+
+## Package Information
+
+- **Application**: HtoA 6.4.4.1 (build rd99f711) for Houdini 20.0.896
+- **Supported Platforms**: linux-64
+- **Source**: Autodesk Arnold download portal (self-extracting `.run` installer)
+- **License**: LicenseRef-AutodeskEULA
+- **Build Tool**: rattler-build (invoked by `submit-package-job`)
+
+## Prerequisites
+
+Before building this package ensure:
+
+1. **Deadline Cloud Infrastructure**
+   - A farm with a queue dedicated to package building (e.g. `replai-studio-package-building-queue`).
+   - Linux workers with connectivity to the target S3 Conda channel.
+2. **Deadline Cloud CLI** installed on the workstation submitting the job.
+3. **Autodesk Account** with access to download the Houdini Arnold installer.
+4. **Source archive** downloaded (see below).
+
+## Archive File Instructions
+
+1. Download `htoa-6.4.4.1_rd99f711_houdini-20.0.896_gcc11.2_linux.run` from the Autodesk Arnold website.
+2. Place the installer in `conda_recipes/archive_files/` (relative to the repository root).
+3. Optionally verify the SHA256 hash: `ea9e5fcc41fb79b30731efd1e26b77040778a8b57c6e2d13c22598187173e33f`.
+
+The build script automatically makes the installer executable, extracts it with Qt Installer Framework flags, and copies the payload into `$PREFIX/opt/htoa`.
+
+## Building the Package
+
+From the `conda_recipes` directory:
+
+```bash
+# Submit using the default queue and channel
+./submit-package-job houdini-htoa
+
+# Submit to a specific queue
+./submit-package-job houdini-htoa -q "replai-studio-package-building-queue"
+
+# Use an alternate S3 channel prefix (bucket derived from the queue defaults)
+./submit-package-job houdini-htoa --s3-channel MyCustomChannel
+```
+
+By default the job uses the S3 channel `s3://<queue-attachments-bucket>/Conda/Default`. Ensure the queue role has `s3:PutObject`, `s3:GetObject`, and `s3:ListBucket` permissions for the chosen bucket/prefix so the `rattler-index` step can upload the package metadata.
+
+### Manual Local Builds (Optional)
+
+If you want to test locally, you can run `rattler-build` (requires the installer to be present):
+
+```bash
+rattler-build build \
+  --recipe-dir recipe/ \
+  --target-platform linux-64
+```
+
+## What the Recipe Installs
+
+- `opt/htoa/` – Arnold plugin files and binaries extracted from the installer.
+- Symlinks in `$PREFIX/bin` for Arnold utilities (`kick`, `maketx`, `noice`, `oslc`, `oslinfo`).
+- `opt/houdini/packages/htoa.json` – Houdini package definition pointing to the plugin location.
+- Conda activation scripts that export `HTOA`, `ARNOLD_LOCATION`, `HOUDINI_DSO_ERROR`, attempt to detect the Houdini version, and prepend Arnold’s Python modules.
+
+## Using the Package in Deadline Cloud
+
+After the package is uploaded to the S3 Conda channel and the channel is reindexed:
+
+1. Add `htoa=0.1.*` to the Houdini job’s conda environment specification.
+2. Ensure the Deadline Cloud queue used for Houdini jobs has read access to the channel.
+3. When the job spins up, Houdini’s package loading system will read `opt/houdini/packages/htoa.json` and load the Arnold plugin automatically.
+
+## Troubleshooting
+
+- **Package build fails due to missing installer**: confirm the `.run` file exists under `conda_recipes/archive_files/` and matches the expected filename.
+- **S3 upload AccessDenied**: update the queue role IAM policy to allow write and list access to the channel bucket/prefix.
+- **Houdini cannot find HtoA at runtime**: verify the package version constraint (`houdini >=20.0,<21`) matches your Houdini package and that the conda environment sets `HOUDINI_PATH`/`PYTHONPATH` as expected.
+
+## Recipe Structure
+
+```
+houdini-htoa/
+├── README.md                  # This file
+├── deadline-cloud.yaml        # Deadline Cloud submission metadata
+└── recipe/
+    ├── recipe.yaml            # rattler-build recipe definition
+    └── build.sh               # Linux build script
+```
+
+## Updating the Recipe
+
+1. Replace version identifiers in `recipe/recipe.yaml` and `deadline-cloud.yaml` for new HtoA/Houdini releases.
+2. Update SHA256 hashes and expected installer filename.
+3. Adjust build logic in `build.sh` if the installer layout changes.
+4. Rebuild via `submit-package-job` and verify that the new package uploads and indexes successfully.
+
+## Resources
+
+- Autodesk Arnold: https://www.arnoldrenderer.com/
+- Houdini Packages Documentation: https://www.sidefx.com/docs/houdini/ref/plugins.html
+- AWS Deadline Cloud Developer Guide: https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/
+- Rattler Build Documentation: https://prefix-dev.github.io/rattler-build/

--- a/conda_recipes/houdini-htoa/deadline-cloud.yaml
+++ b/conda_recipes/houdini-htoa/deadline-cloud.yaml
@@ -1,0 +1,10 @@
+condaPlatforms:
+  - platform: linux-64
+    defaultSubmit: true
+    sourceArchiveFilename: htoa-6.4.4.1_rd99f711_houdini-20.0.896_gcc11.2_linux.run
+    sourceDownloadInstructions: 'Download the HtoA installer from https://www.arnoldrenderer.com/download/'
+    buildTool: rattler-build
+jobParameters:
+  # conda-forge is used to get patchelf
+  - name: CondaChannels
+    value: conda-forge

--- a/conda_recipes/houdini-htoa/recipe/build.sh
+++ b/conda_recipes/houdini-htoa/recipe/build.sh
@@ -85,43 +85,14 @@ for so_file in $(find "$HTOA_ROOT" -name "*.so" -o -name "*.so.*"); do
     fi
 done
 
-# Create Houdini package file for HtoA plugin
-# This tells Houdini where to find the Arnold plugin
-# https://www.sidefx.com/docs/houdini/ref/plugins.html
+# Install the Houdini package definition bundled with HtoA.
+# The upstream file points to _TARGET_DIR_; substitute the conda prefix path.
 mkdir -p "$PREFIX/opt/houdini/packages"
-cat <<'EOF' > "$PREFIX/opt/houdini/packages/htoa.json"
-{
-    "env": [
-        {
-            "HTOA": "$HTOA_ROOT"
-        },
-        {
-            "ARNOLD_LOCATION": "$HTOA_ROOT"
-        },
-        {
-            "PATH": {
-                "value": "$HTOA_ROOT/bin",
-                "method": "prepend"
-            }
-        },
-        {
-            "HOUDINI_PATH": {
-                "value": "$HTOA_ROOT:&",
-                "method": "prepend"
-            }
-        },
-        {
-            "PYTHONPATH": {
-                "value": "$HTOA_ROOT/python",
-                "method": "prepend"
-            }
-        }
-    ]
-}
-EOF
-
-# Replace $HTOA_ROOT with actual path in the JSON file
-sed -i "s|\$HTOA_ROOT|$HTOA_ROOT|g" "$PREFIX/opt/houdini/packages/htoa.json"
+if [ -f "$HTOA_ROOT/htoa.json" ]; then
+    sed "s|_TARGET_DIR_|$HTOA_ROOT|g" "$HTOA_ROOT/htoa.json" > "$PREFIX/opt/houdini/packages/htoa.json"
+else
+    echo "WARNING: $HTOA_ROOT/htoa.json not found; Houdini may not discover the plugin" >&2
+fi
 
 # Script to set environment variables during conda activation
 mkdir -p "$PREFIX/etc/conda/activate.d"
@@ -129,6 +100,9 @@ cat <<EOF > "$PREFIX/etc/conda/activate.d/houdini-htoa-$PKG_VERSION-vars.sh"
 export HTOA="$HTOA_ROOT"
 export ARNOLD_LOCATION="$HTOA_ROOT"
 export HOUDINI_DSO_ERROR=2
+
+# Ensure Arnold shared libraries are discoverable at runtime
+export LD_LIBRARY_PATH="$HTOA_ROOT/lib:\${LD_LIBRARY_PATH:-}"
 
 # Add Arnold's Python module path
 if [ -d "$HTOA_ROOT/python" ]; then
@@ -151,6 +125,9 @@ cat <<EOF > "$PREFIX/etc/conda/deactivate.d/houdini-htoa-$PKG_VERSION-vars.sh"
 unset HTOA
 unset ARNOLD_LOCATION
 unset HOUDINI_DSO_ERROR
+if [ -n "\${LD_LIBRARY_PATH:-}" ]; then
+    export LD_LIBRARY_PATH=\$(echo "\$LD_LIBRARY_PATH" | sed "s|$HTOA_ROOT/lib:||g")
+fi
 unset HOUDINI_VERSION
 
 # Remove Arnold Python path from PYTHONPATH

--- a/conda_recipes/houdini-htoa/recipe/build.sh
+++ b/conda_recipes/houdini-htoa/recipe/build.sh
@@ -1,0 +1,160 @@
+#!/bin/sh
+set -xeuo pipefail
+
+# Version info
+HTOA_PACKAGING_VERSION="$PKG_VERSION"
+UPSTREAM_VERSION="$HTOA_PACKAGING_VERSION"
+BUILD_ID="rd99f711"
+HOUDINI_VERSION="20.0.896"
+
+INSTALLER_DIR="$SRC_DIR/installer"
+EXPECTED_INSTALLER="htoa-${UPSTREAM_VERSION}_${BUILD_ID}_houdini-${HOUDINI_VERSION}_gcc11.2_linux.run"
+INSTALLER="$INSTALLER_DIR/$EXPECTED_INSTALLER"
+HTOA_UNPACK_DIR="$INSTALLER_DIR/htoa_installer_artifacts"
+
+if [ ! -f "$INSTALLER" ]; then
+    echo "Expected installer $EXPECTED_INSTALLER not found in $INSTALLER_DIR" >&2
+    echo "Discovering available installers..." >&2
+    FOUND_INSTALLER=$(find "$INSTALLER_DIR" -maxdepth 1 -type f -name "htoa-*_houdini-${HOUDINI_VERSION}_gcc11.2_linux.run" | sort | head -n 1 || true)
+    if [ -z "${FOUND_INSTALLER:-}" ]; then
+        echo "ERROR: No HtoA installer archives were found in $INSTALLER_DIR" >&2
+        ls -l "$INSTALLER_DIR" || true
+        exit 1
+    fi
+    INSTALLER="$FOUND_INSTALLER"
+    INSTALLER_BASENAME=$(basename "$INSTALLER")
+    UPSTREAM_VERSION=$(printf "%s" "$INSTALLER_BASENAME" | sed -E 's/^htoa-([0-9.]+)_.*/\1/')
+    echo "Using installer $INSTALLER_BASENAME (upstream version $UPSTREAM_VERSION)"
+fi
+HTOA_ROOT="$PREFIX/opt/htoa"
+
+# Extract the self-extracting installer using makeself flags
+# Following the same pattern as maya-redshift
+echo "Extracting HtoA installer..."
+mkdir -p "$HTOA_UNPACK_DIR"
+
+# Make installer executable
+chmod u+x "$INSTALLER"
+
+# Set environment for Qt Installer Framework
+# The installer needs Qt libraries and plugins
+export LD_LIBRARY_PATH="$BUILD_PREFIX/lib:${LD_LIBRARY_PATH:-}"
+export QT_QPA_PLUGIN_PATH="$BUILD_PREFIX/plugins"
+
+# Extract using Qt Installer Framework flags
+echo "Extracting installer contents using --extract-to (silent, license accepted)..."
+if "$INSTALLER" --accept-license --silent --extract-to "$HTOA_UNPACK_DIR"; then
+    echo "Successfully extracted installer contents"
+    ls -lh "$HTOA_UNPACK_DIR"
+else
+    echo "ERROR: Extraction failed"
+    exit 1
+fi
+
+# The extracted contents should include the HtoA files
+# Inspect the unpacked directory to see the structure
+echo "Contents of unpacked directory:"
+ls -la "$HTOA_UNPACK_DIR"
+
+# Install HtoA to the prefix
+mkdir -p "$HTOA_ROOT"
+
+# Copy HtoA files to the installation directory
+# Adjust the source path based on actual extracted structure
+if [ -d "$HTOA_UNPACK_DIR/htoa" ]; then
+    cp -r "$HTOA_UNPACK_DIR/htoa"/* "$HTOA_ROOT/"
+elif [ -d "$HTOA_UNPACK_DIR" ]; then
+    # If files are directly in the unpack dir
+    cp -r "$HTOA_UNPACK_DIR"/* "$HTOA_ROOT/"
+fi
+
+# Create symlinks for Arnold command-line tools
+mkdir -p "$PREFIX/bin"
+for BINARY in kick maketx noice oslc oslinfo; do
+    if [ -f "$HTOA_ROOT/bin/$BINARY" ]; then
+        chmod u+x "$HTOA_ROOT/bin/$BINARY"
+        ln -r -s "$HTOA_ROOT/bin/$BINARY" "$PREFIX/bin/$BINARY"
+    fi
+done
+
+# Add rpath to shared libraries to find Houdini's libraries
+# This ensures the plugin can find Houdini's DSOs at runtime
+for so_file in $(find "$HTOA_ROOT" -name "*.so" -o -name "*.so.*"); do
+    if [ -f "$so_file" ]; then
+        patchelf --add-rpath '$ORIGIN:$ORIGIN/../lib:$ORIGIN/../../houdini/dsolib' "$so_file" || true
+    fi
+done
+
+# Create Houdini package file for HtoA plugin
+# This tells Houdini where to find the Arnold plugin
+# https://www.sidefx.com/docs/houdini/ref/plugins.html
+mkdir -p "$PREFIX/opt/houdini/packages"
+cat <<'EOF' > "$PREFIX/opt/houdini/packages/htoa.json"
+{
+    "env": [
+        {
+            "HTOA": "$HTOA_ROOT"
+        },
+        {
+            "ARNOLD_LOCATION": "$HTOA_ROOT"
+        },
+        {
+            "PATH": {
+                "value": "$HTOA_ROOT/bin",
+                "method": "prepend"
+            }
+        },
+        {
+            "HOUDINI_PATH": {
+                "value": "$HTOA_ROOT:&",
+                "method": "prepend"
+            }
+        },
+        {
+            "PYTHONPATH": {
+                "value": "$HTOA_ROOT/python",
+                "method": "prepend"
+            }
+        }
+    ]
+}
+EOF
+
+# Replace $HTOA_ROOT with actual path in the JSON file
+sed -i "s|\$HTOA_ROOT|$HTOA_ROOT|g" "$PREFIX/opt/houdini/packages/htoa.json"
+
+# Script to set environment variables during conda activation
+mkdir -p "$PREFIX/etc/conda/activate.d"
+cat <<EOF > "$PREFIX/etc/conda/activate.d/houdini-htoa-$PKG_VERSION-vars.sh"
+export HTOA="$HTOA_ROOT"
+export ARNOLD_LOCATION="$HTOA_ROOT"
+export HOUDINI_DSO_ERROR=2
+
+# Add Arnold's Python module path
+if [ -d "$HTOA_ROOT/python" ]; then
+    export PYTHONPATH="$HTOA_ROOT/python:\${PYTHONPATH:-}"
+fi
+
+# Version detection similar to Redshift pattern
+HOU_VERSION_OUTPUT=\$(houdini --version 2>/dev/null)
+if [ \$? -eq 0 ] && [[ "\$HOU_VERSION_OUTPUT" =~ Houdini\ (FX|Core)?\ ?([0-9]+\.[0-9]+\.[0-9]+) ]]; then
+  HOU_VERSION="\${BASH_REMATCH[2]}"
+  export HOUDINI_VERSION="\$HOU_VERSION"
+  echo "Detected Houdini version: \$HOU_VERSION"
+else
+  echo "Warning: Could not determine Houdini version"
+fi
+EOF
+
+mkdir -p "$PREFIX/etc/conda/deactivate.d"
+cat <<EOF > "$PREFIX/etc/conda/deactivate.d/houdini-htoa-$PKG_VERSION-vars.sh"
+unset HTOA
+unset ARNOLD_LOCATION
+unset HOUDINI_DSO_ERROR
+unset HOUDINI_VERSION
+
+# Remove Arnold Python path from PYTHONPATH
+if [ -n "\${PYTHONPATH:-}" ]; then
+    export PYTHONPATH=\$(echo "\$PYTHONPATH" | sed "s|$HTOA_ROOT/python:||g")
+fi
+EOF

--- a/conda_recipes/houdini-htoa/recipe/recipe.yaml
+++ b/conda_recipes/houdini-htoa/recipe/recipe.yaml
@@ -1,0 +1,55 @@
+# Recipe in rattler-build format.
+# See https://prefix-dev.github.io/rattler-build/latest/
+
+context:
+  packaging_version: "0.1.0"
+  htoa_version: "6.4.4.1"
+  build_id: "rd99f711"
+  houdini_version: "20.0.896"
+
+package:
+  name: htoa
+  version: ${{ packaging_version }}
+
+source:
+  - if: linux
+    then:
+      url: file://archive_files/htoa-${{ htoa_version }}_${{ build_id }}_houdini-${{ houdini_version }}_gcc11.2_linux.run
+      sha256: ea9e5fcc41fb79b30731efd1e26b77040778a8b57c6e2d13c22598187173e33f
+      target_directory: installer
+
+build:
+  number: 0
+  string: htoa${{ htoa_version | replace(".", "_") }}
+  # These build options for repackaging an application
+  # https://prefix-dev.github.io/rattler-build/latest/build_options/#prefix-detection-replacement-options
+  prefix_detection:
+    ignore_binary_files: True
+  # https://prefix-dev.github.io/rattler-build/latest/build_options/#dynamic-linking-configuration
+  dynamic_linking:
+    binary_relocation: false
+    missing_dso_allowlist:
+      - "**"
+
+requirements:
+  build:
+    - patchelf
+    - xorg-libxcb
+    - xorg-libx11
+    - xcb-util  # Provides libxcb-util.so.1
+    - xcb-util-wm  # Provides libxcb-icccm.so.4
+    - xcb-util-image  # Provides libxcb-image.so.0
+    - xcb-util-keysyms  # Provides libxcb-keysyms.so.1
+    - xcb-util-renderutil  # Provides libxcb-render-util.so.0
+    - libxkbcommon  # Provides libxkbcommon-x11.so.0
+    - fontconfig  # Provides libfontconfig.so.1
+    - wayland  # Provides libwayland-cursor.so.0
+    - harfbuzz  # Provides libharfbuzz.so.0
+    - qt-main  # Provides Qt platform plugins including offscreen
+  run_constraints:
+    - houdini >=20.0, <21
+
+about:
+  homepage: https://www.arnoldrenderer.com
+  license: LicenseRef-AutodeskEULA
+  summary: Houdini Arnold (HtoA) plugin repackaged for Houdini 20.0 (upstream 6.4.4.1)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Deadline Cloud Houdini jobs could not install `htoa=0.1.*` because the repository lacked a Houdini Arnold (HtoA) conda recipe and build assets.

### What was the solution? (How)
Added the complete [conda_recipes/houdini-htoa/](cci:7://file:///c:/Users/github.com.replai/deadline-cloud-samples/conda_recipes/houdini-htoa:0:0-0:0) folder, including rattler-build recipe files, build script, Deadline submission metadata, and a README that documents prerequisites, build steps, and usage.

### What is the impact of this change?
Enables packaging and publishing the HtoA plugin through Deadline Cloud so Houdini jobs can resolve the dependency without manual intervention.

### How was this change tested?
Built the package via `submit-package-job houdini-htoa` and confirmed the Deadline Cloud run succeeded, producing and uploading the `.conda` artifact.

### Was this change documented?
Yes—documentation is included in [conda_recipes/houdini-htoa/README.md](cci:7://file:///c:/Users/github.com.replai/deadline-cloud-samples/conda_recipes/houdini-htoa/README.md:0:0-0:0).

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*