### PR TITLE
feat: Add samples for task chunking jobs

### DIFF
--- a/job_bundles/task_chunking/README.md
+++ b/job_bundles/task_chunking/README.md
@@ -10,11 +10,11 @@ Render jobs often spend significant time loading applications and scene files be
 
 ### 1. Basic Contiguous Chunks (`basic_contiguous_chunks/`)
 
-A minimal example using `rangeConstraint: CONTIGUOUS`. Each chunk expands to a range like `"1-10"` or `"11-20"`.
+A minimal example using `rangeConstraint: CONTIGUOUS`. Each chunk expands to a range like `"1-10"` or `"11-20"`. The script parses and prints the start and end frame numbers.
 
 ### 2. Basic Non-Contiguous Chunks (`basic_non_contiguous_chunks/`)
 
-A V-Ray example using `rangeConstraint: NONCONTIGUOUS`. Chunks can be arbitrary frame sets like `"1-3,5,7-20:2"`.
+A minimal example using `rangeConstraint: NONCONTIGUOUS`. Chunks can be arbitrary frame sets like `"1-3,5,7-20:2"`. The script prints the frames assigned by the scheduler.
 
 ### 3. Blender Render with Contiguous Chunks (`blender_render_with_contiguous_chunks/`)
 

--- a/job_bundles/task_chunking/README.md
+++ b/job_bundles/task_chunking/README.md
@@ -18,13 +18,16 @@ A minimal example using `rangeConstraint: NONCONTIGUOUS`. Chunks can be arbitrar
 
 ### 3. Blender Render with Contiguous Chunks (`blender_render_with_contiguous_chunks/`)
 
-A real-world example converted from the existing [blender_render](../blender_render/template.yaml) job bundle.
+A real-world example converted from the existing [blender_render](../blender_render/template.yaml) job bundle to render job with contiguous chunks.
+
+### 4. Blender Render with Non-Contiguous Chunks (`blender_render_with_non_contiguous_chunks/`)
+
+A real-world example converted from the existing [blender_render](../blender_render/template.yaml) job bundle to render job with non-contiguous chunks.
 
 Changes from the original:
 1. Added `extensions: [TASK_CHUNKING]`
 2. Added `ChunkSize` parameter (default: 5)
 3. Changed `Frame` from `type: INT` to `type: CHUNK[INT]` with `rangeConstraint: CONTIGUOUS` and `targetRuntimeSeconds: 600`
-4. Updated script to render by frame range
 
 ## Template Structure
 

--- a/job_bundles/task_chunking/README.md
+++ b/job_bundles/task_chunking/README.md
@@ -1,0 +1,59 @@
+# Task Chunking Job Bundle Samples
+
+These samples demonstrate the [Task Chunking](https://github.com/OpenJobDescription/openjd-specifications/blob/mainline/rfcs/0001-task-chunking.md) extension for Open Job Description, which improves resource utilization by grouping multiple frames or tasks into chunks instead of processing them individually.
+
+## Why Use Task Chunking?
+
+Render jobs often spend significant time loading applications and scene files before rendering each frame. Chunking amortizes this overhead by processing multiple frames or tasks per chunk, reducing total job runtime.
+
+## Samples
+
+### 1. Basic Contiguous Chunks (`basic_contiguous_chunks/`)
+
+A minimal example using `rangeConstraint: CONTIGUOUS`. Each chunk expands to a range like `"1-10"` or `"11-20"`.
+
+### 2. Basic Non-Contiguous Chunks (`basic_non_contiguous_chunks/`)
+
+A V-Ray example using `rangeConstraint: NONCONTIGUOUS`. Chunks can be arbitrary frame sets like `"1-3,5,7-20:2"`.
+
+### 3. Blender Render with Contiguous Chunks (`blender_render_with_contiguous_chunks/`)
+
+A real-world example converted from the existing [blender_render](../blender_render/template.yaml) job bundle.
+
+Changes from the original:
+1. Added `extensions: [TASK_CHUNKING]`
+2. Added `ChunkSize` parameter (default: 5)
+3. Changed `Frame` from `type: INT` to `type: CHUNK[INT]` with `rangeConstraint: CONTIGUOUS` and `targetRuntimeSeconds: 600`
+4. Updated script to render by frame range
+
+## Template Structure
+
+```yaml
+specificationVersion: 'jobtemplate-2023-09'
+extensions:
+  - TASK_CHUNKING
+
+steps:
+  - name: Render
+    parameterSpace:
+      taskParameterDefinitions:
+        - name: Frame
+          type: CHUNK[INT]
+          range: "{{Param.Frames}}"
+          chunks:
+            defaultTaskCount: 10          # Default frames per chunk
+            targetRuntimeSeconds: 600     # Optional: allows the scheduler to adjust the task count for chunks to match this runtime
+            rangeConstraint: CONTIGUOUS   # or NONCONTIGUOUS
+```
+
+## Range Constraints
+
+| Constraint | `{{Task.Param.Frame}}` expands to | Use when |
+|------------|-----------------------------------|----------|
+| `CONTIGUOUS` | `"1-10"`, `"11-20"` | App supports start/end frame arguments |
+| `NONCONTIGUOUS` | `"1-3,5,7-10"` | App supports arbitrary frame lists |
+
+## References
+
+- [RFC 0001: Task Chunking](https://github.com/OpenJobDescription/openjd-specifications/blob/mainline/rfcs/0001-task-chunking.md)
+- [Open Job Description Specification](https://github.com/OpenJobDescription/openjd-specifications)

--- a/job_bundles/task_chunking/basic_contiguous_chunks/template.yaml
+++ b/job_bundles/task_chunking/basic_contiguous_chunks/template.yaml
@@ -1,0 +1,52 @@
+specificationVersion: 'jobtemplate-2023-09'
+extensions:
+- TASK_CHUNKING
+name: Contiguous Chunks
+parameterDefinitions:
+  - name: SceneFile
+    type: PATH
+    objectType: FILE
+    dataFlow: IN
+  - name: Frames
+    type: STRING
+    default: 1,10-12,18-50
+  - name: ChunkSize
+    type: INT
+    default: 10
+steps:
+  - name: Render
+    parameterSpace:
+      taskParameterDefinitions:
+        - name: Frame
+          ## The CHUNK[INT] task parameter type is added by this proposal
+          type: CHUNK[INT]
+          range: "{{Param.Frames}}"
+          ## The chunks field must be provided for type CHUNK[INT]
+          chunks:
+            ## Required, is how big to make each chunk by default
+            defaultTaskCount: "{{Param.ChunkSize}}"
+            ## Optional and can be ignored by the scheduler. If supported,
+            ## the scheduler adjusts the task count for chunks to match
+            ## this runtime. The value is in seconds, so 900 is 15 minutes.
+            targetRuntimeSeconds: 900
+            ## Required, affects the script handling the onRun action.
+            ## CONTIGUOUS means {{Task.Param.Frame}} always expands to
+            ## "<startframe>-<endframe>", e.g. "1-1" or "11-20".
+            rangeConstraint: CONTIGUOUS
+    script:
+      actions:
+        onRun:
+          command: bash
+          args: ["{{Task.File.RenderChunk}}"]
+      embeddedFiles:
+        - name: RenderChunk
+          filename: render.sh
+          type: TEXT
+          ## Because a CONTIGUOUS chunk is always like "<startframe>-<endframe>",
+          ## this code can use the cut command to get the start and end values.
+          data: |
+            START_FRAME="$(echo '{{Task.Param.Frame}}' | cut -d- -f1)"
+            END_FRAME="$(echo '{{Task.Param.Frame}}' | cut -d- -f2)"
+            render -scenefile '{{Param.SceneFile}}' \
+                -start "$START_FRAME" \
+                -end "$END_FRAME"

--- a/job_bundles/task_chunking/basic_contiguous_chunks/template.yaml
+++ b/job_bundles/task_chunking/basic_contiguous_chunks/template.yaml
@@ -3,13 +3,9 @@ extensions:
 - TASK_CHUNKING
 name: Contiguous Chunks
 parameterDefinitions:
-  - name: SceneFile
-    type: PATH
-    objectType: FILE
-    dataFlow: IN
   - name: Frames
     type: STRING
-    default: 1,10-12,18-50
+    default: 1,10-12,18-50, 60-100
   - name: ChunkSize
     type: INT
     default: 10
@@ -28,7 +24,7 @@ steps:
             ## Optional and can be ignored by the scheduler. If supported,
             ## the scheduler adjusts the task count for chunks to match
             ## this runtime. The value is in seconds, so 900 is 15 minutes.
-            targetRuntimeSeconds: 900
+            targetRuntimeSeconds: 600
             ## Required, affects the script handling the onRun action.
             ## CONTIGUOUS means {{Task.Param.Frame}} always expands to
             ## "<startframe>-<endframe>", e.g. "1-1" or "11-20".
@@ -47,6 +43,5 @@ steps:
           data: |
             START_FRAME="$(echo '{{Task.Param.Frame}}' | cut -d- -f1)"
             END_FRAME="$(echo '{{Task.Param.Frame}}' | cut -d- -f2)"
-            render -scenefile '{{Param.SceneFile}}' \
-                -start "$START_FRAME" \
-                -end "$END_FRAME"
+            echo "Start frame: $START_FRAME"
+            echo "End frame: $END_FRAME"

--- a/job_bundles/task_chunking/basic_non_contiguous_chunks/template.yaml
+++ b/job_bundles/task_chunking/basic_non_contiguous_chunks/template.yaml
@@ -1,0 +1,42 @@
+specificationVersion: 'jobtemplate-2023-09'
+extensions:
+- TASK_CHUNKING
+name: V-Ray with Non-contiguous Chunks
+parameterDefinitions:
+  - name: VRSceneFile
+    type: PATH
+    objectType: FILE
+    dataFlow: IN
+  - name: Frames
+    type: STRING
+    default: "1-60:2"
+steps:
+  - name: Render
+    parameterSpace:
+      taskParameterDefinitions:
+        - name: Frame
+          type: CHUNK[INT]
+          range: "{{Param.Frames}}"
+          chunks:
+            defaultTaskCount: 10
+            targetRuntimeSeconds: 600
+            ## NONCONTIGUOUS means {{Task.Param.Frame}} expands to
+            ## an arbitrary integer range expression, e.g. "1-3,5,7-20:2".
+            rangeConstraint: NONCONTIGUOUS
+    script:
+       actions:
+        onRun:
+          command: bash
+          args: ["{{Task.File.RenderChunk}}"]
+      embeddedFiles:
+        - name: RenderChunk
+          filename: render.sh
+          type: TEXT
+          ## Because a NONCONTIGUOUS chunk is an arbitrary integer range expression,
+          ## and the V-Ray -frame option accepts a similar syntax with different characters,
+          ## this code can use the tr command to transform it into the V-Ray format.
+          data: |
+            # E.g. "1-3,5,7-20:2" becomes "1-3;5;7-20,2" for V-Ray
+            FRAMES=$(echo '{{Task.Param.Frame}}' | tr ',:' ';,')
+            vray -sceneFile='{{Param.VRSceneFile}}' \
+                 -frames="$FRAMES"

--- a/job_bundles/task_chunking/basic_non_contiguous_chunks/template.yaml
+++ b/job_bundles/task_chunking/basic_non_contiguous_chunks/template.yaml
@@ -1,15 +1,11 @@
 specificationVersion: 'jobtemplate-2023-09'
 extensions:
 - TASK_CHUNKING
-name: V-Ray with Non-contiguous Chunks
+name: Non-contiguous Chunks
 parameterDefinitions:
-  - name: VRSceneFile
-    type: PATH
-    objectType: FILE
-    dataFlow: IN
   - name: Frames
     type: STRING
-    default: "1-60:2"
+    default: "1-3,5,7-20,21-100:2"
 steps:
   - name: Render
     parameterSpace:
@@ -24,7 +20,7 @@ steps:
             ## an arbitrary integer range expression, e.g. "1-3,5,7-20:2".
             rangeConstraint: NONCONTIGUOUS
     script:
-       actions:
+      actions:
         onRun:
           command: bash
           args: ["{{Task.File.RenderChunk}}"]
@@ -32,11 +28,7 @@ steps:
         - name: RenderChunk
           filename: render.sh
           type: TEXT
-          ## Because a NONCONTIGUOUS chunk is an arbitrary integer range expression,
-          ## and the V-Ray -frame option accepts a similar syntax with different characters,
-          ## this code can use the tr command to transform it into the V-Ray format.
+          ## A NONCONTIGUOUS chunk is an arbitrary integer range expression.
+          ## Depends on what your DCC supports, you may need to transform the scheduler assigned frames.
           data: |
-            # E.g. "1-3,5,7-20:2" becomes "1-3;5;7-20,2" for V-Ray
-            FRAMES=$(echo '{{Task.Param.Frame}}' | tr ',:' ';,')
-            vray -sceneFile='{{Param.VRSceneFile}}' \
-                 -frames="$FRAMES"
+            echo "Frames: {{Task.Param.Frame}}"

--- a/job_bundles/task_chunking/blender_render_with_contiguous_chunks/template.yaml
+++ b/job_bundles/task_chunking/blender_render_with_contiguous_chunks/template.yaml
@@ -1,0 +1,122 @@
+specificationVersion: 'jobtemplate-2023-09'
+extensions:
+  - TASK_CHUNKING
+name: Blender Render
+
+parameterDefinitions:
+
+# Render Parameters
+- name: BlenderSceneFile
+  type: PATH
+  objectType: FILE
+  dataFlow: IN
+  userInterface:
+    control: CHOOSE_INPUT_FILE
+    label: Blender Scene File
+    groupLabel: Render Parameters
+    fileFilters:
+    - label: Blender Scene Files
+      patterns: ["*.blend"]
+    - label: All Files
+      patterns: ["*"]
+  description: >
+    Choose the Blender scene file you want to render. Use the 'Job Attachments' tab
+    to add textures and other files that the job needs.
+- name: Frames
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Frames
+    groupLabel: Render Parameters
+  default: 1-100
+- name: ChunkSize
+  type: INT
+  userInterface:
+    control: SPIN_BOX
+    label: Chunk Size
+    groupLabel: Render Parameters
+  default: 5
+  minValue: 1
+  description: Number of frames per chunk.
+- name: OutputDir
+  type: PATH
+  objectType: DIRECTORY
+  dataFlow: OUT
+  userInterface:
+    control: CHOOSE_DIRECTORY
+    label: Output Directory
+    groupLabel: Render Parameters
+  default: "./output"
+  description: Choose the render output directory.
+- name: OutputPattern
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Output File Pattern
+    groupLabel: Render Parameters
+  default: "output_####"
+  description: Enter the output filename pattern (without extension).
+- name: Format
+  type: STRING
+  userInterface:
+    control: DROPDOWN_LIST
+    label: Output File Format
+    groupLabel: Render Parameters
+  description: Choose the file format to render as.
+  default: JPEG
+  allowedValues: [TGA, RAWTGA, JPEG, IRIS, IRIZ, PNG, HDR, TIFF, OPEN_EXR, OPEN_EXR_MULTILAYER, CINEON, DPX, DDS, JP2, WEBP]
+
+# Software Environment
+- name: CondaPackages
+  type: STRING
+  userInterface:
+    control: HIDDEN
+  default: blender
+  description: >
+    If you have a Queue Environment that creates a Conda environment from a parameter called CondaPackages, this
+    will set the default packages to use for the job.
+- name: RezPackages
+  type: STRING
+  userInterface:
+    control: HIDDEN
+  default: blender
+  description: >
+    If you have a Queue Environment that creates a Rez environment from a parameter called RezPackages, this will
+    tell it to install blender.
+
+steps:
+- name: RenderBlender
+  parameterSpace:
+    taskParameterDefinitions:
+    - name: Frame
+      type: CHUNK[INT]
+      range: "{{Param.Frames}}"
+      chunks:
+        defaultTaskCount: "{{Param.ChunkSize}}"
+        targetRuntimeSeconds: 600
+        rangeConstraint: CONTIGUOUS
+  script:
+    actions:
+      onRun:
+        command: bash
+        args: ['{{Task.File.Run}}']
+    embeddedFiles:
+      - name: Run
+        type: TEXT
+        data: |
+          # Configure the task to fail if any individual command fails.
+          set -xeuo pipefail
+
+          mkdir -p '{{Param.OutputDir}}'
+
+          # Parse contiguous chunk range (e.g., "1-5" or "7-7")
+          START_FRAME="$(echo '{{Task.Param.Frame}}' | cut -d- -f1)"
+          END_FRAME="$(echo '{{Task.Param.Frame}}' | cut -d- -f2)"
+
+          blender --background '{{Param.BlenderSceneFile}}' \
+                  --render-output '{{Param.OutputDir}}/{{Param.OutputPattern}}' \
+                  --render-format {{Param.Format}} \
+                  --use-extension 1 \
+                  --frame-start "$START_FRAME" \
+                  --frame-end "$END_FRAME" \
+                  --render-anim

--- a/job_bundles/task_chunking/blender_render_with_non_contiguous_chunks/template.yaml
+++ b/job_bundles/task_chunking/blender_render_with_non_contiguous_chunks/template.yaml
@@ -1,7 +1,7 @@
 specificationVersion: 'jobtemplate-2023-09'
 extensions:
   - TASK_CHUNKING
-name: Blender Render with Contiguous Chunks
+name: Blender Render with Non-Contiguous Chunks
 
 parameterDefinitions:
 
@@ -19,16 +19,15 @@ parameterDefinitions:
       patterns: ["*.blend"]
     - label: All Files
       patterns: ["*"]
-  description: >
-    Choose the Blender scene file you want to render. Use the 'Job Attachments' tab
-    to add textures and other files that the job needs.
+  description: Choose the Blender scene file you want to render.
 - name: Frames
   type: STRING
   userInterface:
     control: LINE_EDIT
     label: Frames
     groupLabel: Render Parameters
-  default: 1-100
+  default: "1-10,15,20-100:2"
+  description: "The frames to render. Supports ranges and steps, e.g. 1-10,15,20-100:2"
 - name: ChunkSize
   type: INT
   userInterface:
@@ -86,7 +85,7 @@ steps:
       chunks:
         defaultTaskCount: "{{Param.ChunkSize}}"
         targetRuntimeSeconds: 600
-        rangeConstraint: CONTIGUOUS
+        rangeConstraint: NONCONTIGUOUS
   script:
     actions:
       onRun:
@@ -101,14 +100,34 @@ steps:
 
           mkdir -p '{{Param.OutputDir}}'
 
-          # Parse contiguous chunk range (e.g., "1-5" or "7-7")
-          START_FRAME="$(echo '{{Task.Param.Frame}}' | cut -d- -f1)"
-          END_FRAME="$(echo '{{Task.Param.Frame}}' | cut -d- -f2)"
+          # Parse non-contiguous chunk (e.g., "1-3,5,7-10:2") into individual -f arguments
+          # Blender renders specific frames with: blender -b file.blend -f 1 -f 2 -f 3
+          FRAME_ARGS=""
+          for part in $(echo '{{Task.Param.Frame}}' | tr ',' ' '); do
+            if [[ "$part" == *":"* ]]; then
+              # Handle step notation (e.g., "1-10:2")
+              range="${part%%:*}"
+              step="${part##*:}"
+              start="${range%%-*}"
+              end="${range##*-}"
+              for f in $(seq "$start" "$step" "$end"); do
+                FRAME_ARGS="$FRAME_ARGS -f $f"
+              done
+            elif [[ "$part" == *"-"* ]]; then
+              # Handle range (e.g., "1-10")
+              start="${part%%-*}"
+              end="${part##*-}"
+              for f in $(seq "$start" "$end"); do
+                FRAME_ARGS="$FRAME_ARGS -f $f"
+              done
+            else
+              # Single frame
+              FRAME_ARGS="$FRAME_ARGS -f $part"
+            fi
+          done
 
           blender --background '{{Param.BlenderSceneFile}}' \
                   --render-output '{{Param.OutputDir}}/{{Param.OutputPattern}}' \
                   --render-format {{Param.Format}} \
                   --use-extension 1 \
-                  --frame-start "$START_FRAME" \
-                  --frame-end "$END_FRAME" \
-                  --render-anim
+                  $FRAME_ARGS

--- a/job_bundles/task_chunking/blender_render_with_non_contiguous_chunks/template.yaml
+++ b/job_bundles/task_chunking/blender_render_with_non_contiguous_chunks/template.yaml
@@ -4,8 +4,6 @@ extensions:
 name: Blender Render with Non-Contiguous Chunks
 
 parameterDefinitions:
-
-# Render Parameters
 - name: BlenderSceneFile
   type: PATH
   objectType: FILE
@@ -13,7 +11,6 @@ parameterDefinitions:
   userInterface:
     control: CHOOSE_INPUT_FILE
     label: Blender Scene File
-    groupLabel: Render Parameters
     fileFilters:
     - label: Blender Scene Files
       patterns: ["*.blend"]
@@ -25,7 +22,6 @@ parameterDefinitions:
   userInterface:
     control: LINE_EDIT
     label: Frames
-    groupLabel: Render Parameters
   default: "1-10,15,20-100:2"
   description: "The frames to render. Supports ranges and steps, e.g. 1-10,15,20-100:2"
 - name: ChunkSize
@@ -33,10 +29,16 @@ parameterDefinitions:
   userInterface:
     control: SPIN_BOX
     label: Chunk Size
-    groupLabel: Render Parameters
   default: 5
   minValue: 1
   description: Number of frames per chunk.
+- name: TargetRuntime
+  type: INT
+  userInterface:
+    control: SPIN_BOX
+    label: Target Runtime (Seconds)
+  default: 180
+  description: Enter the target runtime (0 to disable adaptive chunking).
 - name: OutputDir
   type: PATH
   objectType: DIRECTORY
@@ -44,7 +46,6 @@ parameterDefinitions:
   userInterface:
     control: CHOOSE_DIRECTORY
     label: Output Directory
-    groupLabel: Render Parameters
   default: "./output"
   description: Choose the render output directory.
 - name: OutputPattern
@@ -52,7 +53,6 @@ parameterDefinitions:
   userInterface:
     control: LINE_EDIT
     label: Output File Pattern
-    groupLabel: Render Parameters
   default: "output_####"
   description: Enter the output filename pattern (without extension).
 - name: Format
@@ -60,20 +60,15 @@ parameterDefinitions:
   userInterface:
     control: DROPDOWN_LIST
     label: Output File Format
-    groupLabel: Render Parameters
   description: Choose the file format to render as.
   default: JPEG
   allowedValues: [TGA, RAWTGA, JPEG, IRIS, IRIZ, PNG, HDR, TIFF, OPEN_EXR, OPEN_EXR_MULTILAYER, CINEON, DPX, DDS, JP2, WEBP]
-
-# Software Environment
 - name: CondaPackages
   type: STRING
   userInterface:
     control: HIDDEN
   default: blender
-  description: >
-    If you have a Queue Environment that creates a Conda environment from a parameter called CondaPackages, this
-    will set the default packages to use for the job.
+  description: Conda packages to install. Requires a Queue Environment to create the Conda Environment.
 
 steps:
 - name: RenderBlender
@@ -84,7 +79,7 @@ steps:
       range: "{{Param.Frames}}"
       chunks:
         defaultTaskCount: "{{Param.ChunkSize}}"
-        targetRuntimeSeconds: 600
+        targetRuntimeSeconds: "{{Param.TargetRuntime}}"
         rangeConstraint: NONCONTIGUOUS
   script:
     actions:
@@ -92,42 +87,56 @@ steps:
         command: bash
         args: ['{{Task.File.Run}}']
     embeddedFiles:
+      - name: Frames2Blender
+        type: TEXT
+        filename: frames_2_blender.py
+        data: |
+          """
+          Converts an Open Job Description range expression into a --render-frame option for the Blender CLI.
+
+          $ FRAMES=$(python frames_2_blender.py "1-5:2,9-11,15")
+          $ echo $FRAMES
+          1,3,5,9..11,15
+
+          * https://github.com/OpenJobDescription/openjd-specifications/wiki/2023-09-Template-Schemas#34111-intrangeexpr
+          * https://docs.blender.org/manual/en/latest/advanced/command_line/arguments.html
+          """
+
+          import sys, re
+
+          def range_expr_to_blender(range_expr):
+              # Regex that matches "<int>", "<int>-<int>", or "<int>-<int>:<int>"
+              int_pat = r"\s*(-?[0-9]+)\s*"
+              part_re = re.compile(f"^{int_pat}(?:-{int_pat}(?::{int_pat})?)?$")
+              blender_parts = []
+              for part in range_expr.split(","):
+                  if m := part_re.match(part):
+                      start, end, step = m.groups()
+                      if step is not None:
+                          # Linear sequence "3-7:2" means the values [3, 5, 7].
+                          blender_parts.extend(range(int(start), int(end) + (int(step)//abs(int(step))), int(step)))
+                      elif end is not None:
+                          # Interval "3-6" means the values [3, 4, 5, 6].
+                          blender_parts.append(f"{start}..{end}")
+                      else:
+                          # Integer "3" means the values [3].
+                          blender_parts.append(start)
+                  else:
+                      raise ValueError(f"Invalid frame range expression: {range_expr}")
+              return ",".join(str(part) for part in blender_parts)
+
+          print(range_expr_to_blender(sys.argv[1]))
       - name: Run
         type: TEXT
         data: |
-          # Configure the task to fail if any individual command fails.
           set -xeuo pipefail
 
           mkdir -p '{{Param.OutputDir}}'
 
-          # Parse non-contiguous chunk (e.g., "1-3,5,7-10:2") into individual -f arguments
-          # Blender renders specific frames with: blender -b file.blend -f 1 -f 2 -f 3
-          FRAME_ARGS=""
-          for part in $(echo '{{Task.Param.Frame}}' | tr ',' ' '); do
-            if [[ "$part" == *":"* ]]; then
-              # Handle step notation (e.g., "1-10:2")
-              range="${part%%:*}"
-              step="${part##*:}"
-              start="${range%%-*}"
-              end="${range##*-}"
-              for f in $(seq "$start" "$step" "$end"); do
-                FRAME_ARGS="$FRAME_ARGS -f $f"
-              done
-            elif [[ "$part" == *"-"* ]]; then
-              # Handle range (e.g., "1-10")
-              start="${part%%-*}"
-              end="${part##*-}"
-              for f in $(seq "$start" "$end"); do
-                FRAME_ARGS="$FRAME_ARGS -f $f"
-              done
-            else
-              # Single frame
-              FRAME_ARGS="$FRAME_ARGS -f $part"
-            fi
-          done
+          FRAMES="$(python '{{Task.File.Frames2Blender}}' '{{Task.Param.Frame}}')"
 
           blender --background '{{Param.BlenderSceneFile}}' \
                   --render-output '{{Param.OutputDir}}/{{Param.OutputPattern}}' \
                   --render-format {{Param.Format}} \
                   --use-extension 1 \
-                  $FRAME_ARGS
+                  --render-frame "$FRAMES"


### PR DESCRIPTION
feat: Add samples for task chunking jobs

### What was the problem/requirement? (What/Why)
We need to add sample job templates for task chunking jobs.

### What was the solution? (How)
Add samples for task chunking jobs

### What is the impact of this change?
Customer will have samples for using task chunking feature

### How was this change tested?
I submitted jobs with each sample in the PR and confirmed they all works as expected.

For basic contiguous chunking job, here is some of the logs:
<img width="1493" height="639" alt="Screenshot 2026-02-12 at 10 39 15 AM" src="https://github.com/user-attachments/assets/5a08cdde-0ac0-4a8c-9270-47831849762d" />

For basic non-contiguous chunking job, here is some of the logs:
<img width="1497" height="665" alt="Screenshot 2026-02-12 at 10 38 14 AM" src="https://github.com/user-attachments/assets/1748b87e-7dc4-48cf-8037-71fa7d76dc77" />

For Blender contiguous chunking job, here is some of the logs:
<img width="1498" height="717" alt="Screenshot 2026-02-12 at 10 41 19 AM" src="https://github.com/user-attachments/assets/68af6e44-3da0-46ae-9200-29a9c40510dc" />

For Blender non-contiguous chunking job, here is some of the logs:
<img width="1493" height="796" alt="Screenshot 2026-02-12 at 11 33 18 AM" src="https://github.com/user-attachments/assets/ee69b5c7-73c2-4fda-b03d-32b822928b82" />


### Was this change documented?
Yes, I added a read me as part of this commit

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*