### PR TITLE
feat: add disconnect UBL queue environment sample

### DIFF
--- a/queue_environments/README.md
+++ b/queue_environments/README.md
@@ -149,3 +149,17 @@ The core enhancement of this queue environment is to use named Conda environment
 jobs. The default environment name uses the hash of the Conda channels and packages, or you can explicitly
 set the name in the job. It also includes a parameter for how long to use an environment without running a package
 update, so that most of the time it will take seconds to activate an environment that's being reused.
+
+### Disconnect UBL queue environment
+
+The file [disconnect_ubl_queue_env.yaml](disconnect_ubl_queue_env.yaml) unsets Deadline Cloud Usage Based
+License (UBL) environment variables. Use this queue environment if you want to turn off all connections to
+Deadline Cloud UBL for your queue and force the use of a custom license server (see the
+[Bring Your Own License documentation](https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/smf-byol.html)).
+
+This queue environment should be run before any other queue environments (for example, by setting the priority to 0)
+so that connections to your custom floating licenses (such as RLM) in other queue environments are not
+accidentally removed.
+
+Please note that this is a sample, additional UBL environment variables may be
+added in the future.

--- a/queue_environments/disconnect_ubl_queue_env.yaml
+++ b/queue_environments/disconnect_ubl_queue_env.yaml
@@ -1,0 +1,42 @@
+specificationVersion: 'environment-2023-09'
+environment:
+  name: DisconnectUBL
+  description: |
+    Unsets Deadline Cloud Usage Based License (UBL) environment variables.
+
+    Use this queue environment if you would like to turn off all connection to
+    Deadline Cloud UBL for your queue and force the use of a custom license server.
+    (see https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/smf-byol.html).
+
+    This queue environment should be run before any other queue environments
+    (for example, by setting the priority to 0) so that connections to your
+    custom licenses server (such as RLM) in other queue environments are not
+    accidentally removed.
+
+    Please note that this is a sample, additional UBL environment variables may
+    be added in the future.
+  script:
+    actions:
+      onEnter:
+        command: bash
+        args:
+        - "{{Env.File.Enter}}"
+    embeddedFiles:
+    - name: Enter
+      filename: disconnect-ubl-enter.sh
+      type: TEXT
+      data: |
+        vars=(
+          ADSKFLEX_LICENSE_FILE
+          LUXION_LICENSE_FILE
+          PIXAR_LICENSE_FILE
+          SESI_LMHOST
+          VRAY_AUTH_CLIENT_SETTINGS
+          foundry_LICENSE
+          g_licenseServerRLM
+          redshift_LICENSE
+        )
+        
+        for var in "${vars[@]}"; do
+          echo "openjd_unset_env: $var"
+        done


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Users who want to use Bring Your Own License (BYOL) with custom license servers may want to ensure that deadline Cloud Usage Based License (UBL) is disconnected.

### What was the solution? (How)

Added a new queue environment sample `disconnect_ubl_queue_env.yaml` that unsets all Deadline Cloud UBL-related environment variables.

The queue environment uses an embedded bash script that outputs `openjd_unset_env` commands for each variable. Updated the queue_environments README.md to document this new sample.

### What is the impact of this change?

Users can now easily configure their queues to never fallback to Deadline Cloud UBL by adding this queue environment with priority 0 (to run before other queue environments).

### How was this change tested?

- Added this queue environment to my queue and verified that all licensing environment variables were unset.

### Was this change documented?

Yes, added documentation to `queue_environments/README.md` explaining:
- What the queue environment does
- When to use it (BYOL scenarios)
- How to configure it (priority 0)

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
