### PR TITLE
feat: Adds a worker configuration script to install fonts on Linux SMF

### DIFF
--- a/host_configuration_scripts/linux_font_installation/README.md
+++ b/host_configuration_scripts/linux_font_installation/README.md
@@ -1,0 +1,58 @@
+# AWS Deadline Cloud Font Installation
+
+This script installs fonts from an S3 bucket on AWS Deadline Cloud service managed fleet instances, making them available to applications like Nuke.
+
+Be aware that fonts may render differently from operating system to operating system.
+
+## Setup
+
+### 1. Upload Fonts to S3
+Upload your font files to an S3 bucket:
+```bash
+aws s3 cp /path/to/your/fonts/ s3://your-bucket-name/Fonts/ --recursive
+```
+
+Using a separate folder for fonts is optional; beware this script will copy over everything in that folder. Making sure only fonts are getting moved will save time at instance startup.
+
+### 2. Configure the Script
+Edit `font_install_host_config.sh` and update these variables:
+```bash
+S3_FONTS_URI="s3://your-bucket-name/Fonts/"
+JOB_USER="job-user"  # This is job-user by default, update if needed
+```
+
+### 3. Add IAM Policy to Fleet
+Your Deadline Cloud fleet needs S3 read permissions. Add this policy to your fleet's IAM role:
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetObject",
+                "s3:ListBucket"
+            ],
+            "Resource": [
+                "arn:aws:s3:::your-bucket-name",
+                "arn:aws:s3:::your-bucket-name/Fonts/*"
+            ]
+        }
+    ]
+}
+```
+
+Replace `your-bucket-name` with your actual S3 bucket name.
+
+## Usage
+
+Deploy the script through the AWS Deadline Cloud console:
+
+1. Open the AWS Deadline Cloud console
+2. Navigate to your fleet
+3. Go to the "Host configuration" section
+4. Copy and paste the contents of `font_install_host_config.sh` into the script field
+5. Save the configuration
+
+New fleet instances will automatically run the font installation script on startup.

--- a/host_configuration_scripts/linux_font_installation/README.md
+++ b/host_configuration_scripts/linux_font_installation/README.md
@@ -1,6 +1,6 @@
 # AWS Deadline Cloud Font Installation
 
-This script installs fonts from an S3 bucket on AWS Deadline Cloud service managed fleet instances, making them available to applications like Nuke.
+This script installs fonts from an S3 bucket on AWS Deadline Cloud Linux service managed fleet instances, making them available to applications like Nuke.
 
 Be aware that fonts may render differently from operating system to operating system.
 

--- a/host_configuration_scripts/linux_font_installation/font_install_host_config.sh
+++ b/host_configuration_scripts/linux_font_installation/font_install_host_config.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -e  # Exit on any error
+
+# Configuration - update these for your environment
+S3_FONTS_URI="s3://your-bucket-name/Fonts/"
+JOB_USER="job-user"
+
+echo "[$(date)] Starting font installation..."
+echo "S3 URI: $S3_FONTS_URI"
+echo "Job User: $JOB_USER"
+
+# Install fontconfig (required for font management)
+echo "Installing fontconfig..."
+yum install -y fontconfig
+
+# Create fonts directory
+echo "Creating fonts directory..."
+mkdir -p "/home/$JOB_USER/.fonts"
+
+# Download fonts with error checking
+echo "Downloading fonts from S3..."
+if aws s3 cp "$S3_FONTS_URI" "/home/$JOB_USER/.fonts" --recursive; then
+    echo "Fonts downloaded successfully"
+else
+    echo "ERROR: Failed to download fonts from S3"
+    exit 1
+fi
+
+# Set proper ownership
+echo "Setting font ownership..."
+chown -R "$JOB_USER:$JOB_USER" "/home/$JOB_USER/.fonts"
+
+# Refresh font cache
+echo "Refreshing font cache..."
+runuser -l "$JOB_USER" -c "fc-cache -fv /home/$JOB_USER/.fonts"
+
+# List installed fonts for verification
+echo "Installed fonts:"
+ls -la "/home/$JOB_USER/.fonts/"
+
+# Test font detection
+echo "Available fonts to applications:"
+runuser -l "$JOB_USER" -c "fc-list"
+
+echo "[$(date)] Font installation completed successfully"

--- a/host_configuration_scripts/linux_font_installation/font_install_host_config.sh
+++ b/host_configuration_scripts/linux_font_installation/font_install_host_config.sh
@@ -22,7 +22,7 @@ echo "Downloading fonts from S3..."
 if aws s3 cp "$S3_FONTS_URI" "/home/$JOB_USER/.fonts" --recursive; then
     echo "Fonts downloaded successfully"
 else
-    echo "ERROR: Failed to download fonts from S3"
+    echo "ERROR: Failed to download fonts from S3. Ensure the fleet role has access to the S3 bucket"
     exit 1
 fi
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

I needed to use fonts that aren't included on the service managed fleet image.

### What was the solution? (How)

Download the font(s) from an S3 bucket and install them. This needs administrator powers, so I used a worker configuration script.

### What is the impact of this change?

If you need a font on a Linux SMF you'll be able to use it. Assuming the font renders as expected, which isn't guaranteed.

### How was this change tested?

Submitted a Nuke job that uses the font 'Arial' in and saw the text in the output image.

<img width="1024" height="778" alt="output" src="https://github.com/user-attachments/assets/4dc6fa37-d1fc-4ce8-8f7c-992b09fbb121" />

[NukeTextTest.nk.zip](https://github.com/user-attachments/files/24458674/NukeTextTest.nk.zip)

### Was this change documented?

Yes, included a README.md.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*