### PR TITLE
feat: Add 2 sample host config scripts to reboot Windows workers and increase page size on Windows workers

### DIFF
--- a/host_configuration_scripts/README.md
+++ b/host_configuration_scripts/README.md
@@ -1,16 +1,20 @@
-# Sample Host Configuration scripts to configure Service Managed Fleets for AWS Deadline Cloud
+# Sample Host Configuration Scripts for AWS Deadline Cloud Service Managed Fleets
 
 ## Summary
 
 This directory contains sample scripts for configuring Service Managed Fleets on Windows and Linux.
 
-[Host Configuration Scripts](https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/smf-admin.html) allow you to perform administrative tasks, such as software installation, on your service-managed fleet workers. These scripts run with elevated privileges, giving you the flexibility to configure your workers for your system.
+Host Configuration Scripts allow you to perform administrative tasks, such as software installation, on your service-managed fleet workers. These scripts run with elevated privileges, giving you the flexibility to configure your workers for your system.
 
-## Common uses for the script include:
+## Common Uses
 - Installing software that requires administrator access
 - Installing Docker containers
 
-## Debugging Host Configuration Scripts:
+## Setup
+
+Copy and paste the sample scripts into the AWS Deadline Cloud console or use the AWS Deadline Cloud CLI to update your fleet. Follow [Run scripts as an administrator to configure workers](https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/smf-admin.html) or reference the [AWS Deadline Cloud update-fleet CLI](https://docs.aws.amazon.com/cli/latest/reference/deadline/update-fleet.html) for more details.
+
+## Debugging
 
 ### CloudWatch Logs 
 Fleet Host Configuration logs are streamed to the Fleet’s log group, and specifically to a worker’s log stream. For example, `/aws/deadline/farm-12345/fleet-09876` is the log group for farm-12345, fleet-09876. Each worker will provision a dedicated log stream, for example worker-13579. Notice in the logs the log banner “Running Host Configuration Script” and “Finished running Host Configuration Script, exit code: 0”. The exit code of the script is included in the finished banner, and can be queried using CloudWatch tools.

--- a/host_configuration_scripts/worker_configuration/README.md
+++ b/host_configuration_scripts/worker_configuration/README.md
@@ -7,4 +7,21 @@ For setup instructions and troubleshooting guidance, refer to the [host_configur
 ## Windows
 
 ### Page File Configuration
-The [configure_page_file.ps1](windows/configure_page_file.ps1) script configures the Windows page file size based on available RAM. It automatically selects the drive with the most free space, sets the page file to 2x the system RAM, and reboots the worker to apply changes. A marker file (`C:\deadline-pagefile-configured`) prevents reconfiguration on subsequent starts.
+The [configure_page_file.ps1](windows/configure_page_file.ps1) script configures the Windows page file size and placement. It prefers local NVMe instance storage when available for optimal performance.
+
+Page file sizing logic:
+- For NVMe drives: By default, uses the smaller of 2x RAM or 75% of NVMe space
+- If NVMe is not available: By default, uses the largest non-boot drive with 2x RAM
+- If no non-boot drives are available: Falls back to the boot drive (C:)
+
+The script automatically detects Amazon EC2 NVMe instance storage, disables automatic page file management, formats the drive and assigns a drive letter if needed, and reboots the worker to apply changes. A marker file (`C:\deadline-pagefile-configured`) prevents reconfiguration on subsequent starts.
+
+#### Configuration Options
+Adjust these variables at the top of the script to fit your workload requirements:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `$RAM_MULTIPLIER` | 2 | Page file size as a multiple of RAM (e.g., 2 = 2x RAM) |
+| `$NVME_SPACE_PERCENTAGE` | 0.75 | Max percentage of NVMe space to use for the page file (e.g., 0.75 = 75%) |
+| `$MIN_DISK_SIZE_GB` | 1 | Minimum disk size in GB to consider for storing page file |
+| `$MARKER_FILE_PATH` | `C:\deadline-pagefile-configured` | Path to the marker file that prevents reconfiguration |

--- a/host_configuration_scripts/worker_configuration/README.md
+++ b/host_configuration_scripts/worker_configuration/README.md
@@ -1,0 +1,10 @@
+# This directory provides example scripts for custom configurations on Deadline Cloud Service Managed Workers
+
+These scripts demonstrate common configuration tasks that may be required for your workloads. For example, adjusting system settings, configuring memory management, or setting up environment-specific parameters.
+
+For setup instructions and troubleshooting guidance, refer to the [host_configuration_scripts README](../README.md).
+
+## Windows
+
+### Page File Configuration
+The [configure_page_file.ps1](windows/configure_page_file.ps1) script configures the Windows page file size based on available RAM. It automatically selects the drive with the most free space, sets the page file to 2x the system RAM, and reboots the worker to apply changes. A marker file (`C:\deadline-pagefile-configured`) prevents reconfiguration on subsequent starts.

--- a/host_configuration_scripts/worker_configuration/windows/configure_page_file.ps1
+++ b/host_configuration_scripts/worker_configuration/windows/configure_page_file.ps1
@@ -111,34 +111,35 @@ if ($selectedDisk) {
    Write-Host "Selected disk: Disk $($selectedDisk.Number) ($([math]::Round($selectedDisk.Size / 1GB, 2))GB)"
    
    if ($selectedDisk.PartitionStyle -eq 'RAW') {
-   Write-Host "Disk $($selectedDisk.Number) is RAW - initializing and formatting..."
-   
-   # Find available drive letter (prefer D, then E, F, etc.)
-   $usedLetters = Get-PSDrive -PSProvider FileSystem | Select-Object -ExpandProperty Name
-   $availableLetters = 68..90 | ForEach-Object { [char]$_ } | Where-Object { $_ -notin $usedLetters }
-   $driveLetter = $availableLetters[0]
-   
-   Write-Host "Using drive letter: ${driveLetter}:"
-   
-   Initialize-Disk -Number $selectedDisk.Number -PartitionStyle GPT -Confirm:$false
-   $partition = New-Partition -DiskNumber $selectedDisk.Number -UseMaximumSize -DriveLetter $driveLetter
-   Format-Volume -Partition $partition -FileSystem NTFS -NewFileSystemLabel "PageFile" -Confirm:$false
-   Write-Host "Disk formatted successfully as ${driveLetter}:"
-} else {
-   Write-Host "Disk already initialized - checking for drive letter..."
-   $partition = Get-Partition -DiskNumber $selectedDisk.Number | Where-Object { $_.Type -eq 'Basic' } | Select-Object -First 1
-   
-   if ($partition.DriveLetter) {
-       $driveLetter = $partition.DriveLetter
-       Write-Host "Using existing drive letter: ${driveLetter}:"
-   } else {
-       # Assign drive letter
+       Write-Host "Disk $($selectedDisk.Number) is RAW - initializing and formatting..."
+       
+       # Find available drive letter (prefer D, then E, F, etc.)
        $usedLetters = Get-PSDrive -PSProvider FileSystem | Select-Object -ExpandProperty Name
        $availableLetters = 68..90 | ForEach-Object { [char]$_ } | Where-Object { $_ -notin $usedLetters }
        $driveLetter = $availableLetters[0]
        
-       Write-Host "Assigning drive letter: ${driveLetter}:"
-       Set-Partition -DiskNumber $selectedDisk.Number -PartitionNumber $partition.PartitionNumber -NewDriveLetter $driveLetter
+       Write-Host "Using drive letter: ${driveLetter}:"
+       
+       Initialize-Disk -Number $selectedDisk.Number -PartitionStyle GPT -Confirm:$false
+       $partition = New-Partition -DiskNumber $selectedDisk.Number -UseMaximumSize -DriveLetter $driveLetter
+       Format-Volume -Partition $partition -FileSystem NTFS -NewFileSystemLabel "PageFile" -Confirm:$false
+       Write-Host "Disk formatted successfully as ${driveLetter}:"
+   } else {
+       Write-Host "Disk already initialized - checking for drive letter..."
+       $partition = Get-Partition -DiskNumber $selectedDisk.Number | Where-Object { $_.Type -eq 'Basic' } | Select-Object -First 1
+       
+       if ($partition.DriveLetter) {
+           $driveLetter = $partition.DriveLetter
+           Write-Host "Using existing drive letter: ${driveLetter}:"
+       } else {
+           # Assign drive letter
+           $usedLetters = Get-PSDrive -PSProvider FileSystem | Select-Object -ExpandProperty Name
+           $availableLetters = 68..90 | ForEach-Object { [char]$_ } | Where-Object { $_ -notin $usedLetters }
+           $driveLetter = $availableLetters[0]
+           
+           Write-Host "Assigning drive letter: ${driveLetter}:"
+           Set-Partition -DiskNumber $selectedDisk.Number -PartitionNumber $partition.PartitionNumber -NewDriveLetter $driveLetter
+       }
    }
 }
 
@@ -149,10 +150,23 @@ Write-Host "Disabling automatic page file management..."
 $cs.AutomaticManagedPagefile = $false
 $cs.Put() | Out-Null
 
+# Show page file settings after disabling automatic management
+Write-Host "=== Page File Settings After Disabling Automatic Management ==="
+$pageFilesAfterDisable = Get-WmiObject Win32_PageFileSetting
+if ($pageFilesAfterDisable) {
+   foreach ($pf in $pageFilesAfterDisable) {
+       Write-Host "  Location: $($pf.Name)"
+       Write-Host "  Initial Size: $($pf.InitialSize)MB"
+       Write-Host "  Maximum Size: $($pf.MaximumSize)MB"
+   }
+} else {
+   Write-Host "  No page files configured"
+}
+
 # Remove existing page files
 Write-Host "Removing existing page files..."
-if ($existingPageFiles) {
-   foreach ($pf in $existingPageFiles) {
+if ($pageFilesAfterDisable) {
+   foreach ($pf in $pageFilesAfterDisable) {
        Write-Host "  Removing: $($pf.Name)"
        $pf.Delete()
    }

--- a/host_configuration_scripts/worker_configuration/windows/configure_page_file.ps1
+++ b/host_configuration_scripts/worker_configuration/windows/configure_page_file.ps1
@@ -197,4 +197,4 @@ New-Item $MARKER_FILE_PATH -ItemType File | Out-Null
 Write-Host "=== Configuration Complete - Rebooting ==="
 Restart-Computer -Force
 Start-Sleep 60
-exit 0
+exit 1

--- a/host_configuration_scripts/worker_configuration/windows/configure_page_file.ps1
+++ b/host_configuration_scripts/worker_configuration/windows/configure_page_file.ps1
@@ -1,0 +1,96 @@
+Write-Host "=== Deadline Cloud Page File Configuration Script ==="
+Write-Host "Checking if host already rebooted after page file configuration"
+
+if (Test-Path "C:\deadline-pagefile-configured") { 
+   Write-Host "SUCCESS: Page file already configured and rebooted. Ready to start."
+   Write-Host "=== Current Page File Configuration (After Reboot) ==="
+   Get-WmiObject Win32_PageFileSetting | ForEach-Object {
+       Write-Host "  Location: $($_.Name)"
+       Write-Host "  Initial Size: $($_.InitialSize)MB"
+       Write-Host "  Maximum Size: $($_.MaximumSize)MB"
+   }
+   exit 0 
+}
+
+Write-Host "Host has not been rebooted yet. Starting page file configuration..."
+
+# Show BEFORE state
+Write-Host "=== BEFORE: Current Page File Configuration ==="
+$cs = Get-WmiObject Win32_ComputerSystem
+Write-Host "  Automatic Management: $($cs.AutomaticManagedPagefile)"
+$existingPageFiles = Get-WmiObject Win32_PageFileSetting
+if ($existingPageFiles) {
+   foreach ($pf in $existingPageFiles) {
+       Write-Host "  Location: $($pf.Name)"
+       Write-Host "  Initial Size: $($pf.InitialSize)MB"
+       Write-Host "  Maximum Size: $($pf.MaximumSize)MB"
+   }
+} else {
+   Write-Host "  No page files configured"
+}
+
+# Get RAM info
+$ram = (Get-CimInstance Win32_ComputerSystem).TotalPhysicalMemory / 1MB
+$pageFileSizeMB = [math]::Round($ram * 2)
+Write-Host "Detected RAM: $([math]::Round($ram))MB"
+Write-Host "Target page file size: ${pageFileSizeMB}MB (2x RAM)"
+
+# Find best drive
+Write-Host "Scanning drives for page file placement..."
+$drives = Get-PSDrive -PSProvider FileSystem | Where-Object { $_.Free -gt 0 }
+foreach ($d in $drives) {
+   $freeGB = [math]::Round($d.Free / 1GB, 2)
+   Write-Host "  Drive $($d.Name): ${freeGB}GB free"
+}
+
+$bestDrive = $drives | 
+   Where-Object { $_.Free -gt ($pageFileSizeMB * 1MB * 1.1) } | 
+   Sort-Object Free -Descending | 
+   Select-Object -First 1
+
+if (-not $bestDrive) {
+   Write-Error "ERROR: No drive with sufficient space for ${pageFileSizeMB}MB page file"
+   exit 1
+}
+
+$drive = $bestDrive.Name
+Write-Host "Selected drive: ${drive}: ($([math]::Round($bestDrive.Free / 1GB, 2))GB free)"
+
+# Disable automatic page file management
+Write-Host "Disabling automatic page file management..."
+$cs.AutomaticManagedPagefile = $false
+$cs.Put() | Out-Null
+
+# Remove existing page files
+Write-Host "Removing existing page files..."
+if ($existingPageFiles) {
+   foreach ($pf in $existingPageFiles) {
+       Write-Host "  Removing: $($pf.Name)"
+       $pf.Delete()
+   }
+}
+
+# Create new page file
+Write-Host "Creating new page file: ${drive}:\pagefile.sys"
+$newPf = ([wmiclass]"Win32_PageFileSetting").CreateInstance()
+$newPf.Name = "${drive}:\pagefile.sys"
+$newPf.InitialSize = $pageFileSizeMB
+$newPf.MaximumSize = $pageFileSizeMB
+$newPf.Put() | Out-Null
+
+# Show AFTER state (before reboot)
+Write-Host "=== AFTER: New Page File Configuration (Pending Reboot) ==="
+Get-WmiObject Win32_PageFileSetting | ForEach-Object {
+   Write-Host "  Location: $($_.Name)"
+   Write-Host "  Initial Size: $($_.InitialSize)MB"
+   Write-Host "  Maximum Size: $($_.MaximumSize)MB"
+}
+
+# Create marker file
+Write-Host "Creating marker file: C:\deadline-pagefile-configured"
+New-Item "C:\deadline-pagefile-configured" -ItemType File | Out-Null
+
+Write-Host "=== Configuration Complete - Rebooting ==="
+Restart-Computer -Force
+Start-Sleep 60
+exit 0

--- a/host_configuration_scripts/worker_configuration/windows/configure_page_file.ps1
+++ b/host_configuration_scripts/worker_configuration/windows/configure_page_file.ps1
@@ -1,9 +1,20 @@
+# =============================================================================
+# CONFIGURATION - Adjust these values based on your workload requirements
+# =============================================================================
+$RAM_MULTIPLIER = 2              # Page file size as multiple of RAM (e.g., 2 = 2x RAM)
+$NVME_SPACE_PERCENTAGE = 0.75    # Max percentage of NVMe space to use for the page file (e.g., 0.75 = 75%)
+$MIN_DISK_SIZE_GB = 1            # Minimum disk size in GB to consider for storing page file
+$MARKER_FILE_PATH = "C:\deadline-pagefile-configured"
+# =============================================================================
+
 Write-Host "=== Deadline Cloud Page File Configuration Script ==="
 Write-Host "Checking if host already rebooted after page file configuration"
 
-if (Test-Path "C:\deadline-pagefile-configured") { 
+if (Test-Path $MARKER_FILE_PATH) { 
    Write-Host "SUCCESS: Page file already configured and rebooted. Ready to start."
    Write-Host "=== Current Page File Configuration (After Reboot) ==="
+   $cs = Get-WmiObject Win32_ComputerSystem
+   Write-Host "  Automatic Management: $($cs.AutomaticManagedPagefile)"
    Get-WmiObject Win32_PageFileSetting | ForEach-Object {
        Write-Host "  Location: $($_.Name)"
        Write-Host "  Initial Size: $($_.InitialSize)MB"
@@ -31,30 +42,107 @@ if ($existingPageFiles) {
 
 # Get RAM info
 $ram = (Get-CimInstance Win32_ComputerSystem).TotalPhysicalMemory / 1MB
-$pageFileSizeMB = [math]::Round($ram * 2)
+$targetPageFileSizeMB = [math]::Round($ram * $RAM_MULTIPLIER)
 Write-Host "Detected RAM: $([math]::Round($ram))MB"
-Write-Host "Target page file size: ${pageFileSizeMB}MB (2x RAM)"
+Write-Host "Target page file size: ${targetPageFileSizeMB}MB (${RAM_MULTIPLIER}x RAM)"
 
-# Find best drive
-Write-Host "Scanning drives for page file placement..."
-$drives = Get-PSDrive -PSProvider FileSystem | Where-Object { $_.Free -gt 0 }
-foreach ($d in $drives) {
-   $freeGB = [math]::Round($d.Free / 1GB, 2)
-   Write-Host "  Drive $($d.Name): ${freeGB}GB free"
+# Scan all disks (including unformatted)
+Write-Host "Scanning all disks for page file placement..."
+$allDisks = Get-Disk | Where-Object { !$_.IsBoot -and $_.Size -gt ($MIN_DISK_SIZE_GB * 1GB) }
+Write-Host "Found $($allDisks.Count) non-boot disks larger than ${MIN_DISK_SIZE_GB}GB"
+
+$nvmeDisk = $null
+$largestDisk = $null
+
+foreach ($disk in $allDisks) {
+   $sizeGB = [math]::Round($disk.Size / 1GB, 2)
+   
+   try {
+       $diskInfo = Get-WmiObject -Class Win32_DiskDrive | Where-Object { $_.Index -eq $disk.Number }
+       
+       if ($diskInfo) {
+           $isLocalNVMe = $diskInfo.Model -like "*Amazon EC2 NVMe*"
+           Write-Host "  Disk $($disk.Number): ${sizeGB}GB, Model: $($diskInfo.Model), PartitionStyle: $($disk.PartitionStyle), Local NVMe: $isLocalNVMe"
+           
+           if ($isLocalNVMe -and !$nvmeDisk) {
+               $nvmeDisk = $disk
+               Write-Host "    -> Detected as local NVMe instance storage (preferred)"
+           }
+       } else {
+           Write-Host "  Disk $($disk.Number): ${sizeGB}GB, PartitionStyle: $($disk.PartitionStyle), Model: Unknown"
+       }
+   } catch {
+       Write-Host "  Disk $($disk.Number): ${sizeGB}GB, Could not determine disk type"
+   }
+   
+   if (!$largestDisk -or $disk.Size -gt $largestDisk.Size) {
+       $largestDisk = $disk
+   }
 }
 
-$bestDrive = $drives | 
-   Where-Object { $_.Free -gt ($pageFileSizeMB * 1MB * 1.1) } | 
-   Sort-Object Free -Descending | 
-   Select-Object -First 1
+# Select disk and calculate page file size
+$selectedDisk = $null
+$pageFileSizeMB = $targetPageFileSizeMB
 
-if (-not $bestDrive) {
-   Write-Error "ERROR: No drive with sufficient space for ${pageFileSizeMB}MB page file"
+if ($nvmeDisk) {
+   $nvmeMaxPageFileMB = [math]::Round(($nvmeDisk.Size / 1MB) * $NVME_SPACE_PERCENTAGE)
+   $pageFileSizeMB = [math]::Min($targetPageFileSizeMB, $nvmeMaxPageFileMB)
+   $selectedDisk = $nvmeDisk
+   $nvmePercentDisplay = [math]::Round($NVME_SPACE_PERCENTAGE * 100)
+   Write-Host "Using local NVMe: min(${RAM_MULTIPLIER}x RAM: ${targetPageFileSizeMB}MB, ${nvmePercentDisplay}% NVMe: ${nvmeMaxPageFileMB}MB) = ${pageFileSizeMB}MB"
+} elseif ($largestDisk) {
+   Write-Host "No local NVMe instance storage found - using largest available non-boot disk with ${RAM_MULTIPLIER}x RAM"
+   $selectedDisk = $largestDisk
+   $pageFileSizeMB = $targetPageFileSizeMB
+} else {
+   # Fall back to boot drive if no non-boot drives available
+   Write-Host "No non-boot disks found - falling back to boot drive (C:)"
+   $driveLetter = 'C'
+   $pageFileSizeMB = $targetPageFileSizeMB
+}
+
+if (!$selectedDisk -and !$driveLetter) {
+   Write-Error "ERROR: No suitable disk found for page file"
    exit 1
 }
 
-$drive = $bestDrive.Name
-Write-Host "Selected drive: ${drive}: ($([math]::Round($bestDrive.Free / 1GB, 2))GB free)"
+# Initialize and format disk if needed (skip if using boot drive)
+if ($selectedDisk) {
+   Write-Host "Selected disk: Disk $($selectedDisk.Number) ($([math]::Round($selectedDisk.Size / 1GB, 2))GB)"
+   
+   if ($selectedDisk.PartitionStyle -eq 'RAW') {
+   Write-Host "Disk $($selectedDisk.Number) is RAW - initializing and formatting..."
+   
+   # Find available drive letter (prefer D, then E, F, etc.)
+   $usedLetters = Get-PSDrive -PSProvider FileSystem | Select-Object -ExpandProperty Name
+   $availableLetters = 68..90 | ForEach-Object { [char]$_ } | Where-Object { $_ -notin $usedLetters }
+   $driveLetter = $availableLetters[0]
+   
+   Write-Host "Using drive letter: ${driveLetter}:"
+   
+   Initialize-Disk -Number $selectedDisk.Number -PartitionStyle GPT -Confirm:$false
+   $partition = New-Partition -DiskNumber $selectedDisk.Number -UseMaximumSize -DriveLetter $driveLetter
+   Format-Volume -Partition $partition -FileSystem NTFS -NewFileSystemLabel "PageFile" -Confirm:$false
+   Write-Host "Disk formatted successfully as ${driveLetter}:"
+} else {
+   Write-Host "Disk already initialized - checking for drive letter..."
+   $partition = Get-Partition -DiskNumber $selectedDisk.Number | Where-Object { $_.Type -eq 'Basic' } | Select-Object -First 1
+   
+   if ($partition.DriveLetter) {
+       $driveLetter = $partition.DriveLetter
+       Write-Host "Using existing drive letter: ${driveLetter}:"
+   } else {
+       # Assign drive letter
+       $usedLetters = Get-PSDrive -PSProvider FileSystem | Select-Object -ExpandProperty Name
+       $availableLetters = 68..90 | ForEach-Object { [char]$_ } | Where-Object { $_ -notin $usedLetters }
+       $driveLetter = $availableLetters[0]
+       
+       Write-Host "Assigning drive letter: ${driveLetter}:"
+       Set-Partition -DiskNumber $selectedDisk.Number -PartitionNumber $partition.PartitionNumber -NewDriveLetter $driveLetter
+   }
+}
+
+Write-Host "Final page file size: ${pageFileSizeMB}MB on ${driveLetter}:"
 
 # Disable automatic page file management
 Write-Host "Disabling automatic page file management..."
@@ -71,15 +159,17 @@ if ($existingPageFiles) {
 }
 
 # Create new page file
-Write-Host "Creating new page file: ${drive}:\pagefile.sys"
+Write-Host "Creating new page file: ${driveLetter}:\pagefile.sys"
 $newPf = ([wmiclass]"Win32_PageFileSetting").CreateInstance()
-$newPf.Name = "${drive}:\pagefile.sys"
+$newPf.Name = "${driveLetter}:\pagefile.sys"
 $newPf.InitialSize = $pageFileSizeMB
 $newPf.MaximumSize = $pageFileSizeMB
 $newPf.Put() | Out-Null
 
 # Show AFTER state (before reboot)
 Write-Host "=== AFTER: New Page File Configuration (Pending Reboot) ==="
+$cs = Get-WmiObject Win32_ComputerSystem
+Write-Host "  Automatic Management: $($cs.AutomaticManagedPagefile)"
 Get-WmiObject Win32_PageFileSetting | ForEach-Object {
    Write-Host "  Location: $($_.Name)"
    Write-Host "  Initial Size: $($_.InitialSize)MB"
@@ -87,8 +177,8 @@ Get-WmiObject Win32_PageFileSetting | ForEach-Object {
 }
 
 # Create marker file
-Write-Host "Creating marker file: C:\deadline-pagefile-configured"
-New-Item "C:\deadline-pagefile-configured" -ItemType File | Out-Null
+Write-Host "Creating marker file: $MARKER_FILE_PATH"
+New-Item $MARKER_FILE_PATH -ItemType File | Out-Null
 
 Write-Host "=== Configuration Complete - Rebooting ==="
 Restart-Computer -Force

--- a/host_configuration_scripts/worker_reboot/README.md
+++ b/host_configuration_scripts/worker_reboot/README.md
@@ -4,3 +4,6 @@ Worker reboots may be required for system configuration changes. For example, in
 
 ## Linux
 The [Linux example script](linux.sh) will reboot a Linux Deadline Cloud Worker. When the worker starts, host configuration scripts execute during the `STARTED` state. In the host config script, users can issue standard Linux `reboot` commands. To prevent the worker agent from starting job processing, the script sleeps for 60 seconds while the host shuts down. A `rebooted` file is saved to indicate that a reboot has been issued. Upon the second start, the Deadline Cloud agent can begin processing jobs.
+
+## Windows
+The [Windows example script](windows.ps1) will reboot a Windows Deadline Cloud Worker. Similar to the Linux script, it checks for a marker file (`C:\deadline-rebooted`) to determine if a reboot has already occurred. If the marker file exists, the script exits successfully and the worker can begin processing jobs. Otherwise, it creates the marker file and initiates a system reboot using `Restart-Computer -Force`, then sleeps for 60 seconds while the host shuts down.

--- a/host_configuration_scripts/worker_reboot/windows.ps1
+++ b/host_configuration_scripts/worker_reboot/windows.ps1
@@ -1,0 +1,16 @@
+Write-Host "=== Deadline Cloud Reboot Script Example ==="
+Write-Host "Checking if host already rebooted"
+
+if (Test-Path "C:\deadline-rebooted") { 
+   Write-Host "SUCCESS: Host already rebooted. Ready to start."
+   exit 0 
+}
+
+Write-Host "Host has not been rebooted yet"
+Write-Host "Creating marker file: C:\deadline-rebooted"
+New-Item "C:\deadline-rebooted" -ItemType File | Out-Null
+
+Write-Host "Rebooting host..."
+Restart-Computer -Force
+Start-Sleep 60
+exit 0

--- a/host_configuration_scripts/worker_reboot/windows.ps1
+++ b/host_configuration_scripts/worker_reboot/windows.ps1
@@ -13,4 +13,4 @@ New-Item "C:\deadline-rebooted" -ItemType File | Out-Null
 Write-Host "Rebooting host..."
 Restart-Computer -Force
 Start-Sleep 60
-exit 0
+exit 1


### PR DESCRIPTION
feat: Add 2 sample host config scripts to reboot Windows workers and increase page size on Windows workers

### What was the problem/requirement? (What/Why)
We need to provide host config script examples for rebooting Windows workers and increasing page size on Windows workers

### What was the solution? (How)
Added 2 host config script samples for rebooting Windows workers and increasing page size on Windows workers

### What is the impact of this change?
Customer can use these samples as a starting point when they need to write host config scripts for Windows workers

### How was this change tested?


- If this is a sample, then please describe the steps that you took to test it.
- Include output from your testing to demonstrate it working as expected if possible.

### Was this change documented?
Added them to my test SMF and confirmed it's working as expected.

Logs for rebooting host config script: 
<img width="1020" height="1350" alt="Screenshot 2026-01-22 at 2 16 28 PM" src="https://github.com/user-attachments/assets/4f5caee3-bbc1-4a58-a8b2-43511d3b1784" />

Logs for configure page file host config script:

<img width="1021" height="885" alt="Screenshot 2026-01-22 at 9 08 24 PM" src="https://github.com/user-attachments/assets/0957b148-cdaf-4285-9146-5bee39b891ec" />

...

<img width="980" height="531" alt="Screenshot 2026-01-22 at 9 08 34 PM" src="https://github.com/user-attachments/assets/aae0ca70-712f-4f21-8e1f-ee453e9dcb50" />

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*