### PR TITLE
feat: add Houdini 21.0 Conda package sample recipe

### DIFF
--- a/conda_recipes/houdini-21.0/README.md
+++ b/conda_recipes/houdini-21.0/README.md
@@ -1,0 +1,166 @@
+# Houdini 21.0 Conda Recipe for AWS Deadline Cloud
+
+## Overview
+
+This directory contains a conda build recipe for Houdini 21.0.440, specifically configured for use with AWS Deadline Cloud. This package enables you to run Houdini rendering and processing jobs on Deadline Cloud service-managed fleets.
+
+## Package Information
+
+- **Application**: Houdini 21.0.440
+- **Supported Platforms**: linux-64
+- **Source**: SideFX Houdini downloads page
+- **License**: SideFXEULA
+- **Build Tool**: rattler-build
+
+## Prerequisites
+
+Before building this package, ensure you have:
+
+1. **AWS Deadline Cloud infrastructure** set up with:
+   - A farm configured for package building. See https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/cloudformation/farm_templates/starter_farm for instructions to create a Farm.
+   - A queue named "Package Build Queue". See https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/configure-jobs-s3-channel.html for instructions on creating a package building queue. 
+   - Linux-64 fleet for building linux packages
+
+2. **Deadline Cloud CLI** installed on your workstation
+
+3. **SideFX account** for downloading Houdini installer
+
+4. **Source archive** (see [Archive File Instructions](#archive-file-instructions) below)
+
+## Archive File Instructions
+
+### Linux
+
+#### Download from SideFX
+1. Download the `houdini-21.0.440-linux_x86_64_gcc11.2.tar.gz` from SideFX Houdini's downloads page
+2. Verify the SHA256 hash matches: `a87451f9146d52051a9ba142d535936638351526a48cba0c6156a221f3be58e6`
+3. Clone this repository locally.
+4. Place the downloaded file in the `conda_recipes/archive_files` directory 
+ 
+
+## Plugin Integration
+
+### Plugins
+
+Houdini supports plugins through the use of package files. A package is a json file that tells Houdini where to find plugins. 
+[Houdini Plugin Reference](https://www.sidefx.com/docs/houdini/ref/plugins.html).
+
+Create your package files in `$PREFIX/opt/houdini/packages` and point them to the location of your plugins. See our Redshift for
+Houdini recipe as [an example](conda_recipes/houdini-redshift-2025).
+
+### Plugin Installation Paths
+
+The conda recipe configures the following environment variables and paths for plugin discovery:
+
+```bash
+# Environment variables set by this package
+export HOUDINI_LOCATION=$PREFIX/opt/houdini
+
+# Plugin search paths (in order of precedence)
+$PREFIX/opt/houdini/packages
+```
+
+### Creating Plugin Packages
+
+1. **Plugin Package Structure**
+   ```
+   my-houdini-plugin/
+   ├── recipe/
+   │   ├── recipe.yaml
+   │   ├── build.sh
+   │   └── bld.bat
+   ├── deadline-cloud.yaml
+   └── README.md
+   ```
+
+2. **Plugin Installation Script Example**
+
+   NOTE: Your plugin files can be anywhere as long as your package file points to their directory.
+
+   ```bash
+   # In build.sh
+   mkdir -p $PREFIX/opt/houdini/packages
+   cp my-plugin.json $PREFIX/opt/houdini/packages/
+   cp -r plugin-files/ $PREFIX/opt/houdini/plugin/
+   ```
+
+3. **Plugin Dependencies**
+   - Add this Houdini package as a dependency in your plugin's `recipe.yaml`
+   - Specify version constraints: `houdini >=21.0,<21.5`
+
+## Application-Specific Requirements
+
+### Licensing
+
+See the [AWS Deadline Cloud licensing documentation](https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/license.html) for detailed guidance on license configuration. Houdini requires proper licensing configuration for rendering operations.
+
+### System Requirements
+
+- Linux x86_64 with GCC 11.2 compatibility
+- Sufficient memory for scene processing
+- Optional: GPU acceleration may be needed for certain workloads
+
+## Adapting to Other Versions
+
+### Version Update Checklist
+
+To adapt this recipe for Houdini 20.5, 20.0 or 19.5:
+
+1. **Update Version Information**
+   ```yaml
+   # In recipe/recipe.yaml
+   context:
+     version: "20.0.xxx"  # or desired version
+   
+   # In deadline-cloud.yaml
+   sourceArchiveFilename: houdini-[version]-linux_x86_64_gcc11.2.tar.gz
+   ```
+
+2. **Update Source Archives**
+   - Download new version archives from SideFX
+   - Update SHA256 hashes in `recipe.yaml`
+   - Update source filename in `deadline-cloud.yaml`
+
+3. **Check Dependencies**
+   - Review and update dependency versions
+   - Update minimum system requirements
+
+4. **Update Build Scripts**
+   - Check for changes in installation directory structure
+   - Update file copy operations in build scripts
+   - Verify environment variable paths
+
+5. **Test Plugin Compatibility**
+   - Verify plugin paths haven't changed
+   - Test with existing plugin packages like Redshift
+   - Update plugin integration documentation
+
+
+### Common Version Migration Issues
+
+- **Path Changes**: Installation directories may change between versions
+- **Dependency Updates**: New versions may require different dependencies
+- **Plugin API Changes**: Plugin interfaces may be incompatible between major versions
+- **License Changes**: Licensing requirements may change
+
+## Recipe Structure
+
+```
+houdini-21.0/
+├── README.md                    # This file
+├── deadline-cloud.yaml          # Deadline Cloud configuration
+└── recipe/
+    ├── recipe.yaml             # Rattler-build recipe
+    └── build.sh                # Linux build script
+```
+
+## Resources
+
+- **Houdini Documentation**: https://www.sidefx.com/docs/houdini/
+- **AWS Deadline Cloud Developer Guide**: https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/
+- **Rattler Build Documentation**: https://prefix-dev.github.io/rattler-build/
+- **Plugin Development**: https://www.sidefx.com/docs/houdini/ref/plugins.html
+
+---
+
+**Note**: This recipe is specifically configured for Houdini 21.0.440 on Linux x86_64 platforms.

--- a/conda_recipes/houdini-21.0/deadline-cloud.yaml
+++ b/conda_recipes/houdini-21.0/deadline-cloud.yaml
@@ -1,0 +1,10 @@
+condaPlatforms:
+  - platform: linux-64
+    defaultSubmit: true
+    sourceArchiveFilename: houdini-21.0.440-linux_x86_64_gcc11.2.tar.gz
+    sourceDownloadInstructions: Download the installer archive from SideFX Houdini's downloads page.
+    buildTool: rattler-build
+jobParameters:
+  # conda-forge is used to get patchelf
+  - name: CondaChannels
+    value: conda-forge

--- a/conda_recipes/houdini-21.0/recipe/build.sh
+++ b/conda_recipes/houdini-21.0/recipe/build.sh
@@ -1,0 +1,81 @@
+#!/bin/sh
+set -xeuo pipefail
+
+mkdir -p $PREFIX/opt
+cd $PREFIX/opt
+
+
+# The Houdini installer expects `bc` to run, but does not fail when
+# it is missing. Ensure that it is installed before running the installer
+bc --help
+
+# Install Houdini
+INSTALLER=$SRC_DIR/installer/houdini.install
+# date of the EULA agreement, not the current date
+EULAdate=2021-10-13
+$INSTALLER \
+    --auto-install \
+    --accept-EULA $EULAdate \
+    --no-install-engine-maya \
+    --no-install-engine-unity \
+    --no-install-menus \
+    --no-install-bin-symlink \
+    --no-install-hfs-symlink \
+    --no-install-license \
+    --no-install-hqueue-server \
+    --no-root-check \
+    --make-dir $PREFIX/opt/houdini
+
+HOUDINI_DIR=$PREFIX/opt/houdini
+
+# Remove the documentation, it's not needed on the farm
+rm -r $HOUDINI_DIR/houdini/help
+# Remove the toolkit samples, they're not needed on the farm
+rm -r $HOUDINI_DIR/toolkit/samples
+
+# Create symlinks
+mkdir -p $PREFIX/bin
+for BINARY in houdini houdini-bin houdinicore houdinifx \
+    hscript husk hython hbatch karma karma_cc mantra mantra-bin \
+    vmantra vmantra-bin; do
+ln -r -s $HOUDINI_DIR/bin/$BINARY $PREFIX/bin/$BINARY
+done
+
+# Install Houdini dependencies from local package manager
+mkdir -p $SRC_DIR/download
+cd $SRC_DIR/download
+dnf download --resolve -y alsa-lib fontconfig libXScrnSaver libxkbfile
+
+
+for rpm_file in $(realpath $SRC_DIR/download/*.rpm); do
+    rpm2cpio "$rpm_file" | cpio -idm
+done
+
+# Add $ORIGIN as a RPATH to any .so's and copy into Houdini's installation
+for so_file in $(find . -iname "*.so.*"); do
+    patchelf --add-rpath '$ORIGIN' $so_file
+    cp $so_file $HOUDINI_DIR/dsolib/.
+done
+
+# Script to set environment variables during activation
+mkdir -p $PREFIX/etc/conda/activate.d
+cat <<EOF > $PREFIX/etc/conda/activate.d/houdini-$PKG_VERSION-vars.sh
+export "HOUDINI_LOCATION=\$CONDA_PREFIX/opt/houdini"
+export "HOUDINI_VERSION=$PKG_VERSION"
+export "HOUDINI_BINARY_PATH=\$HOUDINI_LOCATION/bin"
+export "HOUDINI_HOUDINI_PATH=\$HOUDINI_LOCATION/houdini"
+export "HOUDINI_INCLUDE_PATH=\$HOUDINI_LOCATION/toolkit/include"
+export "HOUDINI_LIBRARY_PATH=\$HOUDINI_LOCATION/bin"
+
+EOF
+
+mkdir -p $PREFIX/etc/conda/deactivate.d
+cat <<EOF > $PREFIX/etc/conda/deactivate.d/houdini-$PKG_VERSION-vars.sh
+unset HOUDINI_LIBRARY_PATH
+unset HOUDINI_INCLUDE_PATH
+unset HOUDINI_HOUDINI_PATH
+unset HOUDINI_BINARY_PATH
+unset HOUDINI_VERSION
+unset HOUDINI_LOCATION
+
+EOF

--- a/conda_recipes/houdini-21.0/recipe/recipe.yaml
+++ b/conda_recipes/houdini-21.0/recipe/recipe.yaml
@@ -1,0 +1,42 @@
+# Recipe in rattler-build format.
+# See https://prefix-dev.github.io/rattler-build/latest/
+
+context:
+  version: "21.0.440"
+
+package:
+  name: houdini
+  version: ${{ version }}
+
+source:
+  - if: linux
+    then:
+      url: file://archive_files/houdini-{{ version }}-linux_x86_64_gcc11.2.tar.gz
+      sha256: a87451f9146d52051a9ba142d535936638351526a48cba0c6156a221f3be58e6
+      target_directory: installer
+
+build:
+  number: 0
+  # These build options for repackaging an application
+  # https://prefix-dev.github.io/rattler-build/latest/build_options/#prefix-detection-replacement-options
+  prefix_detection:
+    ignore_binary_files: True
+  # https://prefix-dev.github.io/rattler-build/latest/build_options/#dynamic-linking-configuration
+  dynamic_linking:
+    binary_relocation: False
+
+requirements:
+  build:
+    - patchelf
+
+tests:
+  - script:
+    - houdini -h
+    - hython -h
+
+about:
+  homepage: https://www.sidefx.com/products/houdini/
+  license: LicenseRef-SideFXEULA
+  summary: >
+    Houdini is built from the ground up to be a procedural system that empowers artists to work freely,
+    create multiple iterations and rapidly share workflows with colleagues.


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The only Houdini sample we had was for 20.5. 21.0 is out now and we should show how to build a Conda package for it.
### What was the solution? (How)
Added a sample recipe, it was almst entirely just a copy/paste of the 20.5 recipe and changing version numbers/hashes. The one new addition is libxkbfile is now required to run `houdini` and `husk` directly it seems so that has been added to the dependencies being pulled in through dnf.

### What is the impact of this change?
More samples for customers.

### How was this change tested?

- Built the package in my own build farm following our public docs on how to set one up. Both of the `houdini -h` and `hython -h` tests passed. Did a manual render with Karma and a standalone husk submission which both succeeded.

### Was this change documented?

- It has an updated README

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*