### PR TITLE
feat: add V-Ray tile render job bundle for Linux workers

### DIFF
--- a/conda_recipes/vray/README.md
+++ b/conda_recipes/vray/README.md
@@ -18,3 +18,7 @@ From the `conda_recipes` directory, run the following command to submit a packag
 ```sh
 $ ./submit-package-job vray
 ```
+
+The `submit-package-job` command can be run from any platform (macOS, Windows, or Linux) - it submits a job to Deadline Cloud where a Linux worker builds the package and uploads it to your S3 conda channel.
+
+**Note**: The queue's IAM role needs `s3:PutObject` permission for the `Conda/*` prefix in the job attachments bucket to publish the built package.

--- a/job_bundles/tile_render_with_vray_linux/README.md
+++ b/job_bundles/tile_render_with_vray_linux/README.md
@@ -1,0 +1,73 @@
+# V-Ray Region Render Sample Job Bundle
+
+This job bundle renders a V-Ray scene by dividing the image into configurable regions, rendering each region as a separate task, and then merging them into a final image.
+
+## Features
+
+- **Parallel Region Rendering**: Divides the image into a grid of regions (configurable rows and columns)
+- **Separate Tasks**: Each region renders as an independent task that can run in parallel
+- **Automatic Merging**: A final step merges all regions into the complete image
+- **Configurable Grid**: Control the number of rows and columns to balance parallelism and overhead
+
+## How It Works
+
+1. **RenderRegions Step**: Creates tasks for each region based on `RegionColumns × RegionRows`
+   - Each task calculates its region bounds (left, top, right, bottom)
+   - Renders only that region using V-Ray's `-region` flag
+   - Outputs to a separate file: `output_region_0.png`, `output_region_1.png`, etc.
+
+2. **MergeRegions Step**: Combines all region files into the final image
+   - Uses ImageMagick's `montage` command to stitch regions together
+   - Creates the final output file specified in parameters
+
+## Prerequisites
+
+- V-Ray conda package hosted on a conda channel
+  - Read more about creating V-Ray conda package [here](../../conda_recipes/vray/README.md)
+- A sample `.vrscene` file and its dependencies
+- ImageMagick (for the merge step) - typically available via conda: `conda install imagemagick`
+
+## Parameters
+
+### Render Parameters
+- **Vray Scene File**: The `.vrscene` file to render
+- **Output Directory**: Where to save rendered images (default: `./output`)
+- **Output File Name**: Name of the final merged image (default: `output.png`)
+- **Image Width**: Width of the output image in pixels (default: 1920)
+- **Image Height**: Height of the output image in pixels (default: 1080)
+
+### Region Settings
+- **Region Columns**: Number of columns to divide the image into (default: 2, range: 1-10)
+- **Region Rows**: Number of rows to divide the image into (default: 2, range: 1-10)
+
+### Software Environment
+- **Conda Packages**: Conda packages to install (default: `vray imagemagick`)
+
+## Path Remapping
+
+This job bundle automatically handles path remapping for assets using the session's path mapping rules. When you add files via Job Attachments, the paths are automatically translated from your local workstation to the worker machines, and V-Ray's `-remapPath` parameter is configured accordingly.
+
+For example, if your `.vrscene` file references textures at `/shared/projects/project1/textures/`, and Job Attachments maps this to `/mnt/projects/project1/textures/` on the workers, V-Ray will automatically use the correct paths.
+
+## Example Usage
+
+For a 1920×1080 image with 2 columns and 2 rows:
+- Creates 4 tasks (2×2 grid)
+- Task (col=1, row=1): Renders region [0,0,960,540] (top-left)
+- Task (col=2, row=1): Renders region [960,0,1920,540] (top-right)
+- Task (col=1, row=2): Renders region [0,540,960,1080] (bottom-left)
+- Task (col=2, row=2): Renders region [960,540,1920,1080] (bottom-right)
+- Final task merges all 4 regions into the complete image
+
+## Performance Considerations
+
+- **More regions = more parallelism** but also more overhead
+- For small images, fewer regions may be faster
+- For large images or complex scenes, more regions can significantly reduce total render time
+- Consider your worker pool size when choosing region count
+
+## Customization
+
+All V-Ray command line flags can be found in the [Chaos V-Ray Standalone documentation](https://docs.chaos.com/display/VNS/V-Ray+Standalone+Command+Line+Options).
+
+Additional flags can be added to the `vray` command in the template's embedded script.

--- a/job_bundles/tile_render_with_vray_linux/README.md
+++ b/job_bundles/tile_render_with_vray_linux/README.md
@@ -1,31 +1,58 @@
 # V-Ray Region Render Sample Job Bundle
 
-This job bundle renders a V-Ray scene by dividing the image into configurable regions, rendering each region as a separate task, and then merging them into a final image.
+This job bundle renders a V-Ray scene by dividing the image into configurable regions, rendering each region as a separate task, and then merging them into a final image. Optionally creates a movie from rendered frames.
 
 ## Features
 
 - **Parallel Region Rendering**: Divides the image into a grid of regions (configurable rows and columns)
 - **Separate Tasks**: Each region renders as an independent task that can run in parallel
-- **Automatic Merging**: A final step merges all regions into the complete image
-- **Configurable Grid**: Control the number of rows and columns to balance parallelism and overhead
+- **Automatic Merging**: Merges all regions into the complete image using ImageMagick
+- **Optional Movie Creation**: Creates an MP4 movie from rendered frames using ffmpeg
+- **Path Remapping**: Automatically handles asset path translation between workstation and workers
 
 ## How It Works
 
-1. **RenderRegions Step**: Creates tasks for each region based on `RegionColumns × RegionRows`
+1. **RenderRegions Step**: Creates tasks for each region based on `RegionColumns × RegionRows × Frames`
    - Each task calculates its region bounds (left, top, right, bottom)
-   - Renders only that region using V-Ray's `-region` flag
-   - Outputs to a separate file: `output_region_0.png`, `output_region_1.png`, etc.
+   - Renders only that region using V-Ray's `-crop` flag
+   - Outputs to a separate file: `output_f1_region_r0_c0.png`, `output_f1_region_r0_c1.png`, etc.
 
-2. **MergeRegions Step**: Combines all region files into the final image
-   - Uses ImageMagick's `montage` command to stitch regions together
-   - Creates the final output file specified in parameters
+2. **MergeRegions Step**: Combines all region files into the final image for each frame
+   - Uses ImageMagick's `convert` command to stitch regions together
+   - Creates the final output file: `output.0001.png`, `output.0002.png`, etc.
+
+3. **CreateMovieFile Step** (optional): Creates a movie from the merged frames
+   - Uses ffmpeg to encode frames into an MP4 video
+   - Only runs if `CreateMovie` parameter is set to `true`
 
 ## Prerequisites
 
-- V-Ray conda package hosted on a conda channel
-  - Read more about creating V-Ray conda package [here](../../conda_recipes/vray/README.md)
-- A sample `.vrscene` file and its dependencies
-- ImageMagick (for the merge step) - typically available via conda: `conda install imagemagick`
+### 1. Build the V-Ray Conda Package
+
+Follow the instructions in the [V-Ray conda recipe README](../../conda_recipes/vray/README.md) to build and publish the V-Ray conda package to your S3 channel.
+
+Read more about creating V-Ray conda package [here](../../conda_recipes/vray/README.md).
+
+### 2. Set Up the Queue Environment
+
+Create a Conda queue environment that references your S3 channel and conda-forge (for imagemagick/ffmpeg):
+
+```bash
+aws deadline create-queue-environment \
+   --farm-id <FARM_ID> \
+   --queue-id <QUEUE_ID> \
+   --priority 1 \
+   --template-type YAML \
+   --template file://queue_environments/conda_queue_env_improved_caching.yaml
+```
+
+Update the `CondaChannels` default in the queue environment to include both your S3 channel and conda-forge:
+
+```yaml
+default: "s3://<job-attachments-bucket>/Conda/Default conda-forge"
+```
+### 3. Sample Scene Files
+You'll need a `.vrscene` file and its dependencies. The [Chaos ENVISION documentation samples](https://docs.chaos.com/display/ENVISION/Sample+Scenes) include vrscene files you can use for testing.
 
 ## Parameters
 
@@ -35,13 +62,33 @@ This job bundle renders a V-Ray scene by dividing the image into configurable re
 - **Output File Name**: Name of the final merged image (default: `output.png`)
 - **Image Width**: Width of the output image in pixels (default: 1920)
 - **Image Height**: Height of the output image in pixels (default: 1080)
+- **Frames**: Frame range to render (default: `1`, supports ranges like `1-10` or `1,5,10`)
 
 ### Region Settings
 - **Region Columns**: Number of columns to divide the image into (default: 2, range: 1-10)
 - **Region Rows**: Number of rows to divide the image into (default: 2, range: 1-10)
 
+### Movie Settings
+- **Create Movie**: Whether to create an MP4 from rendered frames (default: `false`)
+- **Movie Filename**: Output movie filename (default: `output.mp4`)
+- **Frame Rate**: Frame rate for the movie (default: 24)
+
 ### Software Environment
-- **Conda Packages**: Conda packages to install (default: `vray imagemagick`)
+- **Conda Packages**: Conda packages to install (default: `vray imagemagick ffmpeg`)
+
+## Job Submission
+
+Using the GUI:
+```bash
+deadline bundle gui-submit job_bundles/tile_render_with_vray_linux
+```
+
+Using the CLI:
+```bash
+deadline bundle submit job_bundles/tile_render_with_vray_linux \
+    -p VraySceneFile="/path/to/scene.vrscene" \
+    -p OutputDir="./output"
+```
 
 ## Path Remapping
 
@@ -49,15 +96,17 @@ This job bundle automatically handles path remapping for assets using the sessio
 
 For example, if your `.vrscene` file references textures at `/shared/projects/project1/textures/`, and Job Attachments maps this to `/mnt/projects/project1/textures/` on the workers, V-Ray will automatically use the correct paths.
 
+The job also sets `VRAY_PATH_REMAPPING_CASE_SENSITIVE=1` to ensure proper path matching on Linux workers when source paths come from Windows.
+
 ## Example Usage
 
 For a 1920×1080 image with 2 columns and 2 rows:
-- Creates 4 tasks (2×2 grid)
-- Task (col=1, row=1): Renders region [0,0,960,540] (top-left)
-- Task (col=2, row=1): Renders region [960,0,1920,540] (top-right)
-- Task (col=1, row=2): Renders region [0,540,960,1080] (bottom-left)
-- Task (col=2, row=2): Renders region [960,540,1920,1080] (bottom-right)
-- Final task merges all 4 regions into the complete image
+- Creates 4 render tasks (2×2 grid) per frame
+- Task (col=0, row=0): Renders region [0,0,960,540] (top-left)
+- Task (col=1, row=0): Renders region [960,0,1920,540] (top-right)
+- Task (col=0, row=1): Renders region [0,540,960,1080] (bottom-left)
+- Task (col=1, row=1): Renders region [960,540,1920,1080] (bottom-right)
+- Merge task combines all 4 regions into the complete image
 
 ## Performance Considerations
 

--- a/job_bundles/tile_render_with_vray_linux/README.md
+++ b/job_bundles/tile_render_with_vray_linux/README.md
@@ -9,6 +9,7 @@ This job bundle renders a V-Ray scene by dividing the image into configurable re
 - **Automatic Merging**: Merges all regions into the complete image using ImageMagick
 - **Optional Movie Creation**: Creates an MP4 movie from rendered frames using ffmpeg
 - **Path Remapping**: Automatically handles asset path translation between workstation and workers
+- **Standalone Scripts**: Render and merge logic in separate script files for easy customization
 
 ## How It Works
 
@@ -25,13 +26,23 @@ This job bundle renders a V-Ray scene by dividing the image into configurable re
    - Uses ffmpeg to encode frames into an MP4 video
    - Only runs if `CreateMovie` parameter is set to `true`
 
+## Bundle Structure
+
+```
+tile_render_with_vray_linux/
+├── template.yaml                    # Job template definition
+├── scripts/
+│   ├── render_region.sh            # Renders a single region tile
+│   ├── merge_regions.sh            # Merges region tiles into complete frame
+│   └── setup_vray_path_mapping.py  # Generates V-Ray path remapping args
+└── README.md
+```
+
 ## Prerequisites
 
 ### 1. Build the V-Ray Conda Package
 
 Follow the instructions in the [V-Ray conda recipe README](../../conda_recipes/vray/README.md) to build and publish the V-Ray conda package to your S3 channel.
-
-Read more about creating V-Ray conda package [here](../../conda_recipes/vray/README.md).
 
 ### 2. Set Up the Queue Environment
 
@@ -51,8 +62,23 @@ Update the `CondaChannels` default in the queue environment to include both your
 ```yaml
 default: "s3://<job-attachments-bucket>/Conda/Default conda-forge"
 ```
+
 ### 3. Sample Scene Files
-You'll need a `.vrscene` file and its dependencies. The [Chaos ENVISION documentation samples](https://docs.chaos.com/display/ENVISION/Sample+Scenes) include vrscene files you can use for testing.
+
+## Exporting from 3ds Max
+
+To export a `.vrscene` file from 3ds Max for use with this job bundle:
+
+1. Open your scene in 3ds Max with V-Ray as the active renderer
+2. Open the V-Ray Scene Exporter:
+   - **V-Ray 6+**: Go to the top menu bar: `V-Ray > .vrscene exporter`
+   - **V-Ray 5 & Older**: Right-click in any viewport and select `.vrscene exporter` from the Quad menu
+3. Configure export settings:
+   - Set the **Export path**
+   - For animation, select the correct frame range (e.g., "Single File" or "File Per Frame")
+4. Click **Export**
+
+Refer to the [Chaos V-Ray documentation](https://documentation.chaos.com/space/VMAX/113575461/V-Ray+Scene+Exporter) for detailed export options.
 
 ## Parameters
 
@@ -92,11 +118,22 @@ deadline bundle submit job_bundles/tile_render_with_vray_linux \
 
 ## Path Remapping
 
-This job bundle automatically handles path remapping for assets using the session's path mapping rules. When you add files via Job Attachments, the paths are automatically translated from your local workstation to the worker machines, and V-Ray's `-remapPath` parameter is configured accordingly.
+This job bundle automatically handles path remapping for assets using the session's path mapping rules.
 
-For example, if your `.vrscene` file references textures at `/shared/projects/project1/textures/`, and Job Attachments maps this to `/mnt/projects/project1/textures/` on the workers, V-Ray will automatically use the correct paths.
+### How It Works
 
-The job also sets `VRAY_PATH_REMAPPING_CASE_SENSITIVE=1` to ensure proper path matching on Linux workers when source paths come from Windows.
+1. The `setup_vray_path_mapping.py` script reads the session's path mapping rules from `{{Session.PathMappingRulesFile}}`
+2. Generates V-Ray `-remapPath` arguments for each source→destination mapping
+3. Saves the arguments to `/tmp/vray_remap_paths.txt`
+4. The render script applies these arguments to the V-Ray command
+
+### Example
+
+When you add files via Job Attachments, paths are automatically translated:
+
+- **Source path** (your workstation): `C:\Projects\MyProject\textures\`
+- **Destination path** (worker): `/sessions/.../assetroot-.../textures/`
+- **V-Ray argument**: `-remapPath='C:\Projects\MyProject\textures\=/sessions/.../assetroot-.../textures/'`
 
 ## Example Usage
 
@@ -117,6 +154,10 @@ For a 1920×1080 image with 2 columns and 2 rows:
 
 ## Customization
 
-All V-Ray command line flags can be found in the [Chaos V-Ray Standalone documentation](https://docs.chaos.com/display/VNS/V-Ray+Standalone+Command+Line+Options).
+The scripts in the `scripts/` folder can be modified to customize behavior:
 
-Additional flags can be added to the `vray` command in the template's embedded script.
+- `render_region.sh`: Modify V-Ray command line options
+- `merge_regions.sh`: Change merge behavior or add post-processing
+- `setup_vray_path_mapping.py`: Customize path mapping logic
+
+All V-Ray command line flags can be found in the [Chaos V-Ray Standalone documentation](https://docs.chaos.com/display/VNS/V-Ray+Standalone+Command+Line+Options).

--- a/job_bundles/tile_render_with_vray_linux/scripts/merge_regions.sh
+++ b/job_bundles/tile_render_with_vray_linux/scripts/merge_regions.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Merge region tiles into a complete frame using ImageMagick
+set -euo pipefail
+
+# Parse arguments
+OUTPUT_DIR="$1"
+FILENAME="$2"
+FRAME="$3"
+COLS="$4"
+ROWS="$5"
+
+echo "=== Merge Regions Task ==="
+echo "Frame: $FRAME, Grid: ${COLS}x${ROWS}"
+
+BASE="${FILENAME%.*}"
+EXT="${FILENAME##*.}"
+
+# Check all region files exist
+echo "Checking region files..."
+MISSING=0
+for ((row=0; row<ROWS; row++)); do
+  for ((col=0; col<COLS; col++)); do
+    F="${OUTPUT_DIR}/${BASE}_f${FRAME}_region_r${row}_c${col}.${EXT}"
+    if [ ! -f "$F" ]; then
+      echo "ERROR: Missing $F"
+      MISSING=$((MISSING+1))
+    fi
+  done
+done
+
+if [ $MISSING -gt 0 ]; then
+  echo "ERROR: $MISSING region files missing"
+  exit 1
+fi
+
+# Merge rows horizontally
+echo "Merging rows horizontally..."
+for ((row=0; row<ROWS; row++)); do
+  ROW_FILES=""
+  for ((col=0; col<COLS; col++)); do
+    ROW_FILES="$ROW_FILES ${OUTPUT_DIR}/${BASE}_f${FRAME}_region_r${row}_c${col}.${EXT}"
+  done
+  convert $ROW_FILES +append "${OUTPUT_DIR}/${BASE}_f${FRAME}_row_${row}.${EXT}"
+done
+
+# Merge all rows vertically
+echo "Merging rows vertically..."
+ALL_ROWS=""
+for ((row=0; row<ROWS; row++)); do
+  ALL_ROWS="$ALL_ROWS ${OUTPUT_DIR}/${BASE}_f${FRAME}_row_${row}.${EXT}"
+done
+
+PADDED_FRAME=$(printf "%04d" $FRAME)
+FINAL_OUTPUT="${OUTPUT_DIR}/${BASE}.${PADDED_FRAME}.${EXT}"
+convert $ALL_ROWS -append "$FINAL_OUTPUT"
+
+# Cleanup intermediate row files
+for ((row=0; row<ROWS; row++)); do
+  rm -f "${OUTPUT_DIR}/${BASE}_f${FRAME}_row_${row}.${EXT}"
+done
+
+echo "Merged image: $FINAL_OUTPUT"

--- a/job_bundles/tile_render_with_vray_linux/scripts/render_region.sh
+++ b/job_bundles/tile_render_with_vray_linux/scripts/render_region.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Render a single region tile using V-Ray
+set -euo pipefail
+
+# Parse arguments
+SETUP_PATH_MAPPING_SCRIPT="$1"
+SCENE_FILE="$2"
+OUTPUT_DIR="$3"
+FILENAME="$4"
+PATH_MAPPING_FILE="$5"
+FRAME="$6"
+REGION_COL="$7"
+REGION_ROW="$8"
+COLS="$9"
+ROWS="${10}"
+IMG_WIDTH="${11}"
+IMG_HEIGHT="${12}"
+
+echo "=== Render Region Task ==="
+echo "Frame: $FRAME, RegionCol: $REGION_COL, RegionRow: $REGION_ROW"
+echo "Scene: $SCENE_FILE"
+
+# Convert 1-based to 0-based indices
+COL=$((REGION_COL - 1))
+ROW=$((REGION_ROW - 1))
+
+# Calculate region boundaries
+REGION_WIDTH=$((IMG_WIDTH / COLS))
+REGION_HEIGHT=$((IMG_HEIGHT / ROWS))
+LEFT=$((COL * REGION_WIDTH))
+TOP=$((ROW * REGION_HEIGHT))
+RIGHT=$(( COL == COLS - 1 ? IMG_WIDTH : (COL + 1) * REGION_WIDTH ))
+BOTTOM=$(( ROW == ROWS - 1 ? IMG_HEIGHT : (ROW + 1) * REGION_HEIGHT ))
+
+echo "Region (col=$COL, row=$ROW): [$LEFT,$TOP,$RIGHT,$BOTTOM]"
+
+# Prepare output filename
+BASE="${FILENAME%.*}"
+EXT="${FILENAME##*.}"
+OUT_FILE="${OUTPUT_DIR}/${BASE}_f${FRAME}_region_r${ROW}_c${COL}.${EXT}"
+echo "Output: $OUT_FILE"
+
+# Enable case-sensitive path remapping
+export VRAY_PATH_REMAPPING_CASE_SENSITIVE=1
+
+# Change to scene directory for relative path resolution
+SCENE_DIR=$(dirname "$SCENE_FILE")
+if [ -d "$SCENE_DIR" ]; then
+  echo "Changing to scene directory: $SCENE_DIR"
+  cd "$SCENE_DIR"
+else
+  echo "Warning: Scene directory does not exist: $SCENE_DIR"
+fi
+
+# Setup path mapping
+echo "Setting up path mapping..."
+python3 "$SETUP_PATH_MAPPING_SCRIPT" "$PATH_MAPPING_FILE"
+
+# Build V-Ray command
+VRAY_CMD="vray -sceneFile='${SCENE_FILE}' -imgFile='${OUT_FILE}' -display=0 -imgWidth=$IMG_WIDTH -imgHeight=$IMG_HEIGHT -frames=$FRAME -crop='$LEFT;$TOP;$RIGHT;$BOTTOM'"
+
+# Add path remapping if available
+if [ -f /tmp/vray_remap_paths.txt ]; then
+  REMAP_PATHS=$(cat /tmp/vray_remap_paths.txt)
+  if [ -n "$REMAP_PATHS" ]; then
+    VRAY_CMD="$VRAY_CMD $REMAP_PATHS"
+  fi
+fi
+
+echo "Running V-Ray..."
+eval $VRAY_CMD
+
+echo "Render complete: $OUT_FILE"

--- a/job_bundles/tile_render_with_vray_linux/scripts/setup_vray_path_mapping.py
+++ b/job_bundles/tile_render_with_vray_linux/scripts/setup_vray_path_mapping.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Set up V-Ray path mapping from Deadline Cloud session path mapping rules."""
+import json
+import os
+import sys
+
+OUTPUT_FILE = "/tmp/vray_remap_paths.txt"
+
+def main():
+    os.environ["VRAY_PATH_REMAPPING_CASE_SENSITIVE"] = "1"
+    
+    path_mapping_file = sys.argv[1] if len(sys.argv) > 1 else ""
+    
+    if not path_mapping_file or not os.path.isfile(path_mapping_file):
+        print(f"No path mapping rules file found: {path_mapping_file}")
+        open(OUTPUT_FILE, "w").close()
+        return
+    
+    with open(path_mapping_file) as f:
+        data = json.load(f)
+    
+    rules = data.get("path_mapping_rules", [])
+    remap_args = []
+    
+    for r in rules:
+        src, dst = r.get("source_path"), r.get("destination_path")
+        if src and dst:
+            remap_args.append(f"-remapPath='{src}={dst}'")
+            print(f"Path mapping: {src} -> {dst}")
+    
+    with open(OUTPUT_FILE, "w") as f:
+        f.write(" ".join(remap_args))
+
+if __name__ == "__main__":
+    main()

--- a/job_bundles/tile_render_with_vray_linux/template.yaml
+++ b/job_bundles/tile_render_with_vray_linux/template.yaml
@@ -3,7 +3,7 @@ name: V-Ray Region Render
 
 parameterDefinitions:
 
-# Render Parameters
+# Render Parameters: V-Ray scene, output location, and image dimensions
 - name: VraySceneFile
   type: PATH
   objectType: FILE
@@ -54,6 +54,8 @@ parameterDefinitions:
     groupLabel: Render Parameters 
   default: 1080
   description: Height of the output image in pixels.
+
+# Region Settings: Controls how the image is divided into tiles for parallel rendering
 - name: RegionColumns
   type: INT
   userInterface:
@@ -74,6 +76,8 @@ parameterDefinitions:
   minValue: 1
   maxValue: 10
   description: Number of rows to divide the image into.
+
+# Frame and Animation Settings: Frame range specification and movie output options
 - name: Frames
   type: STRING
   userInterface:
@@ -110,7 +114,7 @@ parameterDefinitions:
   maxValue: 120
   description: Frame rate for the output movie (only used if Create Movie is enabled).
 
-# Software Environment
+# Software Environment: Conda packages required for rendering, merging, and movie creation
 - name: CondaPackages
   type: STRING
   userInterface:
@@ -123,6 +127,7 @@ parameterDefinitions:
     tell it to install vray, imagemagick, and ffmpeg.
 
 steps:
+# Step 1: Render each region of each frame in parallel across workers
 - name: RenderRegions
   parameterSpace:
     taskParameterDefinitions:
@@ -214,6 +219,7 @@ steps:
       anyOf:
       - linux
 
+# Step 2: Merge region tiles into complete frames using ImageMagick
 - name: MergeRegions
   parameterSpace:
     taskParameterDefinitions:
@@ -243,16 +249,13 @@ steps:
           EXT="${FILENAME##*.}"
           OUTPUT_DIR="{{Param.OutputDir}}"
           
-          # V-Ray appends frame number as 4-digit suffix (e.g., .0001.png)
-          FRAME_SUFFIX=$(printf "%04d" $FRAME)
-          
-          echo "Looking for region files with pattern: ${BASE}_f${FRAME}_region_r*_c*.${FRAME_SUFFIX}.${EXT}"
+          echo "Looking for region files with pattern: ${BASE}_f${FRAME}_region_r*_c*.${EXT}"
           
           # Check if all region files exist
           MISSING_FILES=0
           for ((row=0; row<ROWS; row++)); do
             for ((col=0; col<COLS; col++)); do
-              REGION_FILE="${OUTPUT_DIR}/${BASE}_f${FRAME}_region_r${row}_c${col}.${FRAME_SUFFIX}.${EXT}"
+              REGION_FILE="${OUTPUT_DIR}/${BASE}_f${FRAME}_region_r${row}_c${col}.${EXT}"
               if [ ! -f "$REGION_FILE" ]; then
                 echo "ERROR: Missing region file: $REGION_FILE"
                 MISSING_FILES=$((MISSING_FILES + 1))
@@ -273,7 +276,7 @@ steps:
             for ((row=0; row<ROWS; row++)); do
               ROW_FILES=""
               for ((col=0; col<COLS; col++)); do
-                ROW_FILES="$ROW_FILES ${OUTPUT_DIR}/${BASE}_f${FRAME}_region_r${row}_c${col}.${FRAME_SUFFIX}.${EXT}"
+                ROW_FILES="$ROW_FILES ${OUTPUT_DIR}/${BASE}_f${FRAME}_region_r${row}_c${col}.${EXT}"
               done
               convert $ROW_FILES +append "${OUTPUT_DIR}/${BASE}_f${FRAME}_row_${row}.${EXT}"
               echo "Created row $row for frame $FRAME"
@@ -299,6 +302,7 @@ steps:
       anyOf:
       - linux
 
+# Step 3: Create movie from frame sequence (optional)
 - name: CreateMovieFile
   dependencies:
   - dependsOn: MergeRegions

--- a/job_bundles/tile_render_with_vray_linux/template.yaml
+++ b/job_bundles/tile_render_with_vray_linux/template.yaml
@@ -3,6 +3,23 @@ name: V-Ray Region Render
 
 parameterDefinitions:
 
+# Script Files
+- name: RenderRegionScript
+  type: PATH
+  default: scripts/render_region.sh
+  dataFlow: IN
+  objectType: FILE
+- name: MergeRegionsScript
+  type: PATH
+  default: scripts/merge_regions.sh
+  dataFlow: IN
+  objectType: FILE
+- name: SetupVrayPathMappingScript
+  type: PATH
+  default: scripts/setup_vray_path_mapping.py
+  dataFlow: IN
+  objectType: FILE
+
 # Render Parameters: V-Ray scene, output location, and image dimensions
 - name: VraySceneFile
   type: PATH
@@ -55,7 +72,7 @@ parameterDefinitions:
   default: 1080
   description: Height of the output image in pixels.
 
-# Region Settings: Controls how the image is divided into tiles for parallel rendering
+# Region Settings
 - name: RegionColumns
   type: INT
   userInterface:
@@ -77,7 +94,7 @@ parameterDefinitions:
   maxValue: 10
   description: Number of rows to divide the image into.
 
-# Frame and Animation Settings: Frame range specification and movie output options
+# Frame and Animation Settings
 - name: Frames
   type: STRING
   userInterface:
@@ -114,7 +131,7 @@ parameterDefinitions:
   maxValue: 120
   description: Frame rate for the output movie (only used if Create Movie is enabled).
 
-# Software Environment: Conda packages required for rendering, merging, and movie creation
+# Software Environment
 - name: CondaPackages
   type: STRING
   userInterface:
@@ -127,7 +144,7 @@ parameterDefinitions:
     tell it to install vray, imagemagick, and ffmpeg.
 
 steps:
-# Step 1: Render each region of each frame in parallel across workers
+# Step 1: Render each region of each frame in parallel
 - name: RenderRegions
   parameterSpace:
     taskParameterDefinitions:
@@ -143,83 +160,30 @@ steps:
   script:
     actions:
       onRun:
-        command: bash
-        args: ['{{Task.File.Run}}']
+        command: /bin/bash
+        args:
+        - "{{Param.RenderRegionScript}}"
+        - "{{Param.SetupVrayPathMappingScript}}"
+        - "{{Param.VraySceneFile}}"
+        - "{{Param.OutputDir}}"
+        - "{{Param.OutputFilename}}"
+        - "{{Session.PathMappingRulesFile}}"
+        - "{{Task.Param.Frame}}"
+        - "{{Task.Param.RegionCol}}"
+        - "{{Task.Param.RegionRow}}"
+        - "{{Param.RegionColumns}}"
+        - "{{Param.RegionRows}}"
+        - "{{Param.ImageWidth}}"
+        - "{{Param.ImageHeight}}"
         cancelation:
           mode: NOTIFY_THEN_TERMINATE
-    embeddedFiles:
-      - name: Run
-        type: TEXT
-        data: |
-          set -xeuo pipefail
-          FRAME={{Task.Param.Frame}}
-          COL=$(({{Task.Param.RegionCol}} - 1))
-          ROW=$(({{Task.Param.RegionRow}} - 1))
-          COLS={{Param.RegionColumns}}
-          ROWS={{Param.RegionRows}}
-          IMG_WIDTH={{Param.ImageWidth}}
-          IMG_HEIGHT={{Param.ImageHeight}}
-          REGION_WIDTH=$((IMG_WIDTH / COLS))
-          REGION_HEIGHT=$((IMG_HEIGHT / ROWS))
-          LEFT=$((COL * REGION_WIDTH))
-          TOP=$((ROW * REGION_HEIGHT))
-          RIGHT=$(((COL + 1) * REGION_WIDTH))
-          BOTTOM=$(((ROW + 1) * REGION_HEIGHT))
-          if [ $COL -eq $((COLS - 1)) ]; then RIGHT=$IMG_WIDTH; fi
-          if [ $ROW -eq $((ROWS - 1)) ]; then BOTTOM=$IMG_HEIGHT; fi
-          echo "Rendering frame $FRAME, region (col=$COL, row=$ROW): [$LEFT,$TOP,$RIGHT,$BOTTOM]"
-          FILENAME="{{Param.OutputFilename}}"
-          BASE="${FILENAME%.*}"
-          EXT="${FILENAME##*.}"
-          # Enable case-sensitive path remapping in V-Ray
-          export VRAY_PATH_REMAPPING_CASE_SENSITIVE=1
-          
-          VRAY_CMD="vray -sceneFile='{{Param.VraySceneFile}}' -imgFile=\"{{Param.OutputDir}}/${BASE}_f${FRAME}_region_r${ROW}_c${COL}.${EXT}\" -display=0 -imgWidth=$IMG_WIDTH -imgHeight=$IMG_HEIGHT -frames=$FRAME -crop=$LEFT\;$TOP\;$RIGHT\;$BOTTOM"
-          
-          if [ -f "{{Session.PathMappingRulesFile}}" ]; then
-            echo "Path mapping rules file contents:"
-            cat "{{Session.PathMappingRulesFile}}"
-            echo ""
-            
-            echo "Listing contents of mapped destination paths:"
-            if command -v jq &> /dev/null; then
-              jq -r '.path_mapping_rules[].destination_path' "{{Session.PathMappingRulesFile}}" | while read dest_path; do
-                if [ -d "$dest_path" ]; then
-                  echo "Contents of $dest_path:"
-                  ls -laR "$dest_path" || echo "Failed to list $dest_path"
-                  echo ""
-                fi
-              done
-            else
-              python3 -c "import json; f=open('{{Session.PathMappingRulesFile}}'); d=json.load(f); f.close(); [print(r['destination_path']) for r in d.get('path_mapping_rules',[]) if r.get('destination_path')]" | while read dest_path; do
-                if [ -d "$dest_path" ]; then
-                  echo "Contents of $dest_path:"
-                  ls -laR "$dest_path" || echo "Failed to list $dest_path"
-                  echo ""
-                fi
-              done
-            fi
-            
-            echo "Building V-Ray remapPath arguments"
-            if command -v jq &> /dev/null; then
-              REMAP_PATHS=$(jq -r '.path_mapping_rules[] | "-remapPath=\"" + .source_path + "=" + .destination_path + "\""' "{{Session.PathMappingRulesFile}}" | tr '\n' ' ')
-            else
-              REMAP_PATHS=$(python3 -c "import json; f=open('{{Session.PathMappingRulesFile}}'); d=json.load(f); f.close(); print(' '.join(['-remapPath=\"'+r['source_path']+'='+r['destination_path']+'\"' for r in d.get('path_mapping_rules',[]) if r.get('source_path') and r.get('destination_path')]))")
-            fi
-            if [ -n "$REMAP_PATHS" ]; then
-              VRAY_CMD="$VRAY_CMD $REMAP_PATHS"
-              echo "Added path remapping: $REMAP_PATHS"
-            fi
-          fi
-          
-          eval $VRAY_CMD
   hostRequirements:
     attributes:
     - name: attr.worker.os.family
       anyOf:
       - linux
 
-# Step 2: Merge region tiles into complete frames using ImageMagick
+# Step 2: Merge region tiles into complete frames
 - name: MergeRegions
   parameterSpace:
     taskParameterDefinitions:
@@ -231,71 +195,16 @@ steps:
   script:
     actions:
       onRun:
-        command: bash
-        args: ['{{Task.File.Run}}']
+        command: /bin/bash
+        args:
+        - "{{Param.MergeRegionsScript}}"
+        - "{{Param.OutputDir}}"
+        - "{{Param.OutputFilename}}"
+        - "{{Task.Param.Frame}}"
+        - "{{Param.RegionColumns}}"
+        - "{{Param.RegionRows}}"
         cancelation:
           mode: NOTIFY_THEN_TERMINATE
-    embeddedFiles:
-      - name: Run
-        type: TEXT
-        data: |
-          set -xeuo pipefail
-          FRAME={{Task.Param.Frame}}
-          echo "Merging regions for frame $FRAME into final image..."
-          COLS={{Param.RegionColumns}}
-          ROWS={{Param.RegionRows}}
-          FILENAME="{{Param.OutputFilename}}"
-          BASE="${FILENAME%.*}"
-          EXT="${FILENAME##*.}"
-          OUTPUT_DIR="{{Param.OutputDir}}"
-          
-          echo "Looking for region files with pattern: ${BASE}_f${FRAME}_region_r*_c*.${EXT}"
-          
-          # Check if all region files exist
-          MISSING_FILES=0
-          for ((row=0; row<ROWS; row++)); do
-            for ((col=0; col<COLS; col++)); do
-              REGION_FILE="${OUTPUT_DIR}/${BASE}_f${FRAME}_region_r${row}_c${col}.${EXT}"
-              if [ ! -f "$REGION_FILE" ]; then
-                echo "ERROR: Missing region file: $REGION_FILE"
-                MISSING_FILES=$((MISSING_FILES + 1))
-              else
-                echo "Found: $REGION_FILE"
-              fi
-            done
-          done
-          
-          if [ $MISSING_FILES -gt 0 ]; then
-            echo "ERROR: $MISSING_FILES region files are missing for frame $FRAME. Cannot merge."
-            echo "Available files in output directory:"
-            ls -la "${OUTPUT_DIR}/" 2>/dev/null || echo "No files found"
-            exit 1
-          fi
-          
-          if command -v convert &> /dev/null; then
-            for ((row=0; row<ROWS; row++)); do
-              ROW_FILES=""
-              for ((col=0; col<COLS; col++)); do
-                ROW_FILES="$ROW_FILES ${OUTPUT_DIR}/${BASE}_f${FRAME}_region_r${row}_c${col}.${EXT}"
-              done
-              convert $ROW_FILES +append "${OUTPUT_DIR}/${BASE}_f${FRAME}_row_${row}.${EXT}"
-              echo "Created row $row for frame $FRAME"
-            done
-            ALL_ROWS=""
-            for ((row=0; row<ROWS; row++)); do
-              ALL_ROWS="$ALL_ROWS ${OUTPUT_DIR}/${BASE}_f${FRAME}_row_${row}.${EXT}"
-            done
-            # Use zero-padded frame number for proper sorting
-            PADDED_FRAME=$(printf "%04d" $FRAME)
-            convert $ALL_ROWS -append "${OUTPUT_DIR}/${BASE}.${PADDED_FRAME}.${EXT}"
-            for ((row=0; row<ROWS; row++)); do
-              rm -f "${OUTPUT_DIR}/${BASE}_f${FRAME}_row_${row}.${EXT}"
-            done
-            echo "Merged image created: ${OUTPUT_DIR}/${BASE}.${PADDED_FRAME}.${EXT}"
-          else
-            echo "Warning: ImageMagick not found. Region files are available but not merged."
-            echo "Region files: ${OUTPUT_DIR}/${BASE}_f${FRAME}_region_*.${FRAME_SUFFIX}.${EXT}"
-          fi
   hostRequirements:
     attributes:
     - name: attr.worker.os.family

--- a/job_bundles/tile_render_with_vray_linux/template.yaml
+++ b/job_bundles/tile_render_with_vray_linux/template.yaml
@@ -1,0 +1,347 @@
+specificationVersion: 'jobtemplate-2023-09'
+name: V-Ray Region Render
+
+parameterDefinitions:
+
+# Render Parameters
+- name: VraySceneFile
+  type: PATH
+  objectType: FILE
+  dataFlow: IN
+  userInterface:
+    control: CHOOSE_INPUT_FILE
+    label: Vray Scene File
+    groupLabel: Render Parameters
+    fileFilters:
+    - label: Vray Scene Files
+      patterns: ["*.vrscene"]
+    - label: All Files
+      patterns: ["*"]
+  description: >
+    Choose the Vray scene file you want to render. Use the 'Job Attachments' tab
+    to add textures and other files that the job needs.
+- name: OutputDir
+  type: PATH
+  objectType: DIRECTORY
+  dataFlow: OUT
+  userInterface:
+    control: CHOOSE_DIRECTORY
+    label: Output Directory
+    groupLabel: Render Parameters
+  default: "./output"
+  description: Choose the render output directory.
+- name: OutputFilename
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Output File Name
+    groupLabel: Render Parameters
+  default: "output.png"
+  description: Enter the output filename (with extension of choice).
+- name: ImageWidth
+  type: INT
+  userInterface:
+    control: SPIN_BOX
+    label: Image Width
+    groupLabel: Render Parameters
+  default: 1920
+  description: Width of the output image in pixels.
+- name: ImageHeight
+  type: INT
+  userInterface:
+    control: SPIN_BOX
+    label: Image Height
+    groupLabel: Render Parameters 
+  default: 1080
+  description: Height of the output image in pixels.
+- name: RegionColumns
+  type: INT
+  userInterface:
+    control: SPIN_BOX
+    label: Region Columns
+    groupLabel: Region Settings
+  default: 2
+  minValue: 1
+  maxValue: 10
+  description: Number of columns to divide the image into.
+- name: RegionRows
+  type: INT
+  userInterface:
+    control: SPIN_BOX
+    label: Region Rows
+    groupLabel: Region Settings
+  default: 2
+  minValue: 1
+  maxValue: 10
+  description: Number of rows to divide the image into.
+- name: Frames
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Frames
+    groupLabel: Render Parameters
+  default: "1"
+  description: Frame range to render (e.g., "1", "1-10", "1,5,10").
+- name: CreateMovie
+  type: STRING
+  userInterface:
+    control: CHECK_BOX
+    label: Create Movie
+    groupLabel: Render Parameters
+  default: "false"
+  allowedValues: ["true", "false"]
+  description: Create a movie file from the rendered frames using ffmpeg.
+- name: MovieFilename
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Movie Filename
+    groupLabel: Render Parameters
+  default: "output.mp4"
+  description: Output movie filename (only used if Create Movie is enabled).
+- name: FrameRate
+  type: INT
+  userInterface:
+    control: SPIN_BOX
+    label: Frame Rate
+    groupLabel: Render Parameters
+  default: 24
+  minValue: 1
+  maxValue: 120
+  description: Frame rate for the output movie (only used if Create Movie is enabled).
+
+# Software Environment
+- name: CondaPackages
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Conda Packages
+    groupLabel: Software Environment
+  default: vray imagemagick ffmpeg
+  description: >
+    If you have a Queue Environment that creates a Conda environment from a parameter called CondaPackages, this will
+    tell it to install vray, imagemagick, and ffmpeg.
+
+steps:
+- name: RenderRegions
+  parameterSpace:
+    taskParameterDefinitions:
+    - name: Frame
+      type: INT
+      range: "{{Param.Frames}}"
+    - name: RegionCol
+      type: INT
+      range: "1-{{Param.RegionColumns}}"
+    - name: RegionRow
+      type: INT
+      range: "1-{{Param.RegionRows}}"
+  script:
+    actions:
+      onRun:
+        command: bash
+        args: ['{{Task.File.Run}}']
+        cancelation:
+          mode: NOTIFY_THEN_TERMINATE
+    embeddedFiles:
+      - name: Run
+        type: TEXT
+        data: |
+          set -xeuo pipefail
+          FRAME={{Task.Param.Frame}}
+          COL=$(({{Task.Param.RegionCol}} - 1))
+          ROW=$(({{Task.Param.RegionRow}} - 1))
+          COLS={{Param.RegionColumns}}
+          ROWS={{Param.RegionRows}}
+          IMG_WIDTH={{Param.ImageWidth}}
+          IMG_HEIGHT={{Param.ImageHeight}}
+          REGION_WIDTH=$((IMG_WIDTH / COLS))
+          REGION_HEIGHT=$((IMG_HEIGHT / ROWS))
+          LEFT=$((COL * REGION_WIDTH))
+          TOP=$((ROW * REGION_HEIGHT))
+          RIGHT=$(((COL + 1) * REGION_WIDTH))
+          BOTTOM=$(((ROW + 1) * REGION_HEIGHT))
+          if [ $COL -eq $((COLS - 1)) ]; then RIGHT=$IMG_WIDTH; fi
+          if [ $ROW -eq $((ROWS - 1)) ]; then BOTTOM=$IMG_HEIGHT; fi
+          echo "Rendering frame $FRAME, region (col=$COL, row=$ROW): [$LEFT,$TOP,$RIGHT,$BOTTOM]"
+          FILENAME="{{Param.OutputFilename}}"
+          BASE="${FILENAME%.*}"
+          EXT="${FILENAME##*.}"
+          # Enable case-sensitive path remapping in V-Ray
+          export VRAY_PATH_REMAPPING_CASE_SENSITIVE=1
+          
+          VRAY_CMD="vray -sceneFile='{{Param.VraySceneFile}}' -imgFile=\"{{Param.OutputDir}}/${BASE}_f${FRAME}_region_r${ROW}_c${COL}.${EXT}\" -display=0 -imgWidth=$IMG_WIDTH -imgHeight=$IMG_HEIGHT -frames=$FRAME -crop=$LEFT\;$TOP\;$RIGHT\;$BOTTOM"
+          
+          if [ -f "{{Session.PathMappingRulesFile}}" ]; then
+            echo "Path mapping rules file contents:"
+            cat "{{Session.PathMappingRulesFile}}"
+            echo ""
+            
+            echo "Listing contents of mapped destination paths:"
+            if command -v jq &> /dev/null; then
+              jq -r '.path_mapping_rules[].destination_path' "{{Session.PathMappingRulesFile}}" | while read dest_path; do
+                if [ -d "$dest_path" ]; then
+                  echo "Contents of $dest_path:"
+                  ls -laR "$dest_path" || echo "Failed to list $dest_path"
+                  echo ""
+                fi
+              done
+            else
+              python3 -c "import json; f=open('{{Session.PathMappingRulesFile}}'); d=json.load(f); f.close(); [print(r['destination_path']) for r in d.get('path_mapping_rules',[]) if r.get('destination_path')]" | while read dest_path; do
+                if [ -d "$dest_path" ]; then
+                  echo "Contents of $dest_path:"
+                  ls -laR "$dest_path" || echo "Failed to list $dest_path"
+                  echo ""
+                fi
+              done
+            fi
+            
+            echo "Building V-Ray remapPath arguments"
+            if command -v jq &> /dev/null; then
+              REMAP_PATHS=$(jq -r '.path_mapping_rules[] | "-remapPath=\"" + .source_path + "=" + .destination_path + "\""' "{{Session.PathMappingRulesFile}}" | tr '\n' ' ')
+            else
+              REMAP_PATHS=$(python3 -c "import json; f=open('{{Session.PathMappingRulesFile}}'); d=json.load(f); f.close(); print(' '.join(['-remapPath=\"'+r['source_path']+'='+r['destination_path']+'\"' for r in d.get('path_mapping_rules',[]) if r.get('source_path') and r.get('destination_path')]))")
+            fi
+            if [ -n "$REMAP_PATHS" ]; then
+              VRAY_CMD="$VRAY_CMD $REMAP_PATHS"
+              echo "Added path remapping: $REMAP_PATHS"
+            fi
+          fi
+          
+          eval $VRAY_CMD
+  hostRequirements:
+    attributes:
+    - name: attr.worker.os.family
+      anyOf:
+      - linux
+
+- name: MergeRegions
+  parameterSpace:
+    taskParameterDefinitions:
+    - name: Frame
+      type: INT
+      range: "{{Param.Frames}}"
+  dependencies:
+  - dependsOn: RenderRegions
+  script:
+    actions:
+      onRun:
+        command: bash
+        args: ['{{Task.File.Run}}']
+        cancelation:
+          mode: NOTIFY_THEN_TERMINATE
+    embeddedFiles:
+      - name: Run
+        type: TEXT
+        data: |
+          set -xeuo pipefail
+          FRAME={{Task.Param.Frame}}
+          echo "Merging regions for frame $FRAME into final image..."
+          COLS={{Param.RegionColumns}}
+          ROWS={{Param.RegionRows}}
+          FILENAME="{{Param.OutputFilename}}"
+          BASE="${FILENAME%.*}"
+          EXT="${FILENAME##*.}"
+          OUTPUT_DIR="{{Param.OutputDir}}"
+          
+          # V-Ray appends frame number as 4-digit suffix (e.g., .0001.png)
+          FRAME_SUFFIX=$(printf "%04d" $FRAME)
+          
+          echo "Looking for region files with pattern: ${BASE}_f${FRAME}_region_r*_c*.${FRAME_SUFFIX}.${EXT}"
+          
+          # Check if all region files exist
+          MISSING_FILES=0
+          for ((row=0; row<ROWS; row++)); do
+            for ((col=0; col<COLS; col++)); do
+              REGION_FILE="${OUTPUT_DIR}/${BASE}_f${FRAME}_region_r${row}_c${col}.${FRAME_SUFFIX}.${EXT}"
+              if [ ! -f "$REGION_FILE" ]; then
+                echo "ERROR: Missing region file: $REGION_FILE"
+                MISSING_FILES=$((MISSING_FILES + 1))
+              else
+                echo "Found: $REGION_FILE"
+              fi
+            done
+          done
+          
+          if [ $MISSING_FILES -gt 0 ]; then
+            echo "ERROR: $MISSING_FILES region files are missing for frame $FRAME. Cannot merge."
+            echo "Available files in output directory:"
+            ls -la "${OUTPUT_DIR}/" 2>/dev/null || echo "No files found"
+            exit 1
+          fi
+          
+          if command -v convert &> /dev/null; then
+            for ((row=0; row<ROWS; row++)); do
+              ROW_FILES=""
+              for ((col=0; col<COLS; col++)); do
+                ROW_FILES="$ROW_FILES ${OUTPUT_DIR}/${BASE}_f${FRAME}_region_r${row}_c${col}.${FRAME_SUFFIX}.${EXT}"
+              done
+              convert $ROW_FILES +append "${OUTPUT_DIR}/${BASE}_f${FRAME}_row_${row}.${EXT}"
+              echo "Created row $row for frame $FRAME"
+            done
+            ALL_ROWS=""
+            for ((row=0; row<ROWS; row++)); do
+              ALL_ROWS="$ALL_ROWS ${OUTPUT_DIR}/${BASE}_f${FRAME}_row_${row}.${EXT}"
+            done
+            # Use zero-padded frame number for proper sorting
+            PADDED_FRAME=$(printf "%04d" $FRAME)
+            convert $ALL_ROWS -append "${OUTPUT_DIR}/${BASE}.${PADDED_FRAME}.${EXT}"
+            for ((row=0; row<ROWS; row++)); do
+              rm -f "${OUTPUT_DIR}/${BASE}_f${FRAME}_row_${row}.${EXT}"
+            done
+            echo "Merged image created: ${OUTPUT_DIR}/${BASE}.${PADDED_FRAME}.${EXT}"
+          else
+            echo "Warning: ImageMagick not found. Region files are available but not merged."
+            echo "Region files: ${OUTPUT_DIR}/${BASE}_f${FRAME}_region_*.${FRAME_SUFFIX}.${EXT}"
+          fi
+  hostRequirements:
+    attributes:
+    - name: attr.worker.os.family
+      anyOf:
+      - linux
+
+- name: CreateMovieFile
+  dependencies:
+  - dependsOn: MergeRegions
+  script:
+    actions:
+      onRun:
+        command: bash
+        args: ['{{Task.File.Run}}']
+        cancelation:
+          mode: NOTIFY_THEN_TERMINATE
+    embeddedFiles:
+      - name: Run
+        type: TEXT
+        data: |
+          set -xeuo pipefail
+          
+          if [ "{{Param.CreateMovie}}" != "true" ]; then
+            echo "Movie creation disabled, skipping"
+            exit 0
+          fi
+          
+          echo "Creating movie from rendered frames..."
+          FILENAME="{{Param.OutputFilename}}"
+          BASE="${FILENAME%.*}"
+          EXT="${FILENAME##*.}"
+          OUTPUT_DIR="{{Param.OutputDir}}"
+          MOVIE_FILE="{{Param.MovieFilename}}"
+          FRAME_RATE={{Param.FrameRate}}
+          
+          if command -v ffmpeg &> /dev/null; then
+            # Create movie from frame sequence using proper frame pattern
+            # Pattern: output.%04d.png matches output.0001.png, output.0002.png, etc.
+            ffmpeg -framerate $FRAME_RATE -i "${OUTPUT_DIR}/${BASE}.%04d.${EXT}" \
+                   -c:v libx264 -pix_fmt yuv420p -crf 18 \
+                   "${OUTPUT_DIR}/${MOVIE_FILE}"
+            
+            echo "Movie created: ${OUTPUT_DIR}/${MOVIE_FILE}"
+          else
+            echo "Error: ffmpeg not found. Cannot create movie file."
+            exit 1
+          fi
+  hostRequirements:
+    attributes:
+    - name: attr.worker.os.family
+      anyOf:
+      - linux


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Users needed a way to render V-Ray scenes using tile/region rendering on Linux workers in AWS Deadline Cloud. Tile rendering divides an image into smaller regions that can be rendered in parallel across multiple workers, significantly reducing total render time for large or complex scenes.

### What was the solution? (How)
Added a new job bundle tile_render_with_vray_linux that:
- Divides images into a configurable grid of regions (rows × columns)
- Renders each region as an independent parallel task using V-Ray's -crop flag
- Merges regions into complete frames using ImageMagick
- Optionally creates an MP4 movie from rendered frames using ffmpeg
- Handles path remapping automatically for assets via Job Attachments

Also improved the V-Ray conda recipe README with:
- Clarification that submit-package-job can run from any platform
- Note about required S3 permissions for the queue's IAM role

### What is the impact of this change?
Enables parallel tile rendering for V-Ray scenes on Deadline Cloud. Reduces render time for large/complex scenes by distributing work across workers. Provides a complete workflow from scene to final image (and optional movie)

### How was this change tested?
- Submitted the job bundle to a Deadline Cloud queue with Linux workers
- Tested with sample V-Ray scenes from Chaos documentation
- Verified region rendering, merging, and movie creation steps complete successfully
- Confirmed path remapping works correctly for assets uploaded via Job Attachments

### Was this change documented?

- README.md added for the job bundle 
- V-Ray conda recipe README updated with additional usage notes

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*