### PR TITLE
feat: add Redshift 2026 for Houdini 21.0 sample Conda recipe

### DIFF
--- a/conda_recipes/houdini-20.5/deadline-cloud.yaml
+++ b/conda_recipes/houdini-20.5/deadline-cloud.yaml
@@ -2,7 +2,7 @@ condaPlatforms:
   - platform: linux-64
     defaultSubmit: true
     sourceArchiveFilename: houdini-20.5.654-linux_x86_64_gcc11.2.tar.gz
-    sourceDownloadInstructions: Download the installer archive from SideFX Houdini's downloads page.
+    sourceDownloadInstructions: Download the old installer archive(not the launcher) from SideFX Houdini's downloads page.
     buildTool: rattler-build
 jobParameters:
   # conda-forge is used to get patchelf

--- a/conda_recipes/houdini-21.0/deadline-cloud.yaml
+++ b/conda_recipes/houdini-21.0/deadline-cloud.yaml
@@ -2,7 +2,7 @@ condaPlatforms:
   - platform: linux-64
     defaultSubmit: true
     sourceArchiveFilename: houdini-21.0.440-linux_x86_64_gcc11.2.tar.gz
-    sourceDownloadInstructions: Download the installer archive from SideFX Houdini's downloads page.
+    sourceDownloadInstructions: Download the old installer archive(not the launcher) from SideFX Houdini's downloads page.
     buildTool: rattler-build
 jobParameters:
   # conda-forge is used to get patchelf

--- a/conda_recipes/houdini-redshift-2026/README.md
+++ b/conda_recipes/houdini-redshift-2026/README.md
@@ -1,0 +1,173 @@
+# Redshift for Houdini 2026 Conda Recipe for AWS Deadline Cloud
+
+## Overview
+
+This directory contains a conda build recipe for Redshift for Houdini 2026.1.1, specifically configured for use with AWS Deadline Cloud. This package enables you to run Redshift rendering jobs with Houdini on Deadline Cloud service-managed fleets.
+
+## Package Information
+
+- **Application**: Redshift for Houdini redshift_2026.1.1_2105803004
+- **Supported Platforms**: linux-64
+- **Source**: Maxon website
+- **License**: LicenseRef-MaxonEULA
+- **Build Tool**: rattler-build
+
+## Prerequisites
+
+Before building this package, ensure you have:
+
+1. **AWS Deadline Cloud infrastructure** set up with:
+   - A farm configured for package building
+   - A queue named "Package Build Queue" (or specify with `-q` option)
+   - Linux-64 fleet for building linux packages
+
+2. **Deadline Cloud CLI** installed on your workstation
+
+3. **Source archive** (see [Archive File Instructions](#archive-file-instructions) below)
+
+4. **Maxon account** for downloading Redshift installer
+
+5. **A Houdini conda package** as this is a plugin dependency
+
+## Archive File Instructions
+
+### Linux
+
+#### Download from Maxon
+1. Download the `redshift_2026.1.1_2105803004_linux_x64.run` installer from the Maxon website
+2. Place the downloaded file in the `conda_recipes/archive_files` directory
+3. Verify the SHA256 hash matches: `3af69b23a5b4bff88ba85017e2992f3d6fd38036857c67e03284e4bcddce670c`
+
+## Plugin Integration
+
+### Plugin Architecture
+
+Redshift integrates with Houdini through a plugin system that requires version-specific compatibility. This package automatically detects the installed Houdini version and configures the appropriate Redshift plugin version.
+This recipe creates a package in `"$PREFIX/opt/houdini/packages"` which points to the plugin. For more information about Houdini packages, see the [Houdini Packages documentation](https://www.sidefx.com/docs/houdini/ref/plugins.html).
+
+### Plugin Installation Paths
+
+The conda recipe configures Redshift to integrate with Houdini installations:
+
+```bash
+# Environment variables set by this package
+export REDSHIFT_LOCATION=$PREFIX/opt/redshift
+
+# Integration with Houdini
+# Redshift plugins are installed to match Houdini version requirements
+```
+
+### Version Compatibility Logic
+
+This package implements intelligent version matching:
+
+1. **Exact Match**: Looks for an exact match between the Houdini version and available Redshift plugin versions
+2. **Major.Minor Match**: If no exact match is found, uses a plugin version that matches the major.minor version of Houdini
+3. **Fallback**: If no matching major.minor version is found, the package will exit and not configure Redshift
+4. **Version Detection**: If the `houdini --version` call doesn't print a valid version string, the package will exit
+
+### Creating Related Plugin Packages
+
+1. **Plugin Package Structure**
+   ```
+   my-redshift-extension/
+   ├── recipe/
+   │   ├── recipe.yaml
+   │   ├── build.sh
+   │   └── bld.bat
+   ├── deadline-cloud.yaml
+   └── README.md
+   ```
+
+2. **Plugin Dependencies**
+   - Add both Houdini and Redshift packages as dependencies in your plugin's `recipe.yaml`
+   - Specify version constraints: `houdini >=21.0,<21.5` and `houdini-redshift >=2026.1.0`
+
+## Application-Specific Requirements
+
+### Licensing
+
+See the [AWS Deadline Cloud licensing documentation](https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/license.html) for detailed guidance on license configuration. Redshift requires proper licensing configuration for rendering operations.
+
+### GPU Requirements
+
+Redshift is a GPU-accelerated renderer with specific requirements. See the [Redshift documentation](https://www.maxon.net/en/requirements/redshift-requirements) for full list.:
+- NVIDIA GPU with CUDA support
+- Minimum 8GB VRAM 
+- CUDA compute capability 6.0 or higher
+
+### System Requirements
+
+- Linux x86_64 compatibility
+- Compatible Houdini installation (21.0+, <21.5)
+- NVIDIA drivers with CUDA support
+
+## Adapting to Other Versions
+
+### Version Update Checklist
+
+To adapt this recipe for other Redshift versions:
+
+1. **Update Version Information**
+   ```yaml
+   # In recipe/recipe.yaml
+   context:
+     version: "2026.x.x_xxxxxxxx"  # new version
+   
+   # In deadline-cloud.yaml
+   sourceArchiveFilename: redshift_[version]_linux_x64.run
+   ```
+
+2. **Update Source Archives**
+   - Download new version installer from Maxon
+   - Update SHA256 hash in `recipe.yaml`
+   - Update source filename in `deadline-cloud.yaml`
+
+3. **Check Houdini Compatibility**
+   - Verify supported Houdini versions for the new Redshift release
+   - Update dependency constraints in `recipe.yaml`
+   - Test version detection logic
+
+4. **Update Build Scripts**
+   - Check for changes in installer structure
+   - Update file extraction and installation paths
+
+5. **Test Integration**
+   - Verify Redshift loads correctly in Houdini
+   - Test rendering functionality
+   - Validate version matching logic
+
+6. **Update Documentation**
+   - Update version numbers throughout README
+   - Update Houdini compatibility information
+   - Update any version-specific requirements
+
+### Common Version Migration Issues
+
+- **Houdini Compatibility**: New Redshift versions may drop support for older Houdini versions
+- **Plugin Structure Changes**: Installation directory structure may change
+- **Dependency Updates**: New versions may require different system dependencies
+- **License Changes**: Licensing requirements may change between versions
+
+## Recipe Structure
+
+```
+houdini-redshift-2026/
+├── README.md                    # This file
+├── deadline-cloud.yaml          # Deadline Cloud configuration
+└── recipe/
+    ├── recipe.yaml             # Rattler-build recipe
+    └── build.sh                # Linux build script with version detection
+```
+
+## Resources
+
+- **Redshift Documentation**: https://help.maxon.net/r3d/houdini/en-us/
+- **Houdini Plugin Configuration**: https://help.maxon.net/r3d/houdini/en-us/Content/html/Houdini+Plugin+Configuration.html
+- **AWS Deadline Cloud Developer Guide**: https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/
+- **Rattler Build Documentation**: https://prefix-dev.github.io/rattler-build/
+- **Maxon Redshift**: https://www.maxon.net/en/redshift
+
+---
+
+**Warning**: When changing the Redshift version, be sure to check what versions of Houdini it supports due to the strict version compatibility requirements. This package includes automatic version detection to prevent incompatible combinations.

--- a/conda_recipes/houdini-redshift-2026/deadline-cloud.yaml
+++ b/conda_recipes/houdini-redshift-2026/deadline-cloud.yaml
@@ -1,0 +1,10 @@
+condaPlatforms:
+  - platform: linux-64
+    defaultSubmit: true
+    sourceArchiveFilename: redshift_2026.1.1_2105803004_linux_x64.run
+    sourceDownloadInstructions: Download the Redshift installer from the Maxon website
+    buildTool: rattler-build
+jobParameters:
+  # conda-forge is used to get patchelf
+  - name: CondaChannels
+    value: conda-forge

--- a/conda_recipes/houdini-redshift-2026/recipe/build.sh
+++ b/conda_recipes/houdini-redshift-2026/recipe/build.sh
@@ -1,0 +1,143 @@
+#!/bin/sh
+set -xeuo pipefail
+
+# The version without the update number
+REDSHIFT_VERSION="$PKG_VERSION"
+
+INSTALLER_DIR="$SRC_DIR/installer"
+INSTALLER="$INSTALLER_DIR/redshift_${REDSHIFT_VERSION}_linux_x64.run"
+REDSHIFT_UNPACK_DIR="$INSTALLER_DIR/redshift_installer_artifacts"
+REDSHIFT_ROOT="$PREFIX/opt/redshift"
+
+# Extract the run file into its accompanying tarball and setup script
+chmod u+x "$INSTALLER"
+$INSTALLER --target "$REDSHIFT_UNPACK_DIR" --noexec
+
+# Skip superuser check by modifying the setup script in-place
+sed -i 's/\[ "$(id -u)" != "0" \]/false/' "$REDSHIFT_UNPACK_DIR/setup.sh"
+
+# Run the setup script
+cd "$REDSHIFT_UNPACK_DIR"
+./setup.sh --installpath "$REDSHIFT_ROOT"
+
+# Clean up unneeded DCC artifacts
+rm -r "$REDSHIFT_ROOT/redshift4c4d"
+rm -r "$REDSHIFT_ROOT/redshift4katana"
+rm -r "$REDSHIFT_ROOT/redshift4maya"
+
+# Create symlink for redshiftCmdLine
+mkdir -p "$PREFIX/bin"
+ln -r -s "$REDSHIFT_ROOT/bin/redshiftCmdLine" "$PREFIX/bin/redshiftCmdLine"
+
+# Add rpath into the Houdini installation in the same environment
+for so_file in $(find "$REDSHIFT_ROOT"/redshift4houdini/*/dso -iname "redshift4houdini.so"); do
+    patchelf --add-rpath '$ORIGIN/../../../../houdini/dsolib' "$so_file"
+done
+
+# Create Houdini package file for Redshift plugin and place into Houdini search path
+# https://help.maxon.net/r3d/houdini/en-us/Content/html/Houdini+Plugin+Configuration.html
+mkdir -p "$PREFIX/opt/houdini/packages"
+cat <<EOF > "$PREFIX/opt/houdini/packages/redshift_package.json"
+{
+    "env":[
+        {"HOUDINI_PATH": "\${REDSHIFT_COREDATAPATH}/redshift4houdini/\${RS_PLUGIN_VERSION}"},
+        {"PATH": "\${REDSHIFT_COREDATAPATH}/bin"},
+    ]
+}
+EOF
+
+# Script to set environment variables during activation
+# Environment variables are based on what is needed for portable Redshift installations
+# https://help.maxon.net/r3d/houdini/en-us/Content/html/Custom+Install+Locations.html
+mkdir -p "$PREFIX/etc/conda/activate.d"
+cat <<EOF > "$PREFIX/etc/conda/activate.d/houdini-redshift-$PKG_VERSION-vars.sh"
+export REDSHIFT_COREDATAPATH="$REDSHIFT_ROOT"
+export REDSHIFT_LOCALDATAPATH="\$REDSHIFT_COREDATAPATH/redshift_local_data"
+export REDSHIFT_PROCEDURALSPATH="\$REDSHIFT_COREDATAPATH/procedurals"
+export REDSHIFT_PREFSPATH="\$REDSHIFT_LOCALDATAPATH/preferences.xml"
+export HOUDINI_DSO_ERROR=2
+
+# Redshift plugins for Houdini are versioned to match the exact patch release
+# of the Houdini version. If there is no exact match this package will point
+# to the latest plugin version for either the matching MAJOR.MINOR Houdini version.
+# Using a plugin version that doesn't match the Houdini version could cause
+# instability and failures.
+
+HOU_VERSION_OUTPUT=\$(houdini --version 2>/dev/null)
+if [ $? -eq 0 ] && [[ "\$HOU_VERSION_OUTPUT" =~ Houdini\ FX\ ([0-9]+\.[0-9]+\.[0-9]+) ]]; then
+  HOU_VERSION="\${BASH_REMATCH[1]}"
+
+  # Get all available plugin versions
+  AVAILABLE_VERSIONS=\$(find "\$REDSHIFT_COREDATAPATH/redshift4houdini/" -mindepth 1 -maxdepth 1 -type d -printf "%f\n")
+
+  # Check for exact match first
+  if echo "\$AVAILABLE_VERSIONS" | grep -q "^\$HOU_VERSION$"; then
+    export RS_PLUGIN_VERSION="\$HOU_VERSION"
+  else
+    # Extract major.minor from HOU_VERSION (e.g. 21.0 from 21.0.440)
+    HOU_MAJOR_MINOR=\${HOU_VERSION%.*}
+    
+    # Find the latest patch release for a matching major.minor version
+    MATCHING_VERSION=\$(echo "\$AVAILABLE_VERSIONS" | grep "^\$HOU_MAJOR_MINOR" | sort -V | tail -1)
+
+    if [ -n "\$MATCHING_VERSION" ]; then
+      export RS_PLUGIN_VERSION="\$MATCHING_VERSION"
+      echo "Warning: No exact match Redshift plugin found for Houdini \$HOU_VERSION, using \$RS_PLUGIN_VERSION instead"
+    else
+      # If no matching major.minor version is found fail to load the package
+      echo "Error: No matching Redshift plugin found for Houdini \$HOU_MAJOR_MINOR in \$AVAILABLE_VERSIONS"
+      exit 1
+    fi
+  fi
+else
+  echo "Error: Could not determine Houdini version using 'houdini --version'"
+  exit 1
+fi
+
+# PXR_PLUGINPATH_NAME should be able to be set for the Solaris plugin in the Redshift package file.
+# https://help.maxon.net/r3d/houdini/en-us/Content/html/Houdini+Plugin+Configuration.html
+# However, there's a known issue where that doesn't work on Linux.
+# Instead we can set it outside the package file as part of the environment as the suggested workaround.
+
+internal_package_add_to_search_path () {
+    # Add a path to a new or existing environment variable.
+    # Usage: internal_package_add_to_search_path VAR_NAME /search/path/value
+    eval "CURRENT_VALUE=\\\${\$1:-}"
+    if [ "\$CURRENT_VALUE" = "" ]; then
+        eval "export \"\$1=\\\$2\""
+    else
+        NEW_VALUE="\$CURRENT_VALUE:\$2"
+        eval "export \"\$1=\\\$NEW_VALUE\""
+    fi
+}
+
+internal_package_add_to_search_path PXR_PLUGINPATH_NAME "\$REDSHIFT_COREDATAPATH/redshift4solaris/\$RS_PLUGIN_VERSION"
+
+unset -f internal_package_add_to_search_path
+EOF
+
+mkdir -p "$PREFIX/etc/conda/deactivate.d"
+cat <<EOF > "$PREFIX/etc/conda/deactivate.d/houdini-redshift-$PKG_VERSION-vars.sh"
+internal_package_remove_from_search_path () {
+    # Removes the given path from the given environment variable.
+    # Usage: internal_package_remove_from_search_path VAR_NAME /search/path/value
+    eval "CURRENT_VALUE=\\\$\$1"
+    if [ "\$CURRENT_VALUE" = "\$2" ]; then
+        eval "unset \$1"
+    else
+        NEW_VALUE="\$(echo ":\$CURRENT_VALUE:" | sed -e "s|:\$2:|:|")"
+        NEW_VALUE="\${NEW_VALUE%:}"
+        NEW_VALUE="\${NEW_VALUE#:}"
+        eval "export \"\$1=\\\$NEW_VALUE\""
+    fi
+}
+
+internal_package_remove_from_search_path PXR_PLUGINPATH_NAME "\$REDSHIFT_COREDATAPATH/redshift4solaris/\$RS_PLUGIN_VERSION"
+
+unset REDSHIFT_COREDATAPATH
+unset REDSHIFT_LOCALDATAPATH
+unset REDSHIFT_PROCEDURALSPATH
+unset REDSHIFT_PREFSPATH
+unset HOUDINI_DSO_ERROR
+unset -f internal_package_remove_from_search_path
+EOF

--- a/conda_recipes/houdini-redshift-2026/recipe/recipe.yaml
+++ b/conda_recipes/houdini-redshift-2026/recipe/recipe.yaml
@@ -1,0 +1,43 @@
+# Recipe in rattler-build format.
+# See https://prefix-dev.github.io/rattler-build/latest/
+
+context:
+  version: "2026.1.1_2105803004"
+
+package:
+  name: houdini-redshift
+  version: ${{ version }}
+
+source:
+  - if: linux
+    then:
+      url: file://archive_files/redshift_${{ version }}_linux_x64.run
+      sha256: 3af69b23a5b4bff88ba85017e2992f3d6fd38036857c67e03284e4bcddce670c
+      target_directory: installer
+
+build:
+  number: 0
+  # These build options for repackaging an application
+  # https://prefix-dev.github.io/rattler-build/latest/build_options/#prefix-detection-replacement-options
+  prefix_detection:
+    ignore_binary_files: True
+  # https://prefix-dev.github.io/rattler-build/latest/build_options/#dynamic-linking-configuration
+  dynamic_linking:
+    binary_relocation: false
+    missing_dso_allowlist:
+      - "**"
+
+requirements:
+  build:
+    - patchelf
+  run:
+    - houdini >=20.0, <21.5
+
+tests:
+  - script:
+    - redshiftCmdLine -listrenderoptions
+
+about:
+  homepage: https://www.maxon.net/en/redshift
+  license: LicenseRef-MaxonEULA
+  summary: Redshift is a powerful 3D rendering software that helps visualize your 3D designs, models, animations, and scenes.


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We have a Redshift 2025 for Houdini sample Conda recipe, but Redshift 2026 is out now too.
### What was the solution? (How)
Add the sample recipe for Redshift 2026 for Houdini 21.0. This is essentially a straight copy/paste of the existing Redshift2025 for Houdini recipe with the version numbers and hashes changed. There was one small change needed to remove a line that was deleting plugin files for redshift4blender as Redshift no longer packages a plugin for Blender in 2026 and the line was erroring out.

Also just added a note to our Houdini recipes to specify that you need the old installer, not the launcher installer.

### What is the impact of this change?
More version support

### How was this change tested?

Built both the new Houdini 21.0 recipe and this recipe into a channel in my build account. Ran a Redshift job submission and verified that the render logs were using Redshift and that the output looked correct.

### Was this change documented?

The README for the sample is updated.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*