### PR TITLE
feat: add conda recipe sample for Unreal Engine using rattler-build

### DIFF
--- a/conda_recipes/unreal-engine-openjd/recipe/recipe.yaml
+++ b/conda_recipes/unreal-engine-openjd/recipe/recipe.yaml
@@ -23,6 +23,10 @@ build:
     - unreal-engine-p4-utils = deadline.unreal_perforce_utils.cli:main
 
 requirements:
+  # rattler-build automatically adds python and python_abi as runtime dependencies in the generated repodata.json file.
+  # Since this is an OpenJD adaptor package that will be installed into environments where Python is already present (and managed separately), 
+  # we don't want rattler-build to inject these dependencies automatically. 
+  # The ignore_run_exports directive prevents rattler-build from adding these implicit runtime dependencies while still allowing us to use them as build-time host dependencies.
   ignore_run_exports:
     by_name:
       - python_abi

--- a/conda_recipes/unreal-engine/README.md
+++ b/conda_recipes/unreal-engine/README.md
@@ -80,17 +80,8 @@ Before building, update `recipe/recipe.yaml` to match your Unreal Engine install
 ### Uploading a locally built conda package to S3
 
 The `rattler-build publish` command can upload directly to S3 and handle indexing automatically. If you need to upload a pre-built package manually:
-
-1. Upload to your S3 channel:
    ```
-   aws s3 cp <path-to-conda-package> s3://<bucket>/<channel-path>
-   ```
-
-2. Update the channel index using [rattler-index](https://prefix.dev/channels/conda-forge/packages/rattler-index):
-   ```
-   conda install -c conda-forge rattler-index
-   rattler-index <local-channel-path>
-   aws s3 sync <local-channel-path> s3://<bucket>/<channel-path>
+   rattler-build publish <path-to-conda-package>.conda --to s3://...
    ```
 
 ## Recipe Details

--- a/conda_recipes/unreal-engine/README.md
+++ b/conda_recipes/unreal-engine/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This recipe packages Unreal Engine for use in AWS Deadline Cloud ecosystem. It uses UE 5.6 as an example, but you can adapt it for any UE version, including custom source builds.
+This recipe packages Unreal Engine for use in the AWS Deadline Cloud ecosystem. It uses UE 5.6 as an example, but you can adapt it for any UE version, including custom source builds.
 
 Unlike other recipes in this repository, this one is designed to be built **locally** on a machine where Unreal Engine is already installed.
 
@@ -42,13 +42,13 @@ Before building, update `recipe/recipe.yaml` to match your Unreal Engine install
    ```yaml
    context:
      name: "unrealengine"
-     version: "5.4"  # Your UE version
+     version: "5.6"  # Your UE version
    ```
 
 2. **Update the source path**:
    ```yaml
    source:
-     - path: 'C:\Program Files\Epic Games\UE_5.4\Engine'  # Your UE Engine path
+     - path: 'C:\Program Files\Epic Games\UE_5.6\Engine'  # Your UE Engine path
    ```
 
    For custom source builds:
@@ -57,7 +57,7 @@ Before building, update `recipe/recipe.yaml` to match your Unreal Engine install
      - path: 'D:\UnrealEngine\Engine'  # Your custom build path
    ```
 
-## Building the Package Locally
+## Publishing the Package
 
 1. Publish a conda package by running rattler-build:
    ```
@@ -67,7 +67,7 @@ Before building, update `recipe/recipe.yaml` to match your Unreal Engine install
    The build process will:
    - Copy the Engine directory from your UE installation
    - Exclude non-essential files (documentation, source code, build artifacts, etc.)
-   - Create a conda package in the channel
+   - Create a conda package in the channel and re-index the channel
    - For building a test package, use the `package-format` option to reduce compression level and speed up the build process. 
    ```
    --package-format conda:0
@@ -77,25 +77,20 @@ Before building, update `recipe/recipe.yaml` to match your Unreal Engine install
 
    > **Note:** The build may take up to 90 minutes depending on your disk speed.
 
-## Uploading to Your S3 Conda Channel
+### Uploading a locally built conda package to S3
 
-If not published to an S3 conda channel in the step above, upload the package manually:
+The `rattler-build publish` command can upload directly to S3 and handle indexing automatically. If you need to upload a pre-built package manually:
 
-1. Locate the built package in <publish-conda-channel>
-
-2. Upload to your S3 channel:
+1. Upload to your S3 channel:
    ```
-   aws s3 cp <path-to-generated-conda-package> <s3-conda-channel>
+   aws s3 cp <path-to-conda-package> s3://<bucket>/<channel-path>
    ```
 
-3. Update the channel index using [rattler-index](https://prefix.dev/channels/conda-forge/packages/rattler-index):
+2. Update the channel index using [rattler-index](https://prefix.dev/channels/conda-forge/packages/rattler-index):
    ```
-   # Install rattler-index if not already installed
    conda install -c conda-forge rattler-index
-
-   # Reindex your conda channel, then sync to S3
-   rattler-index <conda-channel-path>
-   aws s3 sync <conda-channel-path> <s3-conda-channel>
+   rattler-index <local-channel-path>
+   aws s3 sync <local-channel-path> s3://<bucket>/<channel-path>
    ```
 
 ## Recipe Details

--- a/conda_recipes/unreal-engine/README.md
+++ b/conda_recipes/unreal-engine/README.md
@@ -1,0 +1,119 @@
+# Unreal Engine Conda Package Recipe
+
+## Overview
+
+This recipe packages Unreal Engine for use in AWS Deadline Cloud ecosystem. It uses UE 5.6 as an example, but you can adapt it for any UE version, including custom source builds.
+
+Unlike other recipes in this repository, this one is designed to be built **locally** on a machine where Unreal Engine is already installed.
+
+For example, UE 5.6 requires packaging ~80,000 files totaling 20+ GiB. If you submit a conda build job to AWS Deadline Cloud:
+- **Without compression**: You'd upload a 20GB zip file as a job attachment, and workers would need to download all 20GB before building.
+- **With compression**: Compressing takes time and can reduce the file size to ~10GB, but workers must then decompress it before building, which also takes time.
+
+Either way, the upload/download/decompression overhead makes submitting UE as a job attachment impractical. Building locally on a machine with UE already installed avoids this entirely.
+
+This approach is especially useful for studios using custom UE source builds that aren't available for download.
+
+## Prerequisites
+
+1. **Unreal Engine** installed on your Windows machine
+   - Unreal Engine installed via Epic Games Launcher (e.g., `C:\Program Files\Epic Games\UE_5.6`)
+   - Or your custom source build location
+
+2. **[rattler-build](https://rattler-build.prefix.dev/)** installed locally
+   ```
+   # Using conda
+   conda install -c conda-forge rattler-build
+
+   # Or using pixi
+   pixi global install rattler-build
+   ```
+3. **Enable Windows long path support**
+
+   Follow the [Microsoft documentation](https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry) to enable long path support.
+
+4. **AWS CLI** configured with credentials that have write access to your S3 conda channel
+
+## Adapting the Recipe for Your UE Version
+
+Before building, update `recipe/recipe.yaml` to match your Unreal Engine installation:
+
+1. **Update the version**:
+   ```yaml
+   context:
+     name: "unrealengine"
+     version: "5.4"  # Your UE version
+   ```
+
+2. **Update the source path**:
+   ```yaml
+   source:
+     - path: 'C:\Program Files\Epic Games\UE_5.4\Engine'  # Your UE Engine path
+   ```
+
+   For custom source builds:
+   ```yaml
+   source:
+     - path: 'D:\UnrealEngine\Engine'  # Your custom build path
+   ```
+
+## Building the Package Locally
+
+1. Publish a conda package by running rattler-build:
+   ```
+   rattler-build publish <path-to-recipe-file> --to <publish-conda-channel>
+   ```
+
+   The build process will:
+   - Copy the Engine directory from your UE installation
+   - Exclude non-essential files (documentation, source code, build artifacts, etc.)
+   - Create a conda package in the channel
+   - For building a test package, use the `package-format` option to reduce compression level and speed up the build process. 
+   ```
+   --package-format conda:0
+   ```
+
+   The channel can be on prefix.dev, anaconda.org, an S3 bucket, a local filesystem folder (or network mount), or a Quetz or Artifactory instance. See the [rattler-build publish documentation](https://rattler-build.prefix.dev/v0.55.0/publish/) for details.
+
+   > **Note:** The build may take up to 90 minutes depending on your disk speed.
+
+## Uploading to Your S3 Conda Channel
+
+If not published to an S3 conda channel in the step above, upload the package manually:
+
+1. Locate the built package in <publish-conda-channel>
+
+2. Upload to your S3 channel:
+   ```
+   aws s3 cp <path-to-generated-conda-package> <s3-conda-channel>
+   ```
+
+3. Update the channel index using [rattler-index](https://prefix.dev/channels/conda-forge/packages/rattler-index):
+   ```
+   # Install rattler-index if not already installed
+   conda install -c conda-forge rattler-index
+
+   # Reindex your conda channel, then sync to S3
+   rattler-index <conda-channel-path>
+   aws s3 sync <conda-channel-path> <s3-conda-channel>
+   ```
+
+## Recipe Details
+
+### Excluded Files
+
+The recipe excludes the following to reduce package size:
+
+| Category | Patterns |
+|----------|----------|
+| Directories | Documentation, Extras, Samples, Templates, FeaturePacks, Intermediate, DerivedDataCache, Saved, Build, Source, Restricted |
+| Build artifacts | `*.ipdb`, `*.iobj`, `*.exp`, `*.ilk`, `*.obj`, `*.log` |
+| Source files | `*.cpp`, `*.c`, `*.inl`, `*.hpp`, `*.cs` |
+| Dev files | `*.vcxproj`, `*.sln`, `*.filters`, `*.user`, `*.rc`, `*.manifest`, `*.pdb`, `*.lib` |
+
+For custom source builds, you may need to adjust these exclusions based on your build configuration.
+
+## Troubleshooting
+
+**Build fails with "path not found"**
+- Verify UE is installed and the path in `recipe.yaml` is correct

--- a/conda_recipes/unreal-engine/recipe/recipe.yaml
+++ b/conda_recipes/unreal-engine/recipe/recipe.yaml
@@ -11,13 +11,15 @@ package:
   version: ${{ version }}
 
 source:
-  - path: 'C:\Program Files\Epic Games\UE_5.6\Engine'
+  - path: 'C:\Program Files\Epic Games\UE_${{ version }}\Engine'
 
 build:
   number: ${{ build_number }}
   string: ${{ build_number }}
   script:
+    # Creating the Engine directory structure in the conda prefix dir
     - if not exist "%PREFIX%\Engine" mkdir "%PREFIX%\Engine"
+    # Using robocopy to efficiently copy files while preserving attributes
     - robocopy "%SRC_DIR%" "%PREFIX%\Engine" /E /COPY:DAT /R:1 /W:1 & if %ERRORLEVEL% LEQ 7 (exit /b 0) else (exit /b %ERRORLEVEL%)
   files:
     exclude:
@@ -55,6 +57,10 @@ build:
       - "**/*.manifest"
       - "**/*.pdb"
       - "**/*.lib"
+
+tests:
+  - script:
+    - if not exist "%PREFIX%\Engine\Binaries\Win64\UnrealEditor.exe" exit 1
 
 about:
   homepage: https://www.unrealengine.com/

--- a/conda_recipes/unreal-engine/recipe/recipe.yaml
+++ b/conda_recipes/unreal-engine/recipe/recipe.yaml
@@ -1,0 +1,60 @@
+context:
+  name: "unrealengine"
+  version: "5.6"
+  # build_number: Used for both version ordering (number) and filename (string).
+  # Increment when rebuilding the same version. Output: unrealengine-{version}-{build_number}.conda
+  build_number: 0
+
+  
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  - path: 'C:\Program Files\Epic Games\UE_5.6\Engine'
+
+build:
+  number: ${{ build_number }}
+  string: ${{ build_number }}
+  script:
+    - if not exist "%PREFIX%\Engine" mkdir "%PREFIX%\Engine"
+    - robocopy "%SRC_DIR%" "%PREFIX%\Engine" /E /COPY:DAT /R:1 /W:1 & if %ERRORLEVEL% LEQ 7 (exit /b 0) else (exit /b %ERRORLEVEL%)
+  files:
+    exclude:
+      # Directories to exclude
+      - "**/Documentation/**"
+      - "**/Extras/**"
+      - "**/Samples/**"
+      - "**/Templates/**"
+      - "**/FeaturePacks/**"
+      - "**/Intermediate/**"
+      - "**/DerivedDataCache/**"
+      - "**/Saved/**"
+      - "**/Build/**"
+      - "**/Source/**"
+      - "**/Restricted/**"
+      # Build artifacts
+      - "**/*.ipdb"
+      - "**/*.iobj"
+      - "**/*.exp"
+      - "**/*.ilk"
+      - "**/*.obj"
+      - "**/*.log"
+      # Source code files
+      - "**/*.cpp"
+      - "**/*.c"
+      - "**/*.inl"
+      - "**/*.hpp"
+      - "**/*.cs"
+      # Other development files
+      - "**/*.vcxproj"
+      - "**/*.sln"
+      - "**/*.filters"
+      - "**/*.user"
+      - "**/*.rc"
+      - "**/*.manifest"
+      - "**/*.pdb"
+      - "**/*.lib"
+
+about:
+  homepage: https://www.unrealengine.com/


### PR DESCRIPTION
feat: add conda recipe sample for Unreal Engine using rattler-build

### What was the problem/requirement? (What/Why)
There was a need to provide a sample conda recipe demonstrating how to package Unreal Engine for use with AWS Deadline Cloud. This is essential for customers who use Unreal Engine source build to render content. 

### What was the solution? (How)
Unreal Engine is too large (~80,000 files, 20+ GiB) to package using the standard Deadline Cloud job submission workflow. Uploading as a job attachment—whether compressed or not—creates significant overhead from upload/download/decompression time. This PR adds a UE conda recipe designed for local builds on machines where UE is already installed. Users can then publish directly to their S3 conda channel using rattler-build.

### What is the impact of this change?
Provides developers and customers a conda recipe examples of packaging a Unreal Engine as a conda package so it can be used alongside Unreal Engine applications in the Deadline Cloud ecosystem.

### How was this change tested?
Rendered UE jobs successfully in CMF and SMF. 

Screenshot of successful run in SMF:

<img width="1592" height="1080" alt="Screenshot 2026-01-02 at 2 21 08 PM" src="https://github.com/user-attachments/assets/f9bf16e8-0ba5-472f-a4c9-65460adba58a" />

### Was this change documented?
Yes, a README.md is added as part of the PR 

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*