### PR TITLE
feat: Add a worker configuration script to install 3dsMax and Corona

### DIFF
--- a/host_configuration_scripts/3dsmax/3dsmax-2025-and-corona-13/3dsmax-2025-and-corona.ps1
+++ b/host_configuration_scripts/3dsmax/3dsmax-2025-and-corona-13/3dsmax-2025-and-corona.ps1
@@ -1,0 +1,72 @@
+<#
+This is an example host configuration script that downloads and installs 3dsMax 2025 and Corona 13 for 3dsMax 2025.
+You can configure a Windows Service-Managed Fleet to use this host configuration to render your 3dsMax 2025 + Corona jobs.
+This script was tested with the 3dsMax 2025.2 and Corona 13 installers.
+
+Requirements:
+- S3 bucket to host both the 3ds Max 2025 and Corona installers
+- Your fleet role must have permissions to s3:GetObject both the installer files from your S3 bucket.
+#>
+
+# TODO: Replace the below value with your bucket name
+$BUCKET_NAME="your-bucket-name"
+
+# TODO: Replace this with your 3dsMax folder name
+$3DS_MAX_FOLDER_NAME="3ds Max 2025.2 Update - (EN)"
+
+# TODO: Replace this with your 3dsMax zip file name
+$3DS_MAX_ZIP_FILE="$3DS_MAX_FOLDER_NAME.zip"
+
+# TODO: Replace this with your Corona for 3dsMax 2025 installer file name
+$CORONA_FOR_3DS_MAX2025_INSTALLER_FILE="chaos-corona-13-3dsmax-hotfix1.exe"
+
+Write-Host " --- Installing 3dsMax 2025 --- "
+
+mkdir C:\3dsmax_setup -Force
+aws s3 cp --no-progress "s3://$BUCKET_NAME/$3DS_MAX_ZIP_FILE" C:\3dsmax_setup\3dsmax.zip
+Expand-Archive C:\3dsmax_setup\3dsmax.zip C:\3dsmax_setup\
+Start-Process -FilePath "C:\3dsmax_setup\$3DS_MAX_FOLDER_NAME\Setup.exe" -ArgumentList "-q" -Wait -PassThru
+
+Write-Host " --- Installing Corona --- " 
+aws s3 cp --no-progress "s3://$BUCKET_NAME/$CORONA_FOR_3DS_MAX2025_INSTALLER_FILE" C:\3dsmax_setup\ 
+
+Write-Host " --- Starting Corona Install --- " 
+& "C:\3dsmax_setup\$CORONA_FOR_3DS_MAX2025_INSTALLER_FILE" -gui=0 -auto
+
+$content = @"
+<VRLClient>
+        <LicServer>
+                <Host>127.0.0.1</Host>
+                <Port>30304</Port>
+                <Host1>localhost</Host1>
+                <Port1>30304</Port1>
+                <Host2></Host2>
+                <Port2>30304</Port2>
+                <User></User>
+                <Pass></Pass>
+        </LicServer>
+</VRLClient>
+"@
+
+# Create the file with elevated privileges due to Program Files location
+$path = "C:\Program Files\Common Files\ChaosGroup\vrlclient.xml"
+Set-Content -Path $path -Value $content -Force
+
+Write-Host " --- Post install setup --- " 
+
+# This needs to point to the directory, not the file itself. Corona uses the same licensing structure as V-Ray
+[Environment]::SetEnvironmentVariable("VRAY_AUTH_CLIENT_FILE_PATH", "C:\Program Files\Common Files\ChaosGroup", "Machine")
+
+[Environment]::SetEnvironmentVariable("Path", "C:\Program Files\Autodesk\3ds Max 2025;" + [Environment]::GetEnvironmentVariable("Path", "Machine"), "Machine") 
+
+& "C:\Program Files\Autodesk\3ds Max 2025\Python\python.exe" -m ensurepip 
+
+& "C:\Program Files\Autodesk\3ds Max 2025\Python\python.exe" -m pip install deadline-cloud-for-3ds-max 
+
+[Environment]::SetEnvironmentVariable("3DSMAX_EXECUTABLE", "C:\Program Files\Autodesk\3ds Max 2025\3dsmaxbatch.exe", "Machine")
+
+[Environment]::SetEnvironmentVariable("PYTHONPATH", "C:\Program Files\Autodesk\3ds Max 2025\Python;C:\Program Files\Autodesk\3ds Max 2025\Python\Scripts", "Machine") 
+
+[Environment]::SetEnvironmentVariable("Path", "C:\Program Files\Autodesk\3ds Max 2025\Python;C:\Program Files\Autodesk\3ds Max 2025\Python\Scripts;" + [Environment]::GetEnvironmentVariable("Path", "Machine"), "Machine")
+
+Exit 0

--- a/host_configuration_scripts/3dsmax/3dsmax-2025-and-corona-13/3dsmax-2025-and-corona.ps1
+++ b/host_configuration_scripts/3dsmax/3dsmax-2025-and-corona-13/3dsmax-2025-and-corona.ps1
@@ -1,0 +1,72 @@
+<#
+This is an example host configuration script that downloads and installs 3dsMax 2025 and Corona 13 for 3dsMax 2025.
+You can configure a Windows Service-Managed Fleet to use this host configuration to render your 3dsMax 2025 + Corona jobs.
+This script was tested with the 3dsMax 2025.2 and Corona 13 installers.
+
+Requirements:
+- S3 bucket to host both the 3ds Max 2025 and Corona installers
+- Your fleet role must have permissions to s3:GetObject both the installer files from your S3 bucket.
+#>
+
+# TODO: Replace the below value with your bucket name
+$BUCKET_NAME="your-bucket-name"
+
+# TODO: Replace this with your 3dsMax folder name
+$3DS_MAX_FOLDER_NAME="3ds Max 2025.2 Update - (EN)"
+
+# TODO: Replace this with your 3dsMax zip file name
+$3DS_MAX_ZIP_FILE="$3DS_MAX_FOLDER_NAME.zip"
+
+# TODO: Replace this with your Corona for 3dsMax 2025 installer file name
+$CORONA_FOR_3DS_MAX2025_INSTALLER_FILE="chaos-corona-13-3dsmax-hotfix1.exe"
+
+Write-Host ' --- Installing 3dsMax 2025 --- '
+
+mkdir C:\3dsmax_setup -Force
+aws s3 cp --no-progress "s3://$BUCKET_NAME/$3DS_MAX_ZIP_FILE" C:\3dsmax_setup\3dsmax.zip
+Expand-Archive C:\3dsmax_setup\3dsmax.zip C:\3dsmax_setup\
+Start-Process "C:\3dsmax_setup\$3DS_MAX_FOLDER_NAME\Setup.exe" -ArgumentList '-q' -Wait
+
+Write-Host " --- Installing Corona --- " 
+aws s3 cp --no-progress "s3://$BUCKET_NAME/$CORONA_FOR_3DS_MAX2025_INSTALLER_FILE" C:\3dsmax_setup\ 
+
+Write-Host " --- Starting Corona Install --- " 
+C:\3dsmax_setup\$CORONA_FOR_3DS_MAX2025_INSTALLER_FILE -gui=0 -auto
+
+$content = @"
+<VRLClient>
+        <LicServer>
+                <Host>127.0.0.1</Host>
+                <Port>30304</Port>
+                <Host1>localhost</Host1>
+                <Port1>30304</Port1>
+                <Host2></Host2>
+                <Port2>30304</Port2>
+                <User></User>
+                <Pass></Pass>
+        </LicServer>
+</VRLClient>
+"@
+
+# Create the file with elevated privileges due to Program Files location
+$path = "C:\Program Files\Common Files\ChaosGroup\vrlclient.xml"
+Set-Content -Path $path -Value $content -Force
+
+Write-Host " --- Post install setup --- " 
+
+# This needs to point to the directory, not the file itself. Corona uses the same licensing structure as V-Ray
+[Environment]::SetEnvironmentVariable("VRAY_AUTH_CLIENT_FILE_PATH", "C:\Program Files\Common Files\ChaosGroup", "Machine")
+
+[Environment]::SetEnvironmentVariable("Path", "C:\Program Files\Autodesk\3ds Max 2025;" + [Environment]::GetEnvironmentVariable("Path", "Machine"), "Machine") 
+
+& "C:\Program Files\Autodesk\3ds Max 2025\Python\python.exe" -m ensurepip 
+
+& "C:\Program Files\Autodesk\3ds Max 2025\Python\python.exe" -m pip install deadline-cloud-for-3ds-max 
+
+[Environment]::SetEnvironmentVariable("3DSMAX_EXECUTABLE", "C:\Program Files\Autodesk\3ds Max 2025\3dsmaxbatch.exe", "Machine")
+
+[Environment]::SetEnvironmentVariable("PYTHONPATH", "C:\Program Files\Autodesk\3ds Max 2025\Python;C:\Program Files\Autodesk\3ds Max 2025\Python\Scripts", "Machine") 
+
+[Environment]::SetEnvironmentVariable("Path", "C:\Program Files\Autodesk\3ds Max 2025\Python;C:\Program Files\Autodesk\3ds Max 2025\Python\Scripts;" + [Environment]::GetEnvironmentVariable("Path", "Machine"), "Machine")
+
+Exit 0


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Render with 3dsMax and Corona, and use bring-your-own licenses (BYOL).

### What was the solution? (How)

Attached Worker configuration.

### What is the impact of this change?

I can now render 3dsMax+Corona scene files using BYOL.

### How was this change tested?

Updated the bucket name in the script to point to one with the needed software, set up [BYOL for service managed fleets](https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/smf-byol.html) and send off a 3dsMax and Corona scene file.

Below is launching 3dsmax and the first report of a rendering pass from Corona:
```
2026/01/12 09:18:08-06:00 ==============================================
2026/01/12 09:18:08-06:00 --------- Entering Environment: 3ds Max
2026/01/12 09:18:08-06:00 ==============================================
2026/01/12 09:18:08-06:00 ----------------------------------------------
2026/01/12 09:18:08-06:00 Phase: Setup
2026/01/12 09:18:08-06:00 ----------------------------------------------
2026/01/12 09:18:08-06:00 Writing embedded files for Environment to disk.
2026/01/12 09:18:08-06:00 Mapping: Env.File.initData -> C:\Sessions\session-17c464b37b8e4048897f5ae400b385f15rfr7h62\embedded_files5zxcfjdk\init-data.yaml
2026/01/12 09:18:08-06:00 Mapping: Env.File.runStart -> C:\Sessions\session-17c464b37b8e4048897f5ae400b385f15rfr7h62\embedded_files5zxcfjdk\start.bat
2026/01/12 09:18:08-06:00 Mapping: Env.File.runStop -> C:\Sessions\session-17c464b37b8e4048897f5ae400b385f15rfr7h62\embedded_files5zxcfjdk\stop.bat
2026/01/12 09:18:08-06:00 Wrote: initData -> C:\Sessions\session-17c464b37b8e4048897f5ae400b385f15rfr7h62\embedded_files5zxcfjdk\init-data.yaml
2026/01/12 09:18:08-06:00 Wrote: runStart -> C:\Sessions\session-17c464b37b8e4048897f5ae400b385f15rfr7h62\embedded_files5zxcfjdk\start.bat
2026/01/12 09:18:08-06:00 Wrote: runStop -> C:\Sessions\session-17c464b37b8e4048897f5ae400b385f15rfr7h62\embedded_files5zxcfjdk\stop.bat
2026/01/12 09:18:08-06:00 ----------------------------------------------
2026/01/12 09:18:08-06:00 Phase: Running action
2026/01/12 09:18:08-06:00 ----------------------------------------------
2026/01/12 09:18:08-06:00 Running command C:\Windows\System32\WindowsPowerShell\v1.0\powershell.EXE C:\Sessions\session-17c464b37b8e4048897f5ae400b385f15rfr7h62\embedded_files5zxcfjdk\start.bat
2026/01/12 09:18:08-06:00 Command started as pid: 2144
2026/01/12 09:18:08-06:00 Output:
2026/01/12 09:18:09-06:00  
2026/01/12 09:18:09-06:00 C:\Sessions\session-17c464b37b8e4048897f5ae400b385f15rfr7h62>3dsmax-openjd daemon start --connection-file C:\Sessions\session-17c464b37b8e4048897f5ae400b385f15rfr7h62/connection.json --init-data file://C:\Sessions\session-17c464b37b8e4048897f5ae400b385f15rfr7h62\embedded_files5zxcfjdk\init-data.yaml 
2026/01/12 09:18:09-06:00 PYTHONPATH is not set to ""C:\\Program Files\\Autodesk\\3ds Max 2025\\Python"" - overriding setting for the current session
2026/01/12 09:18:09-06:00  
2026/01/12 09:18:09-06:00 INFO: Creating empty configuration at C:\Users\job-user\.openjd\adaptors\runtime\configuration.json
2026/01/12 09:18:09-06:00 INFO: Applying user-level configuration: C:\Users\job-user\.openjd\adaptors\runtime\configuration.json
2026/01/12 09:18:09-06:00 INFO: Creating empty configuration at C:\Users\job-user\.openjd\adaptors\MaxAdaptor\MaxAdaptor.json
2026/01/12 09:18:09-06:00 INFO: Applying user-level configuration: C:\Users\job-user\.openjd\adaptors\MaxAdaptor\MaxAdaptor.json
2026/01/12 09:18:09-06:00 INFO: Initializing backend process...
2026/01/12 09:18:09-06:00 INFO: Running process with args: ['C:\\Program Files\\Autodesk\\3ds Max 2025\\Python\\python.exe', '-m', 'deadline.max_adaptor.MaxAdaptor', 'daemon', '_serve', '--init-data', '{"scene_file": "C:\\\\Sessions\\\\session-17c464b37b8e4048897f5ae400b385f15rfr7h62\\\\assetroot-4556e00dfadb47e9bcb1\\\\_scene.max", "renderer": "Corona", "state_set": "State01", "output_file_name": "State01__scene_###", "output_file_path": "C:\\\\Sessions\\\\session-17c464b37b8e4048897f5ae400b385f15rfr7h62\\\\assetroot-4556e00dfadb47e9bcb1", "output_file_format": ".jpg", "image_width": "1024", "image_height": "576"}', '--path-mapping-rules', '{}', '--connection-file', 'C:\\Sessions\\session-17c464b37b8e4048897f5ae400b385f15rfr7h62\\connection.json', '--bootstrap-log-file', 'C:\\Users\\job-user\\AppData\\Local\\Temp\\adaptor-runtime-background-bootstrap-9a7e4126-fefe-4b70-b425-e2beda8dbd79.log']
2026/01/12 09:18:09-06:00 INFO: Started backend process. PID: 628
2026/01/12 09:18:09-06:00 INFO: Waiting for File 'C:\Sessions\session-17c464b37b8e4048897f5ae400b385f15rfr7h62\connection.json' to exist
2026/01/12 09:18:09-06:00 INFO: Retrying in 1s...
2026/01/12 09:18:11-06:00 INFO: Waiting for File 'C:\Sessions\session-17c464b37b8e4048897f5ae400b385f15rfr7h62\connection.json' to be openable
2026/01/12 09:18:11-06:00 INFO: Waiting for File 'C:\Sessions\session-17c464b37b8e4048897f5ae400b385f15rfr7h62\connection.json' to have valid ConnectionSettings
2026/01/12 09:18:11-06:00 INFO: ========== BEGIN BOOTSTRAP OUTPUT CONTENTS ==========
2026/01/12 09:18:11-06:00 INFO: <frozen runpy>:128: RuntimeWarning: 'deadline.max_adaptor.MaxAdaptor.__main__' found in sys.modules after import of package 'deadline.max_adaptor.MaxAdaptor', but prior to execution of 'deadline.max_adaptor.MaxAdaptor.__main__'; this may result in unpredictable behaviour
2026/01/12 09:18:11-06:00 INFO: INFO: Applying user-level configuration: C:\Users\job-user\.openjd\adaptors\runtime\configuration.json
2026/01/12 09:18:11-06:00 INFO: INFO: Applying user-level configuration: C:\Users\job-user\.openjd\adaptors\MaxAdaptor\MaxAdaptor.json
2026/01/12 09:18:11-06:00 INFO: ========== END BOOTSTRAP OUTPUT CONTENTS ==========
2026/01/12 09:18:11-06:00 INFO: Checking for bootstrap logs at 'C:\Users\job-user\AppData\Local\Temp\adaptor-runtime-background-bootstrap-9a7e4126-fefe-4b70-b425-e2beda8dbd79.log'
2026/01/12 09:18:11-06:00 INFO: ========== BEGIN BOOTSTRAP LOG CONTENTS ==========
2026/01/12 09:18:11-06:00 INFO: [2026-01-12 15:18:10,249][INFO    ] Applying user-level configuration: C:\Users\job-user\.openjd\adaptors\runtime\configuration.json
2026/01/12 09:18:11-06:00 INFO: [2026-01-12 15:18:10,265][INFO    ] Applying user-level configuration: C:\Users\job-user\.openjd\adaptors\MaxAdaptor\MaxAdaptor.json
2026/01/12 09:18:11-06:00 INFO: [2026-01-12 15:18:10,265][INFO    ] Running in background daemon mode.
2026/01/12 09:18:11-06:00 INFO: [2026-01-12 15:18:10,265][INFO    ] Creating Named Pipe with name: \\.\pipe\AdaptorNamedPipe_628
2026/01/12 09:18:11-06:00 INFO: ========== END BOOTSTRAP LOG CONTENTS ==========
2026/01/12 09:18:11-06:00 INFO: Verifying connection to backend...
2026/01/12 09:18:11-06:00 INFO: Connected successfully
2026/01/12 09:18:11-06:00 openjd_env: OPENJD_ADAPTOR_SOCKET=\\.\pipe\AdaptorNamedPipe_628
2026/01/12 09:18:11-06:00 ADAPTOR_OUTPUT: INFO: Running in background daemon mode.
2026/01/12 09:18:11-06:00 ADAPTOR_OUTPUT: INFO: Creating Named Pipe with name: \\.\pipe\AdaptorNamedPipe_628
2026/01/12 09:18:11-06:00 ADAPTOR_OUTPUT: INFO: Loading 'init_data' schema from C:\Program Files\Autodesk\3ds Max 2025\Python\Lib\site-packages\deadline\max_adaptor\MaxAdaptor\schemas\init_data.schema.json
2026/01/12 09:18:11-06:00 ADAPTOR_OUTPUT: INFO: Loading 'run_data' schema from C:\Program Files\Autodesk\3ds Max 2025\Python\Lib\site-packages\deadline\max_adaptor\MaxAdaptor\schemas\run_data.schema.json
2026/01/12 09:18:12-06:00 ADAPTOR_OUTPUT: DEBUG: start max server thread
2026/01/12 09:18:12-06:00 ADAPTOR_OUTPUT: DEBUG: start max server
2026/01/12 09:18:12-06:00 ADAPTOR_OUTPUT: INFO: Creating Named Pipe with name: \\.\pipe\AdaptorServerNamedPipe_628
2026/01/12 09:18:12-06:00 ADAPTOR_OUTPUT: DEBUG: ____action made for scene_file_______
2026/01/12 09:18:12-06:00 ADAPTOR_OUTPUT: DEBUG: ____action made for state_set_______
2026/01/12 09:18:12-06:00 ADAPTOR_OUTPUT: DEBUG: ____action made for output_file_path_______
2026/01/12 09:18:12-06:00 ADAPTOR_OUTPUT: DEBUG: ____action made for output_file_name_______
2026/01/12 09:18:12-06:00 ADAPTOR_OUTPUT: DEBUG: ____action made for output_file_format_______
2026/01/12 09:18:12-06:00 ADAPTOR_OUTPUT: INFO: Render element modification is disabled, skipping render element configuration
2026/01/12 09:18:12-06:00 ADAPTOR_OUTPUT: INFO: Running command: "C:\Program Files\Autodesk\3ds Max 2025\3dsmaxbatch.exe" -dm on -v 5 "C:\Program Files\Autodesk\3ds Max 2025\Python\Lib\site-packages\deadline\max_adaptor\MaxClient\max_client.py"
2026/01/12 09:18:12-06:00 ADAPTOR_OUTPUT: STDOUT: 1/12/2026 15:18:12 PM;  Specified option script: C:\Program Files\Autodesk\3ds Max 2025\Python\Lib\site-packages\deadline\max_adaptor\MaxClient\max_client.py
2026/01/12 09:18:12-06:00 ADAPTOR_OUTPUT: STDOUT: 
2026/01/12 09:18:12-06:00 ADAPTOR_OUTPUT: STDOUT: 1/12/2026 15:18:12 PM;  Specified option dm: 1
2026/01/12 09:18:12-06:00 ADAPTOR_OUTPUT: STDOUT: 
2026/01/12 09:18:12-06:00 ADAPTOR_OUTPUT: STDOUT: 1/12/2026 15:18:12 PM;  Defaulted option li: 0
2026/01/12 09:18:12-06:00 ADAPTOR_OUTPUT: STDOUT: 
2026/01/12 09:18:12-06:00 ADAPTOR_OUTPUT: STDOUT: 1/12/2026 15:18:12 PM;  3ds Max Install Location: C:\Program Files\Autodesk\3ds Max 2025\
2026/01/12 09:18:12-06:00 ADAPTOR_OUTPUT: STDOUT: 
2026/01/12 09:18:12-06:00 ADAPTOR_OUTPUT: STDOUT: 1/12/2026 15:18:12 PM;  3ds Max Executable: 3dsmax.exe
2026/01/12 09:18:12-06:00 ADAPTOR_OUTPUT: STDOUT: 
2026/01/12 09:18:12-06:00 ADAPTOR_OUTPUT: STDOUT: 1/12/2026 15:18:12 PM;  Secure Mode: 'OFF'
2026/01/12 09:18:12-06:00 ADAPTOR_OUTPUT: STDOUT: 
2026/01/12 09:18:12-06:00 ADAPTOR_OUTPUT: STDOUT: 1/12/2026 15:18:12 PM;  Dialog Monitor: On
2026/01/12 09:18:12-06:00 ADAPTOR_OUTPUT: STDOUT: 
2026/01/12 09:18:12-06:00 ADAPTOR_OUTPUT: STDOUT: 1/12/2026 15:18:12 PM;  Script command: " -mxs "(python.ExecuteFile @\"C:\Program Files\Autodesk\3ds Max 2025\Python\Lib\site-packages\deadline\max_adaptor\MaxClient\max_client.py\")""
2026/01/12 09:18:12-06:00 ADAPTOR_OUTPUT: STDOUT: 
2026/01/12 09:18:14-06:00 ADAPTOR_OUTPUT: STDOUT: 1/12/2026 15:18:14 PM;  Product version: 3ds Max 2025.2 (27.2.0.20885)
2026/01/12 09:18:14-06:00 ADAPTOR_OUTPUT: STDOUT: 
2026/01/12 09:18:14-06:00 ADAPTOR_OUTPUT: STDOUT: 1/12/2026 15:18:14 PM;  Data collection and use: personalize your experience and help us identify product improvements by participating in our data collection and usage programs. Learn more about data collection and use: https://www.autodesk.com/company/autodesk-analytics. Autodesk's Privacy Statement: https://www.autodesk.com/company/legal-notices-trademarks/privacy-statement
2026/01/12 09:18:14-06:00 ADAPTOR_OUTPUT: STDOUT: 
2026/01/12 09:18:14-06:00 ADAPTOR_OUTPUT: STDOUT: 1/12/2026 15:18:14 PM;  Data collection and use is 'OFF'. Change your participation anytime in the Help menu of 3ds Max.
2026/01/12 09:18:14-06:00 ADAPTOR_OUTPUT: STDOUT: 
2026/01/12 09:18:50-06:00 ADAPTOR_OUTPUT: STDOUT: 1/12/2026 15:18:49 PM;  ALC Security Tool 1.3 enabled.
2026/01/12 09:18:50-06:00 ADAPTOR_OUTPUT: STDOUT: 
2026/01/12 09:18:50-06:00 ADAPTOR_OUTPUT: STDOUT: 1/12/2026 15:18:49 PM;  ALC2 Security Tool 1.3 enabled.
2026/01/12 09:18:50-06:00 ADAPTOR_OUTPUT: STDOUT: 
2026/01/12 09:18:50-06:00 ADAPTOR_OUTPUT: STDOUT: 1/12/2026 15:18:49 PM;  PhysXPluginMfx Security Tool 1.3 enabled.
2026/01/12 09:18:50-06:00 ADAPTOR_OUTPUT: STDOUT: 
2026/01/12 09:18:50-06:00 ADAPTOR_OUTPUT: STDOUT: 1/12/2026 15:18:49 PM;  PhysXPluginMfx2 Security Tool 1.1 enabled.
2026/01/12 09:18:50-06:00 ADAPTOR_OUTPUT: STDOUT: 
2026/01/12 09:18:50-06:00 ADAPTOR_OUTPUT: STDOUT: 1/12/2026 15:18:49 PM;  CRP Security Tool 1.1 enabled.
2026/01/12 09:18:50-06:00 ADAPTOR_OUTPUT: STDOUT: 
2026/01/12 09:18:50-06:00 ADAPTOR_OUTPUT: STDOUT: 1/12/2026 15:18:49 PM;  ADSL Security Tool 1.1 enabled.
2026/01/12 09:18:50-06:00 ADAPTOR_OUTPUT: STDOUT: 
2026/01/12 09:18:50-06:00 ADAPTOR_OUTPUT: STDOUT: 1/12/2026 15:18:49 PM;  MSCPROP Security Tool 1.0 enabled.
2026/01/12 09:18:50-06:00 ADAPTOR_OUTPUT: STDOUT: 
2026/01/12 09:18:59-06:00 ADAPTOR_OUTPUT: STDOUT: 1/12/2026 15:18:59 PM;  Initializing Python version: 3.11.8
2026/01/12 09:18:59-06:00 ADAPTOR_OUTPUT: STDOUT: 
2026/01/12 09:19:02-06:00 ADAPTOR_OUTPUT: STDOUT: 1/12/2026 15:19:01 PM;  Logger interceptor set up for render element manager
2026/01/12 09:19:02-06:00 ADAPTOR_OUTPUT: STDOUT: 
2026/01/12 09:19:02-06:00 ADAPTOR_OUTPUT: STDOUT: 1/12/2026 15:19:01 PM;  CORONA: Corona is up and running. Corona version: 13 (Hotfix 1), netrender mode: off, slave mode: off, quiet mode: on, Max gamma (display/input/output): 2.2/2.2/2.2
2026/01/12 09:19:02-06:00 ADAPTOR_OUTPUT: STDOUT: 
2026/01/12 09:19:03-06:00 ADAPTOR_OUTPUT: STDOUT: 1/12/2026 15:19:02 PM;  CORONA : Scene uses CoronaPortalMtl which is now deprecated. Portals are no longer needed since Corona version 6 and should be deleted.
2026/01/12 09:19:03-06:00 ADAPTOR_OUTPUT: STDOUT: 
2026/01/12 09:19:03-06:00 ADAPTOR_OUTPUT: STDOUT: 1/12/2026 15:19:02 PM;  CORONA : This scene uses legacy (pre-v4) medium/refraction resolving that is not based on geometry normals and produces incorrect results when multiple medium containers are intersecting. The scene was loaded with the legacy behavior to make the rendered result more consistent with older versions of Corona, but we strongly recommend switching to new behavior using the button below. If normals ...
2026/01/12 09:19:03-06:00 ADAPTOR_OUTPUT: STDOUT: 
2026/01/12 09:19:03-06:00 ADAPTOR_OUTPUT: STDOUT: 1/12/2026 15:19:02 PM;  CORONA : The curve coming from the legacy color mapping configuration is invalid. Default curve will be used.
2026/01/12 09:19:03-06:00 ADAPTOR_OUTPUT: STDOUT: 
2026/01/12 09:19:03-06:00 ADAPTOR_OUTPUT: STDOUT: 1/12/2026 15:19:02 PM;  CORONA : The curve coming from the legacy color mapping configuration is invalid. Default curve will be used.
2026/01/12 09:19:03-06:00 ADAPTOR_OUTPUT: STDOUT: 
2026/01/12 09:19:03-06:00 ADAPTOR_OUTPUT: STDOUT: 1/12/2026 15:19:02 PM;  CORONA : The curve coming from the legacy color mapping configuration is invalid. Default curve will be used.
2026/01/12 09:19:03-06:00 ADAPTOR_OUTPUT: STDOUT: 
2026/01/12 09:19:03-06:00 ADAPTOR_OUTPUT: STDOUT: 1/12/2026 15:19:02 PM;  CORONA : The curve coming from the legacy color mapping configuration is invalid. Default curve will be used.
2026/01/12 09:19:03-06:00 ADAPTOR_OUTPUT: STDOUT: 
2026/01/12 09:19:03-06:00 ADAPTOR_OUTPUT: STDOUT: 1/12/2026 15:19:02 PM;  CORONA : This scene uses legacy (pre-v12 Update 2) map filtering. This filtering may result in blurred textures, when they are viewed through reflection or refraction or viewed directly using non-standard camera projections (e.g. spherical).
2026/01/12 09:19:03-06:00 ADAPTOR_OUTPUT: STDOUT: 
2026/01/12 09:19:04-06:00 ADAPTOR_OUTPUT: STDOUT: 1/12/2026 15:19:03 PM;  MAXScript Evaluate MXSWrapperBase Exception: -- Unknown property: "count" in get_Item()
2026/01/12 09:19:04-06:00 ADAPTOR_OUTPUT: STDOUT: 
2026/01/12 09:19:04-06:00 ADAPTOR_OUTPUT: STDOUT: 1/12/2026 15:19:03 PM;  MAXScript Evaluate MXSWrapperBase Exception: -- Unknown property: "count" in get_Item()
2026/01/12 09:19:04-06:00 ADAPTOR_OUTPUT: STDOUT: 
2026/01/12 09:19:04-06:00 INFO: Done MaxAdaptor main
2026/01/12 09:19:04-06:00 Process pid 2144 exited with code: 0 (unsigned) / 0x0 (hex)
2026/01/12 09:19:04-06:00  
2026/01/12 09:19:04-06:00 ==============================================
2026/01/12 09:19:04-06:00 --------- Running Task
2026/01/12 09:19:04-06:00 ==============================================
2026/01/12 09:19:04-06:00 Parameter values:
2026/01/12 09:19:04-06:00 Frame(INT) = 0
2026/01/12 09:19:04-06:00 Camera(STRING) = Camera001
2026/01/12 09:19:04-06:00 ----------------------------------------------
2026/01/12 09:19:04-06:00 Phase: Setup
2026/01/12 09:19:04-06:00 ----------------------------------------------
2026/01/12 09:19:04-06:00 Writing embedded files for Task to disk.
2026/01/12 09:19:04-06:00 Mapping: Task.File.runData -> C:\Sessions\session-17c464b37b8e4048897f5ae400b385f15rfr7h62\embedded_files5zxcfjdk\run-data.yaml
2026/01/12 09:19:04-06:00 Mapping: Task.File.runRender -> C:\Sessions\session-17c464b37b8e4048897f5ae400b385f15rfr7h62\embedded_files5zxcfjdk\render.bat
2026/01/12 09:19:04-06:00 Wrote: runData -> C:\Sessions\session-17c464b37b8e4048897f5ae400b385f15rfr7h62\embedded_files5zxcfjdk\run-data.yaml
2026/01/12 09:19:04-06:00 Wrote: runRender -> C:\Sessions\session-17c464b37b8e4048897f5ae400b385f15rfr7h62\embedded_files5zxcfjdk\render.bat
2026/01/12 09:19:04-06:00 ----------------------------------------------
2026/01/12 09:19:04-06:00 Phase: Running action
2026/01/12 09:19:04-06:00 ----------------------------------------------
2026/01/12 09:19:04-06:00 Running command C:\Windows\System32\WindowsPowerShell\v1.0\powershell.EXE C:\Sessions\session-17c464b37b8e4048897f5ae400b385f15rfr7h62\embedded_files5zxcfjdk\render.bat
2026/01/12 09:19:04-06:00 Command started as pid: 5792
2026/01/12 09:19:04-06:00 Output:
2026/01/12 09:19:04-06:00  
2026/01/12 09:19:04-06:00 C:\Sessions\session-17c464b37b8e4048897f5ae400b385f15rfr7h62>3dsmax-openjd daemon run --connection-file C:\Sessions\session-17c464b37b8e4048897f5ae400b385f15rfr7h62/connection.json --run-data file://C:\Sessions\session-17c464b37b8e4048897f5ae400b385f15rfr7h62\embedded_files5zxcfjdk\run-data.yaml 
2026/01/12 09:19:04-06:00 PYTHONPATH is not set to ""C:\\Program Files\\Autodesk\\3ds Max 2025\\Python"" - overriding setting for the current session
2026/01/12 09:19:04-06:00  
2026/01/12 09:19:05-06:00 INFO: Applying user-level configuration: C:\Users\job-user\.openjd\adaptors\runtime\configuration.json
2026/01/12 09:19:05-06:00 INFO: Applying user-level configuration: C:\Users\job-user\.openjd\adaptors\MaxAdaptor\MaxAdaptor.json
2026/01/12 09:19:05-06:00 ADAPTOR_OUTPUT: 
2026/01/12 09:19:05-06:00 ADAPTOR_OUTPUT: INFO: Loading 'init_data' schema from C:\Program Files\Autodesk\3ds Max 2025\Python\Lib\site-packages\deadline\max_adaptor\MaxAdaptor\schemas\init_data.schema.json
2026/01/12 09:19:05-06:00 ADAPTOR_OUTPUT: INFO: Loading 'run_data' schema from C:\Program Files\Autodesk\3ds Max 2025\Python\Lib\site-packages\deadline\max_adaptor\MaxAdaptor\schemas\run_data.schema.json
2026/01/12 09:19:09-06:00 ADAPTOR_OUTPUT: STDOUT: 1/12/2026 15:19:08 PM;  CORONA : Parsing scene
2026/01/12 09:19:09-06:00 ADAPTOR_OUTPUT: STDOUT: 
2026/01/12 09:19:12-06:00 ADAPTOR_OUTPUT: STDOUT: 1/12/2026 15:19:11 PM;  CORONA : Calculating displacement
2026/01/12 09:19:12-06:00 ADAPTOR_OUTPUT: STDOUT: 
2026/01/12 09:19:12-06:00 ADAPTOR_OUTPUT: STDOUT: 1/12/2026 15:19:11 PM;  CORONA : Preparing geometry
2026/01/12 09:19:12-06:00 ADAPTOR_OUTPUT: STDOUT: 
2026/01/12 09:19:12-06:00 ADAPTOR_OUTPUT: STDOUT: 1/12/2026 15:19:11 PM;  CORONA : Preparing lights
2026/01/12 09:19:12-06:00 ADAPTOR_OUTPUT: STDOUT: 
2026/01/12 09:19:12-06:00 ADAPTOR_OUTPUT: STDOUT: 1/12/2026 15:19:11 PM;  CORONA : Computing sec. GI
2026/01/12 09:19:12-06:00 ADAPTOR_OUTPUT: STDOUT: 
2026/01/12 09:19:16-06:00 ADAPTOR_OUTPUT: STDOUT: 1/12/2026 15:19:15 PM;  CORONA : Rendering initial pass
2026/01/12 09:19:16-06:00 ADAPTOR_OUTPUT: STDOUT: 
2026/01/12 09:19:18-06:00 ADAPTOR_OUTPUT: STDOUT: 1/12/2026 15:19:17 PM;  CORONA : Rendering pass 2
```

### Was this change documented?

The instructions in [the README](https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/host_configuration_scripts/README.md) covers use and troubleshooting, and the script itself has #TODO callouts where users need to input their bucket name and file name(s). 

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*