### PR TITLE
fix: add --no-progress flags to V-Ray and tyFlow download commands in 3dsMax host config

### DIFF
--- a/host_configuration_scripts/3dsmax/3dsmax-2025-and-vray/3dsmax-2025-and-vray.ps1
+++ b/host_configuration_scripts/3dsmax/3dsmax-2025-and-vray/3dsmax-2025-and-vray.ps1
@@ -32,7 +32,7 @@ Start-Process "C:\3dsmax_setup\$3DS_MAX_FOLDER_NAME\Setup.exe" -ArgumentList '-q
 
 Write-Host ' --- Installing V-Ray for 3dsMax 2025 --- '
 
-aws s3 cp "s3://$BUCKET_NAME/$VRAY_FOR_3DSMAX2025_INSTALLER_FILE" C:\3dsmax_setup\
+aws s3 cp --no-progress "s3://$BUCKET_NAME/$VRAY_FOR_3DSMAX2025_INSTALLER_FILE" C:\3dsmax_setup\
 @"
 <DefValues>
 <Value Name="INSTALL_TYPE" DataType="value">1</Value>

--- a/host_configuration_scripts/3dsmax/3dsmax-2025-vray-and-tyflow/3dsmax-2025-vray-and-tyflow.ps1
+++ b/host_configuration_scripts/3dsmax/3dsmax-2025-vray-and-tyflow/3dsmax-2025-vray-and-tyflow.ps1
@@ -37,7 +37,7 @@ Start-Process "C:\3dsmax_setup\$3DS_MAX_FOLDER_NAME\Setup.exe" -ArgumentList '-q
 
 Write-Host ' --- Installing V-Ray for 3dsMax 2025 --- '
 
-aws s3 cp "s3://$BUCKET_NAME/$VRAY_FOR_3DSMAX2025_INSTALLER_FILE" C:\3dsmax_setup\
+aws s3 cp --no-progress "s3://$BUCKET_NAME/$VRAY_FOR_3DSMAX2025_INSTALLER_FILE" C:\3dsmax_setup\
 @"
 <DefValues>
 <Value Name="INSTALL_TYPE" DataType="value">1</Value>
@@ -55,7 +55,7 @@ Start-Process "C:\3dsmax_setup\$VRAY_FOR_3DSMAX2025_INSTALLER_FILE" -ArgumentLis
 
 Write-Host ' --- Installing tyFlow Plugin --- '
 
-aws s3 cp "s3://$BUCKET_NAME/$TYFLOW_PLUGIN_FILE" C:\3dsmax_setup\
+aws s3 cp --no-progress "s3://$BUCKET_NAME/$TYFLOW_PLUGIN_FILE" C\3dsmax_setup\
 $pluginsDir = "C:\Program Files\Autodesk\3ds Max 2025\plugins"
 New-Item -ItemType Directory -Path $pluginsDir -Force
 Copy-Item "C:\3dsmax_setup\$TYFLOW_PLUGIN_FILE" "$pluginsDir\"


### PR DESCRIPTION
- Add --no-progress flag to V-Ray installer download in 3dsmax-2025-and-vray.ps1
- Add --no-progress flags to V-Ray and tyFlow installer downloads in 3dsmax-2025-vray-and-tyflow.ps1
- Reduces verbose output during S3 downloads in host configuration process
Fixes: just a fix for not spamming the log with thousands of progress lines while downloading V-ray

### What was the problem/requirement? (What/Why)
Worker logs are spammed by download progress due to this line:

1. https://github.com/aws-deadline/deadline-cloud-samples/blob/ef184c7828b272da50f8f7371c57597a81275b00/host_configuration_scripts/3dsmax/3dsmax-2025-and-vray/3dsmax-2025-and-vray.ps1#L35
2. https://github.com/aws-deadline/deadline-cloud-samples/blob/ecb48da498640fb824ae7a49e51651ab921e8b69/host_configuration_scripts/3dsmax/3dsmax-2025-vray-and-tyflow/3dsmax-2025-vray-and-tyflow.ps1#L40
3. https://github.com/aws-deadline/deadline-cloud-samples/blob/ecb48da498640fb824ae7a49e51651ab921e8b69/host_configuration_scripts/3dsmax/3dsmax-2025-vray-and-tyflow/3dsmax-2025-vray-and-tyflow.ps1#L58

### What was the solution? (How)
Added a `--no-progress` flag to it like the way it is added on line: https://github.com/aws-deadline/deadline-cloud-samples/blob/ef184c7828b272da50f8f7371c57597a81275b00/host_configuration_scripts/3dsmax/3dsmax-2025-and-vray/3dsmax-2025-and-vray.ps1#L29

### What is the impact of this change?
V-Ray and tyFlow download progress will not be printed in the Worker logs mb by mb. It will only print the starting: 

```
{"level": "INFO", "message":   "download:   s3://<bucket>/DeadlineCloud/Data/vray_adv_71000_max2025_x64.exe   to ..\\..\\..\\..\\3dsmax_setup\\vray_adv_71000_max2025_x64.exe"}
```


### How was this change tested?

Put the updated host config script in to the fleet's host configuration.
Submitted a job and checked the Cloud Watch logs for Worker. 

### Was this change documented?

No. Let me know if this small change needs a documentation change. 

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*