### PR TITLE
feat: Redshift 2026 integration with Maya versions 2025 and 2026

### DIFF
--- a/conda_recipes/maya-redshift-2026/README.md
+++ b/conda_recipes/maya-redshift-2026/README.md
@@ -1,0 +1,18 @@
+# Redshift for Maya conda build recipe
+
+This package provides Redshift 2026.2.1 support for Maya versions 2025, and 2026.
+
+## Supported Maya Versions
+
+- Maya 2025  
+- Maya 2026
+
+## Download the installer file for Linux
+
+Download the redshift_2026.2.1_2202748377_linux_x64.run installer, or suitable alternate version from Maxon, and
+place it in the `conda_recipes/archive_files` directory in your git clone of the
+[https://github.com/aws-deadline/deadline-cloud-samples](deadline-cloud-samples) repository for
+submitting package build jobs.
+
+Please note that if the installer version used differs from "redshift_2026.2.1_2202748377_linux_x64.run", version
+and filename updates will need to be made to deadline-cloud.yaml and recipe/recipe.yaml

--- a/conda_recipes/maya-redshift-2026/deadline-cloud.yaml
+++ b/conda_recipes/maya-redshift-2026/deadline-cloud.yaml
@@ -1,0 +1,7 @@
+condaPlatforms:
+  - platform: linux-64
+    defaultSubmit: true
+    sourceArchiveFilename:
+    - redshift_2026.2.1_2202748377_linux_x64.run
+    sourceDownloadInstructions: 'Download the redshift_2026.2.1_2202748377_linux_x64.run file.'
+    buildTool: rattler-build

--- a/conda_recipes/maya-redshift-2026/recipe/build.sh
+++ b/conda_recipes/maya-redshift-2026/recipe/build.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+
+# Echo all the commands so debugging from log output is simpler
+set -x
+# Fail the script if any commands it runs fail
+set -euo pipefail
+
+# The version without the update number
+REDSHIFT_VERSION=${PKG_VERSION%.*}
+
+# Redshift supports the following maya versions 
+MAYA_VERSIONS="2022 2023 2024 2025 2026"
+
+INSTALLER_DIR="$SRC_DIR/installer"
+REDSHIFT_UNPACK_DIR="$INSTALLER_DIR/redshift_installer_artifacts"
+REDSHIFT_ROOT="usr/maxon/redshift_${REDSHIFT_VERSION}"
+
+# Extract the run file into its accompanying tarball and setup script
+chmod u+x "$INSTALLER_DIR"/redshift_"${REDSHIFT_VERSION}"*_linux_x64.run
+"$INSTALLER_DIR"/redshift_${REDSHIFT_VERSION}*_linux_x64.run --target "$REDSHIFT_UNPACK_DIR" --noexec
+
+# Skip superuser check by modifying the setup script in-place
+sed -i 's/\[ "$(id -u)" != "0" \]/false/' "$REDSHIFT_UNPACK_DIR/setup.sh"
+
+# Run the setup script
+cd "$REDSHIFT_UNPACK_DIR"
+./setup.sh --installpath "${PREFIX}/${REDSHIFT_ROOT}"
+
+# clear the installer artifacts
+rm setup.sh
+rm package.tar.gz
+
+# clean up unneeded DCC artifacts
+# Note: redshift4blender is not included in Redshift 2026+ (Maxon paused Blender development)
+rm -r "${PREFIX}/${REDSHIFT_ROOT}"/redshift4c4d
+rm -r "${PREFIX}/${REDSHIFT_ROOT}"/redshift4houdini
+rm -r "${PREFIX}/${REDSHIFT_ROOT}"/redshift4katana
+rm -r "${PREFIX}/${REDSHIFT_ROOT}"/redshift4solaris
+
+# Create the redshift4maya.mod file for multiple Maya versions
+#
+# The maya package has set the Maya module path to include virtual environment-equivalents of
+# the system module paths, so this is the usual installation location after the virtual environment
+# prefix.
+
+for MAYA_VERSION in $MAYA_VERSIONS; do
+
+  # Add a relative RPATH from Redshift into Maya using patchelf, which is part of
+  # the conda-build virtual environment. This is so we can follow the recommendation
+  # of https://docs.conda.io/projects/conda-build/en/latest/resources/use-shared-libraries.html
+  # to never use LD_LIBRARY_PATH in Conda environments.
+
+  patchelf --add-rpath "\$ORIGIN/../../../../autodesk/maya${MAYA_VERSION}/lib" "${PREFIX}/${REDSHIFT_ROOT}/redshift4maya/${MAYA_VERSION}"/redshift4maya.so
+  patchelf --add-rpath "\$ORIGIN/../../../../autodesk/maya${MAYA_VERSION}/plug-ins/xgen/lib" "${PREFIX}/${REDSHIFT_ROOT}/redshift4maya/${MAYA_VERSION}"/redshift4maya.so
+
+  # Generate the .mod file for this specific version
+  mkdir -p "$PREFIX/usr/autodesk/modules/maya/$MAYA_VERSION"
+  cat <<EOF > "$PREFIX/usr/autodesk/modules/maya/$MAYA_VERSION/redshift4maya.mod"
++ redshift4maya any $PREFIX/$REDSHIFT_ROOT/redshift4maya
+scripts: common/scripts
+icons: common/icons
+plug-ins: $MAYA_VERSION
+REDSHIFT_COREDATAPATH = $PREFIX/$REDSHIFT_ROOT
+MAYA_CUSTOM_TEMPLATE_PATH +:= common/scripts/NETemplates
+MAYA_RENDER_DESC_PATH +:=  common/rendererDesc
+REDSHIFT_MAYAEXTENSIONSPATH +:= $MAYA_VERSION/extensions
+REDSHIFT_PROCEDURALSPATH += "\$REDSHIFT_COREDATAPATH/procedurals/usd/USD_24.08"
+REDSHIFT_PROCEDURALSPATH += "\$REDSHIFT_COREDATAPATH/procedurals/alembic"
+EOF
+
+done
+

--- a/conda_recipes/maya-redshift-2026/recipe/recipe.yaml
+++ b/conda_recipes/maya-redshift-2026/recipe/recipe.yaml
@@ -1,0 +1,36 @@
+# Recipe in rattler-build format.
+# See https://prefix-dev.github.io/rattler-build/latest/
+
+context:
+  version: "2026.2.1_2202748377"
+
+package:
+  name: maya-redshift
+  version: ${{ version }}
+
+source:
+  - url: file://archive_files/redshift_${{ version }}_linux_x64.run
+    sha256: 7453cb05614c3356d00960ee57e287f064a741242545e1bbc1f5f118e1a07963
+    target_directory: installer
+
+build:
+  number: 0
+  # These build options for repackaging an application
+  # https://prefix-dev.github.io/rattler-build/latest/build_options/#prefix-detection-replacement-options
+  prefix_detection:
+    ignore_binary_files: True
+  # https://prefix-dev.github.io/rattler-build/latest/build_options/#dynamic-linking-configuration
+  dynamic_linking:
+    binary_relocation: False
+    missing_dso_allowlist:
+    - "**"
+
+requirements:
+  run:
+    - maya >=2025, <2027
+
+
+about:
+  homepage: https://www.maxon.net/en/redshift
+  license: LicenseRef-MaxonEULA
+  summary: Redshift is a powerful 3D rendering software that helps visualize your 3D designs, models, animations, and scenes.


### PR DESCRIPTION
Fixes: N/A

### What was the problem/requirement? (What/Why)
Redshift 2026.2.1 was released in December 2025. We need to support it with Maya

### What was the solution? (How)
Added a recipe for Redshift 2026 support with Maya2025 and Maya2026

### What is the impact of this change?
New conda package sample for customers to use redshift 2026

### How was this change tested?
Created the conda package using a starter farm as per ReadMe and tested that a sample scene renders successfully for Maya2025 and Maya2026

<img width="960" height="540" alt="redshiftmayascene 0001" src="https://github.com/user-attachments/assets/e5d0c7ef-66f2-4e8c-87bf-803b12ce932d" />

### Was this change documented?
Yes, ReadMe is updated

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*