### PR TITLE
feat: add 3ds Max V-Ray denoiser job bundle

### DIFF
--- a/job_bundles/3dsmax_vray_denoiser/README.md
+++ b/job_bundles/3dsmax_vray_denoiser/README.md
@@ -1,0 +1,74 @@
+# 3ds Max V-Ray Denoiser Example
+
+This job bundle demonstrates rendering 3ds Max scenes with V-Ray, including automatic VRIMG to EXR conversion with denoising preservation and intelligent frame chunking.
+
+## Features
+
+- **Smart Frame Chunking**: Automatically handles both contiguous ranges (e.g., `1-100`) and non-contiguous ranges (e.g., `1-5,10,15-20`)
+- **VRIMG to EXR Conversion**: Converts V-Ray's native VRIMG format to industry-standard EXR while preserving denoising data
+- **Automatic Cleanup**: Removes temporary VRIMG files after successful conversion
+- **Error Handling**: Validates output directories and checks for required V-Ray tools
+- **Flexible Output**: Supports custom output directories and frame ranges
+
+## Requirements
+
+- **AWS Deadline Cloud CLI** with GUI mode installed on the artists' machines
+- **3ds Max 2025** installed on Windows Worker hosts
+- **V-Ray for 3ds Max 2025** (tested with V-Ray 7.0) installed on Windows Worker hosts
+- You can use 3ds Max and V-Ray (with plugins) host configuration script available [here](https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/host_configuration_scripts/3dsmax) on Windows SMF to install them on the Worker
+
+## Parameters
+
+- **Scene File**: 3ds Max scene file (.max) to render
+- **Frames**: Frame range specification (supports both `1-100` and `1,5,10-20` formats)
+- **Output Directory**: Directory where final EXR files will be saved
+- **Frames Per Task**: Number of frames to render per task (automatically adjusted for non-contiguous ranges to 1)
+
+## Frame Chunking Behavior
+
+The template intelligently handles different frame range formats:
+
+- **Contiguous ranges** (e.g., `1-100`): Uses the specified Frames Per Task for efficient chunking
+- **Non-contiguous ranges** (e.g., `1-5,10,15-20`): Automatically renders one frame per task regardless of Frames Per Task setting
+
+## Output Format
+
+The job renders to V-Ray's native VRIMG format in a temporary directory, then converts to EXR format in the specified output directory. VRIMG files conserve all denoising elements including noise passes, beauty passes, and denoising data. This workflow preserves:
+
+- All denoising elements and passes
+- Multi-channel data
+- High dynamic range
+- Complete V-Ray render information
+
+## Usage
+
+### Scene Tweaks
+
+**Max > Render Setup > V-Ray > Enable built-in frame buffer > Save raw image output:**
+- Give it a local location on the Worker: `C:\Temp\<output>.vrimg` 
+- You can use any name instead of the `<output>` placeholder
+
+**Render Elements Configuration:**
+- Make sure you have all the render elements you need under render elements tab and the Denoiser too
+- Select each render element including the Denoiser and remove the absolute output path
+
+### Submitting the Job
+
+**Setup:**
+- Download the template to a directory and open a terminal
+- Run `deadline bundle gui-submit .`
+- You'll need Deadline Cloud CLI and GUI components installed for this
+- If you run into issues like modules not found or command not found, install Python 3.8+ and follow here: https://github.com/aws-deadline/deadline-cloud?tab=readme-ov-file#getting-started
+
+**Submission Steps:**
+1. **Fill in job details** - You will see a GUI submission window
+2. **Configure scene parameters:**
+   - Fill in the scene file location
+   - Set start and end frame
+   - Specify the output directory
+3. **Select job attachments:**
+   - Select all the assets in the job attachments which scene needs to render
+   - Include tyFlow cache files if applicable
+4. **Submit** the job
+
+The job will handle the rest automatically, including format conversion and cleanup.

--- a/job_bundles/3dsmax_vray_denoiser/template.yaml
+++ b/job_bundles/3dsmax_vray_denoiser/template.yaml
@@ -1,0 +1,151 @@
+specificationVersion: 'jobtemplate-2023-09'
+name: 3ds Max V-Ray Render
+description: |
+  This job bundle renders a 3ds Max scene using V-Ray with frame chunking support.
+  
+  Features:
+  - Frame chunking for efficient parallel rendering
+  - VRIMG to EXR conversion with denoising preservation
+  - Automatic cleanup of temporary files
+  - Error handling and validation
+  
+  Requirements:
+  - 3ds Max 2025 installed on Windows worker hosts
+  - V-Ray plugin for 3ds Max
+
+parameterDefinitions:
+
+# Render Parameters
+- name: SceneFile
+  type: PATH
+  objectType: FILE
+  dataFlow: IN
+  userInterface:
+    control: CHOOSE_INPUT_FILE
+    label: 3ds Max Scene File
+    groupLabel: Render Parameters
+    fileFilters:
+    - label: 3ds Max Scene Files
+      patterns: ["*.max"]
+    - label: All Files
+      patterns: ["*"]
+  description: Choose the 3ds Max scene file you want to render.
+
+- name: Frames
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Frames
+    groupLabel: Render Parameters
+  default: "0-10"
+  description: Frame range to render (e.g., 1-100, 1,5,10-20)
+
+- name: OutputDirectory
+  type: PATH
+  objectType: DIRECTORY
+  dataFlow: OUT
+  userInterface:
+    control: CHOOSE_DIRECTORY
+    label: Output Directory
+    groupLabel: Render Parameters
+  description: Choose the render output directory.
+
+- name: FramesPerTask
+  type: INT
+  userInterface:
+    control: SPIN_BOX
+    label: Frames Per Task
+    groupLabel: Render Parameters
+  default: 1
+  minValue: 1
+  description: Number of frames to render per task
+steps:
+- name: Render EXRs
+  parameterSpace:
+    taskParameterDefinitions:
+    - name: Frame
+      type: INT
+      range: "{{Param.Frames}}:{{Param.FramesPerTask}}"
+  script:
+    embeddedFiles:
+    - name: render_script
+      filename: render.bat
+      type: TEXT
+      runnable: true
+      data: |
+        @echo off
+        setlocal enabledelayedexpansion
+        echo Starting 3ds Max render...
+        echo Scene: {{Param.SceneFile}}
+        echo Original Frame Range: {{Param.Frames}}
+        
+        set /a taskStart={{Task.Param.Frame}}
+        
+        REM Check if this is a non-contiguous range (contains commas)
+        echo {{Param.Frames}} | findstr "," >nul
+        if !errorlevel! equ 0 (
+          REM Non-contiguous range - always render single frame
+          set /a taskEnd=!taskStart!
+          echo Non-contiguous range detected - rendering single frame: !taskStart!
+        ) else (
+          REM Contiguous range - check if we need to limit the end frame
+          set /a taskEnd=!taskStart!+{{Param.FramesPerTask}}-1
+          
+          REM Extract the actual end frame from the range to avoid going beyond it
+          for /f "tokens=2 delims=-" %%a in ("{{Param.Frames}}") do set maxFrame=%%a
+          if !taskEnd! gtr !maxFrame! set taskEnd=!maxFrame!
+          
+          echo Contiguous range - rendering frames !taskStart! to !taskEnd!
+        )
+        
+        REM Validate output directory
+        mkdir "{{Param.OutputDirectory}}" 2>nul
+        echo test > "{{Param.OutputDirectory}}\test.tmp" 2>nul || (
+          echo ERROR: Cannot write to output directory
+          exit /b 1
+        )
+        del "{{Param.OutputDirectory}}\test.tmp" 2>nul
+        
+        REM Check vrimg2exr exists
+        if not exist "C:\ProgramData\Autodesk\ApplicationPlugins\VRay3dsMax2025\bin\vrimg2exr.exe" (
+          echo ERROR: vrimg2exr.exe not found
+          exit /b 1
+        )
+        
+        REM Render frame range for this chunk
+        "C:\Program Files\Autodesk\3ds Max 2025\3dsmaxcmd.exe" -start:!taskStart! -end:!taskEnd! "{{Param.SceneFile}}"
+        if %ERRORLEVEL% NEQ 0 (
+          echo ERROR: 3dsmaxcmd failed with exit code %ERRORLEVEL%
+          exit /b %ERRORLEVEL%
+        )
+        
+        if !taskStart! equ !taskEnd! (
+          echo 3ds Max render completed successfully for frame !taskStart!
+        ) else (
+          echo 3ds Max render completed successfully for frames !taskStart! to !taskEnd!
+        )
+        echo Converting .vrimg files to .exr and moving to output...
+        set converted=0
+        for %%f in ("C:\temp\*.vrimg") do (
+          if exist "{{Param.OutputDirectory}}\%%~nf.exr" (
+            echo Skipping %%~nxf - EXR exists
+          ) else (
+            echo Converting %%~nxf...
+            "C:\ProgramData\Autodesk\ApplicationPlugins\VRay3dsMax2025\bin\vrimg2exr.exe" "%%f" "{{Param.OutputDirectory}}\%%~nf.exr"
+            if !errorlevel! equ 0 (
+              echo Converted %%~nxf to EXR
+              del "%%f" >nul 2>&1
+              set /a converted+=1
+            ) else (
+              echo Failed to convert %%~nxf
+            )
+          )
+        )
+        echo Converted !converted! files to EXR
+        del "C:\temp\*.vrimg" >nul 2>&1
+        dir "{{Param.OutputDirectory}}\*.exr" /b 2>nul || echo No EXR files
+    actions:
+      onRun:
+        command: "{{Task.File.render_script}}"
+        cancelation:
+          mode: NOTIFY_THEN_TERMINATE

--- a/job_bundles/README.md
+++ b/job_bundles/README.md
@@ -53,6 +53,7 @@ the template is metadata for the job parameters, defining the parameter names, t
 The step definition includes a parameter space to define a task for each frame for a range expression in the Frames job parameter,
 and a short script that substitutes job parameters and the Frame task parameter into a script command for each task.
 
+* [3dsmax_vray_denoiser_example](3dsmax_vray_denoiser_example) - 3ds Max V-Ray rendering with smart frame chunking and VRIMG to EXR conversion
 * [blender_render](blender_render/template.yaml)
 * [keyshot_standalone](keyshot_standalone)
 * [afterfx_render_one_task](afterfx_render_one_task)


### PR DESCRIPTION
- Added complete job bundle for 3ds Max V-Ray rendering with denoiser support
- Includes smart frame chunking that handles both contiguous and non-contiguous ranges
- Features VRIMG to EXR conversion with denoising preservation
- Added comprehensive README with usage instructions and requirements
- Updated main job bundles README to include new job bundle

Fixes: *No specific GitHub issue - this is a new feature contribution for V-ray denoiser rendering with render elements*

### What was the problem/requirement? (What/Why)

Users needed a comprehensive job bundle for rendering 3ds Max scenes with V-Ray that includes:
- Intelligent frame chunking for both contiguous (1-100) and non-contiguous (1,5,10-20) frame ranges
- Automatic VRIMG to EXR conversion while preserving denoising data
- Support for V-Ray's advanced denoising capabilities
- Proper cleanup of temporary files

### What was the solution? (How)

Created a new job bundle `3dsmax_vray_denoiser` that:
- Uses `findstr ","` to detect non-contiguous frame ranges and automatically adjusts chunking behaviour
- Renders to VRIMG format first, then converts to EXR using V-Ray's `vrimg2exr` tool
- Preserves all denoising elements, noise passes, beauty passes, and multi-channel data

### What is the impact of this change?

- Artists can now render 3ds Max V-Ray scenes with proper denoising workflow
- Supports both simple and complex frame range specifications automatically
- Reduces manual post-processing by handling format conversion automatically
- Maintains full V-Ray feature compatibility including advanced denoising
- Does the path mapping for output directories for vrimg files

### How was this change tested?

- Tested with 3ds Max 2025 and V-Ray 7.0 on Windows Worker hosts
- Verified frame chunking behaviour with both contiguous ranges (1-100) and non-contiguous ranges (1-5,10,15-20)
- Confirmed VRIMG to EXR conversion preserves denoising data and multi-channel information
- Validated automatic cleanup of temporary VRIMG files after successful conversion
- Tested job submission using `deadline bundle gui-submit .` command

### Was this change documented?

Yes, comprehensive documentation includes:
- Detailed README.md explaining all features and requirements
- Usage instructions with CLI commands
- Frame chunking behavior explanation
- Output format details and denoising preservation information
- Updated main job_bundles README.md to include the new sample

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
