### PR TITLE
feat: add V-Ray and Redshift to renderers list for husk usd example bundle

### DIFF
--- a/job_bundles/houdini_husk_usd_render/README.md
+++ b/job_bundles/houdini_husk_usd_render/README.md
@@ -51,6 +51,22 @@ Please note that husk will not render your scene if no camera is included. the `
 Only a few husk parameters are included for demonstration purpose. Please see the [husk documentation](https://www.sidefx.com/docs/houdini/ref/utils/husk.html) for reference.
 
 
+## Additional Renderers
+
+In addition to the default Karma renderers (BRAY_HdKarma and BRAY_HdKarmaXPU), this job bundle also supports V-Ray and Redshift renderers through their Hydra render delegates:
+
+* **HdVRayRendererPlugin** - V-Ray for Houdini renderer
+* **HdRedshiftRendererPlugin** - Redshift for Houdini renderer
+
+To use these renderers, you must set up V-Ray for Houdini or Redshift for Houdini in your environment. One option to do this is by using the Conda sample recipes available in this repository:
+
+* **V-Ray 7 for Houdini:** [houdini-vray-7](../../conda_recipes/houdini-vray-7/)
+* **Redshift 2025 for Houdini:** [houdini-redshift-2025](../../conda_recipes/houdini-redshift-2025/)
+* **Redshift 2026 for Houdini:** [houdini-redshift-2026](../../conda_recipes/houdini-redshift-2026/)
+
+These conda recipes can be used to create conda packages that include the necessary renderer plugins. Please refer to the individual recipe README files for specific setup instructions and licensing requirements.
+
+
 ## Sample Asset
 
 sample.usda is a simple scene containing a cube and a sphere. 

--- a/job_bundles/houdini_husk_usd_render/template.yaml
+++ b/job_bundles/houdini_husk_usd_render/template.yaml
@@ -81,7 +81,7 @@ parameterDefinitions:
     groupLabel: Render Parameters
   description: Choose the renderer you wish to use. BRAY_HdKarma uses the CPU while BRAY_HdKarmaXPU requires a GPU fleet. If you select BRAY_HdKarmaXPU your queue must be associated with a GPU fleet.
   default: BRAY_HdKarma
-  allowedValues: [BRAY_HdKarma, BRAY_HdKarmaXPU]
+  allowedValues: [BRAY_HdKarma, BRAY_HdKarmaXPU, HdVRayRendererPlugin, HdRedshiftRendererPlugin]
 - name: CondaPackages
   type: STRING
   userInterface:
@@ -125,4 +125,3 @@ steps:
     - name: attr.worker.os.family
       anyOf:
       - linux
-


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
USD export workflows from Houdini to V-Ray, Redshift and others via Husk are quite common. Our husk sample did not have V-Ray or Redshift as renderer options in the dropdown even though we have sample Conda packages now for those workflows.

### What was the solution? (How)
* Updated the renderers list with the renderer names which were retrieved by calling `hou.lop.availableRendererInfo()`
* Updated the README to state that using V-Ray or Redshift requires additional setup and linked the sample Conda recipes we have as one option to provide them on the workers.

### What is the impact of this change?
* More Husk workflows supported without changes needed

### How was this change tested?
- Did both a Redshift and V-Ray submission and verified the correct renderer was used in the logs for rendering.

### Was this change documented?

README has been updated.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*