### PR TITLE
feat: add host config script for Boris FX Sapphire and Frischluft Lenscare plugins for After Effects

### DIFF
--- a/host_configuration_scripts/aftereffects/aftereffects_redgiant/README.md
+++ b/host_configuration_scripts/aftereffects/aftereffects_redgiant/README.md
@@ -57,6 +57,28 @@ This is needed for the Maxon App installation to go smoothly. Download from Micr
 1. Visit the [Microsoft Edge WebView2 download page](https://developer.microsoft.com/en-us/microsoft-edge/webview2?form=MA13LH#download)
 2. Download `MicrosoftEdgeWebView2RuntimeInstallerX64.exe` (x64 version) under the "Evergreen Standalone Installer" section
 
+### 6. Boris FX Sapphire (optional)
+
+Download from Boris FX:
+1. Log into your Boris FX account
+2. Navigate to the [Boris FX Downloads](https://borisfx.com/downloads/?product=sapphire&os=windows) section
+3. Download Sapphire 2026 (or latest version) for Adobe (Windows 64-Bit)
+
+For Boris FX Sapphire, you will need to bring your own licenses. We recommend setting the `genarts_LICENSE` environment variable to license the software. This can be set either inside the host config script by uncommenting and configuring the `$BORIS_LICENSE_SERVER` variable (e.g., `$BORIS_LICENSE_SERVER = "5053@<license-server-hostname>"`), or in a queue environment. See the "Install Floating Client License Using An Environment Variable" section of [this Boris FX article](https://support.borisfx.com/hc/en-us/articles/11198263161997-License-Instructions-Floating-Licenses) for more details on the format of the environment variable.
+
+To enable Boris FX Sapphire installation, set `$INSTALL_BORIS_SAPPHIRE = $true` in the script configuration section.
+
+### 7. Frischluft Lenscare (optional)
+
+Download from Frischluft:
+1. Go to https://www.frischluft.com/lenscare/
+2. Select download for After Effects on windows
+3. Upload your `Lenscare_ae.key` license file to the S3 bucket at `s3://<your-installer-bucket>/Installers/Lenscare_ae.key`
+
+For Frischluft Lenscare, you will need to bring your own licenses. Lenscare is licensed by copying the `Lenscare_ae.key` file to the same folder as the plugin. The script will automatically download and copy the license file from S3 to `C:\Program Files\Adobe\Common\Plug-ins\7.0\MediaCore\Lenscare_ae.key`. For more information about licensing Lenscare, review the "Install Key File" section of the `readme.txt` inside the downloaded Lenscare zip file.
+
+To enable Lenscare installation, set `$INSTALL_LENSCARE = $true` in the script configuration section.
+
 ## S3 Bucket Setup
 
 ### 1. Create S3 Bucket Structure

--- a/host_configuration_scripts/aftereffects/aftereffects_redgiant/README.md
+++ b/host_configuration_scripts/aftereffects/aftereffects_redgiant/README.md
@@ -64,7 +64,7 @@ Download from Boris FX:
 2. Navigate to the [Boris FX Downloads](https://borisfx.com/downloads/?product=sapphire&os=windows) section
 3. Download Sapphire 2026 (or latest version) for Adobe (Windows 64-Bit)
 
-For Boris FX Sapphire, you will need to bring your own licenses. We recommend setting the `genarts_LICENSE` environment variable to license the software. This can be set either inside the host config script by uncommenting and configuring the `$BORIS_LICENSE_SERVER` variable (e.g., `$BORIS_LICENSE_SERVER = "5053@<license-server-hostname>"`), or in a queue environment. See the "Install Floating Client License Using An Environment Variable" section of [this Boris FX article](https://support.borisfx.com/hc/en-us/articles/11198263161997-License-Instructions-Floating-Licenses) for more details on the format of the environment variable.
+For Boris FX Sapphire, you will need to bring your own licenses. We recommend setting the `genarts_LICENSE` environment variable to license the software. This can be set either inside the host config script by configuring the `$BORIS_LICENSE_SERVER` variable (e.g., `$BORIS_LICENSE_SERVER = "5053@<license-server-hostname>"`), or in a queue environment. See the "Install Floating Client License Using An Environment Variable" section of [this Boris FX article](https://support.borisfx.com/hc/en-us/articles/11198263161997-License-Instructions-Floating-Licenses) for more details on the format of the environment variable.
 
 To enable Boris FX Sapphire installation, set `$INSTALL_BORIS_SAPPHIRE = $true` in the script configuration section.
 
@@ -75,7 +75,7 @@ Download from Frischluft:
 2. Select download for After Effects on windows
 3. Upload your `Lenscare_ae.key` license file to the S3 bucket at `s3://<your-installer-bucket>/Installers/Lenscare_ae.key`
 
-For Frischluft Lenscare, you will need to bring your own licenses. Lenscare is licensed by copying the `Lenscare_ae.key` file to the same folder as the plugin. The script will automatically download and copy the license file from S3 to `C:\Program Files\Adobe\Common\Plug-ins\7.0\MediaCore\Lenscare_ae.key`. For more information about licensing Lenscare, review the "Install Key File" section of the `readme.txt` inside the downloaded Lenscare zip file.
+For Frischluft Lenscare, you will need to bring your own licenses. Lenscare is licensed by copying the `Lenscare_ae.key` license file to the same folder as the plugin. In this sample host config script, you will upload your license file to S3 and the host config script will download the license file from S3 to `C:\Program Files\Adobe\Common\Plug-ins\7.0\MediaCore\Lenscare_ae.key` on the worker. For more information about licensing Lenscare, review the "Install Key File" section of the `readme.txt` inside the downloaded Lenscare zip file.
 
 To enable Lenscare installation, set `$INSTALL_LENSCARE = $true` in the script configuration section.
 

--- a/host_configuration_scripts/aftereffects/aftereffects_redgiant/install-software.ps1
+++ b/host_configuration_scripts/aftereffects/aftereffects_redgiant/install-software.ps1
@@ -1,5 +1,7 @@
 # Sequential Software Installation Script
-# Downloads installers from S3 and installs Adobe After Effects, Red Giant, and Universe in order
+# Downloads installers from S3 and installs Adobe After Effects, Red Giant, Universe, Boris Sapphire (optional), and Lenscare (optional) in order
+
+# Stop after first failing command
 $ErrorActionPreference = "Stop"
 
 # Script Configuration Variables - Update these for your environment
@@ -8,13 +10,24 @@ $vpc_endpoint = "<vpc_endpoint>"  # Replace with actual VPC endpoint for CMF Red
 $AE_VERSION = "2025"  # After Effects version year
 $INSTALLER_S3_BUCKET = "<your-installer-bucket>"  # Your S3 bucket name
 $AE_INSTALLER = "After Effects_en_US_WIN_64.zip"
-$REDGIANT_INSTALLER = "RedGiant-2025.6.0-Win.exe"
-$UNIVERSE_INSTALLER = "Universe-2025.3.3_Win.exe"
-$MAXON_APP_INSTALLER = "Maxon_App_2025.4.2_Win.exe"
+$REDGIANT_INSTALLER = "RedGiant-2026.3.0-Win.exe"
+$UNIVERSE_INSTALLER = "Universe-2026.0.1_Win.exe"
+$MAXON_APP_INSTALLER = "Maxon_App_2026.1.0_Win.exe"
 $WEBVIEW2_INSTALLER = "MicrosoftEdgeWebView2RuntimeInstallerX64.exe"
+
+# Optional Plugin Configuration
+$INSTALL_BORIS_SAPPHIRE = $false  # Set to $true to install Boris FX Sapphire
+$BORIS_SAPPHIRE_INSTALLER = "sapphire-ae-install-2026.exe"
+# custom licensing is required for Boris FX, as it is not currently supported by Deadline Cloud Usage Based Licensing
+$BORIS_LICENSE_SERVER = "5053@<license-server-hostname>"
+
+$INSTALL_LENSCARE = $false  # Set to $true to install Frischluft Lenscare
+$LENSCARE_INSTALLER = "lenscare_ae_v1.5.5(win).zip"
+$LENSCARE_LICENSE = "Lenscare_ae.key"
 
 # Derived paths (do not modify)
 $AE_LOCATION = "C:\Program Files\Adobe\Adobe After Effects $AE_VERSION\Support Files"
+$AE_PLUGIN_LOCATION = "C:\Program Files\Adobe\Common\Plug-ins\7.0\MediaCore"
 $downloadsPath = "C:\Temp"
 
 # Start overall timing
@@ -38,6 +51,19 @@ aws s3 cp --no-progress s3://$INSTALLER_S3_BUCKET/Installers/$UNIVERSE_INSTALLER
 if (-not (Test-Path "$downloadsPath\$UNIVERSE_INSTALLER")) { throw "Universe download failed" }
 aws s3 cp --no-progress s3://$INSTALLER_S3_BUCKET/Installers/$WEBVIEW2_INSTALLER $downloadsPath\$WEBVIEW2_INSTALLER
 if (-not (Test-Path "$downloadsPath\$WEBVIEW2_INSTALLER")) { throw "WebView2 Runtime download failed" }
+
+if ($INSTALL_BORIS_SAPPHIRE) {
+    aws s3 cp --no-progress s3://$INSTALLER_S3_BUCKET/Installers/$BORIS_SAPPHIRE_INSTALLER $downloadsPath\$BORIS_SAPPHIRE_INSTALLER
+    if (-not (Test-Path "$downloadsPath\$BORIS_SAPPHIRE_INSTALLER")) { throw "Boris Sapphire download failed" }
+}
+
+if ($INSTALL_LENSCARE) {
+    aws s3 cp --no-progress s3://$INSTALLER_S3_BUCKET/Installers/$LENSCARE_INSTALLER $downloadsPath\$LENSCARE_INSTALLER
+    if (-not (Test-Path "$downloadsPath\$LENSCARE_INSTALLER")) { throw "Lenscare download failed" }
+    aws s3 cp --no-progress s3://$INSTALLER_S3_BUCKET/Installers/$LENSCARE_LICENSE $downloadsPath\$LENSCARE_LICENSE
+    if (-not (Test-Path "$downloadsPath\$LENSCARE_LICENSE")) { throw "Lenscare license download failed" }
+}
+
 $downloadEndTime = Get-Date
 $downloadDuration = $downloadEndTime - $downloadStartTime
 Write-Host "Downloads completed in: $($downloadDuration.ToString('hh\:mm\:ss'))"
@@ -77,6 +103,12 @@ $rgEndTime = Get-Date
 $rgDuration = $rgEndTime - $rgStartTime
 Write-Host "Red Giant installation completed in: $($rgDuration.ToString('hh\:mm\:ss'))"
 
+# Set Red Giant license servers for Customer Managed Fleets (CMF)
+if ($is_cmf) {
+    Write-Host "Setting Red Giant license server for CMF..."
+    [System.Environment]::SetEnvironmentVariable("redshift_LICENSE", "7055@$vpc_endpoint", [System.EnvironmentVariableTarget]::Machine)
+}
+
 # Universe Installation
 $universeStartTime = Get-Date
 Write-Host "Starting Universe installation..."
@@ -85,10 +117,36 @@ $universeEndTime = Get-Date
 $universeDuration = $universeEndTime - $universeStartTime
 Write-Host "Universe installation completed in: $($universeDuration.ToString('hh\:mm\:ss'))"
 
-# Set Red Giant license server for Customer Managed Fleet (CMF)
-if ($is_cmf) {
-    Write-Host "Setting Red Giant license server for CMF..."
-    [System.Environment]::SetEnvironmentVariable("redshift_LICENSE", "7055@$vpc_endpoint", [System.EnvironmentVariableTarget]::Machine)
+if ($INSTALL_BORIS_SAPPHIRE) {
+    # Boris FX Sapphire Installation
+    $bsStartTime = Get-Date
+    Write-Host "Starting Boris Sapphire installation..."
+    if (-not (Test-Path "$downloadsPath\$BORIS_SAPPHIRE_INSTALLER")) { throw "Boris Sapphire installer not found" }
+    Start-Process -FilePath "$downloadsPath\$BORIS_SAPPHIRE_INSTALLER" -ArgumentList "/VERYSILENT" -Wait
+
+    Write-Host "Setting Boris FX license server..."
+    [System.Environment]::SetEnvironmentVariable("genarts_LICENSE", $BORIS_LICENSE_SERVER, [System.EnvironmentVariableTarget]::Machine)
+
+    $bsEndTime = Get-Date
+    $bsDuration = $bsEndTime - $bsStartTime
+    Write-Host "Boris Sapphire installation completed in: $($bsDuration.ToString('hh\:mm\:ss'))"
+}
+
+if ($INSTALL_LENSCARE) {
+    # Lenscare Installation
+    $lenscareStartTime = Get-Date
+    Write-Host "Extracting Lenscare zip file..."
+    if (-not (Test-Path "$downloadsPath\$LENSCARE_INSTALLER")) { throw "Lenscare zip file not found" }
+    $lenscareTempExtract = "$downloadsPath\lenscare_temp"
+    Expand-Archive -Path "$downloadsPath\$LENSCARE_INSTALLER" -DestinationPath $lenscareTempExtract -Force
+    Write-Host "Starting Lenscare installation..."
+    Copy-Item -Path "$lenscareTempExtract\*" -Destination "$AE_PLUGIN_LOCATION" -Recurse -Force
+    Write-Host "Copying Lenscare license file..."
+    if (-not (Test-Path "$downloadsPath\$LENSCARE_LICENSE")) { throw "Lenscare license file not found" }
+    Copy-Item -Path "$downloadsPath\$LENSCARE_LICENSE" -Destination "$AE_PLUGIN_LOCATION\$LENSCARE_LICENSE" -Force
+    $lenscareEndTime = Get-Date
+    $lenscareDuration = $lenscareEndTime - $lenscareStartTime
+    Write-Host "Lenscare installation completed in: $($lenscareDuration.ToString('hh\:mm\:ss'))"
 }
 
 # Calculate and display total time
@@ -101,5 +159,11 @@ Write-Host "After Effects: $($aeDuration.ToString('hh\:mm\:ss'))"
 Write-Host "Maxon App: $($maxonDuration.ToString('hh\:mm\:ss'))"
 Write-Host "Red Giant: $($rgDuration.ToString('hh\:mm\:ss'))"
 Write-Host "Universe: $($universeDuration.ToString('hh\:mm\:ss'))"
+if ($INSTALL_BORIS_SAPPHIRE) {
+    Write-Host "Boris Sapphire: $($bsDuration.ToString('hh\:mm\:ss'))"
+}
+if ($INSTALL_LENSCARE) {
+    Write-Host "Lenscare: $($lenscareDuration.ToString('hh\:mm\:ss'))"
+}
 Write-Host "Total Time: $($totalDuration.ToString('hh\:mm\:ss'))"
 Write-Host "All installations completed!"

--- a/host_configuration_scripts/aftereffects/aftereffects_redgiant/install-software.ps1
+++ b/host_configuration_scripts/aftereffects/aftereffects_redgiant/install-software.ps1
@@ -25,10 +25,11 @@ $INSTALL_LENSCARE = $false  # Set to $true to install Frischluft Lenscare
 $LENSCARE_INSTALLER = "lenscare_ae_v1.5.5(win).zip"
 $LENSCARE_LICENSE = "Lenscare_ae.key"
 
+$AE_PLUGIN_LOCATION = "C:\Program Files\Adobe\Common\Plug-ins\7.0\MediaCore"
+$DOWNLOADS_PATH = "C:\Temp"
+
 # Derived paths (do not modify)
 $AE_LOCATION = "C:\Program Files\Adobe\Adobe After Effects $AE_VERSION\Support Files"
-$AE_PLUGIN_LOCATION = "C:\Program Files\Adobe\Common\Plug-ins\7.0\MediaCore"
-$downloadsPath = "C:\Temp"
 
 # Start overall timing
 $scriptStartTime = Get-Date
@@ -41,27 +42,27 @@ Write-Host "Setting environment variables for rendering..."
 # Download installers from S3
 $downloadStartTime = Get-Date
 Write-Host "Downloading installers from S3..."
-aws s3 cp --no-progress "s3://$INSTALLER_S3_BUCKET/Installers/$AE_INSTALLER" "$downloadsPath\$AE_INSTALLER"
-if (-not (Test-Path "$downloadsPath\$AE_INSTALLER")) { throw "After Effects download failed" }
-aws s3 cp --no-progress s3://$INSTALLER_S3_BUCKET/Installers/$REDGIANT_INSTALLER $downloadsPath\$REDGIANT_INSTALLER
-if (-not (Test-Path "$downloadsPath\$REDGIANT_INSTALLER")) { throw "Red Giant download failed" }
-aws s3 cp --no-progress s3://$INSTALLER_S3_BUCKET/Installers/$MAXON_APP_INSTALLER $downloadsPath\$MAXON_APP_INSTALLER
-if (-not (Test-Path "$downloadsPath\$MAXON_APP_INSTALLER")) { throw "Maxon App download failed" }
-aws s3 cp --no-progress s3://$INSTALLER_S3_BUCKET/Installers/$UNIVERSE_INSTALLER $downloadsPath\$UNIVERSE_INSTALLER
-if (-not (Test-Path "$downloadsPath\$UNIVERSE_INSTALLER")) { throw "Universe download failed" }
-aws s3 cp --no-progress s3://$INSTALLER_S3_BUCKET/Installers/$WEBVIEW2_INSTALLER $downloadsPath\$WEBVIEW2_INSTALLER
-if (-not (Test-Path "$downloadsPath\$WEBVIEW2_INSTALLER")) { throw "WebView2 Runtime download failed" }
+aws s3 cp --no-progress "s3://$INSTALLER_S3_BUCKET/Installers/$AE_INSTALLER" "$DOWNLOADS_PATH\$AE_INSTALLER"
+if (-not (Test-Path "$DOWNLOADS_PATH\$AE_INSTALLER")) { throw "After Effects download failed" }
+aws s3 cp --no-progress s3://$INSTALLER_S3_BUCKET/Installers/$REDGIANT_INSTALLER $DOWNLOADS_PATH\$REDGIANT_INSTALLER
+if (-not (Test-Path "$DOWNLOADS_PATH\$REDGIANT_INSTALLER")) { throw "Red Giant download failed" }
+aws s3 cp --no-progress s3://$INSTALLER_S3_BUCKET/Installers/$MAXON_APP_INSTALLER $DOWNLOADS_PATH\$MAXON_APP_INSTALLER
+if (-not (Test-Path "$DOWNLOADS_PATH\$MAXON_APP_INSTALLER")) { throw "Maxon App download failed" }
+aws s3 cp --no-progress s3://$INSTALLER_S3_BUCKET/Installers/$UNIVERSE_INSTALLER $DOWNLOADS_PATH\$UNIVERSE_INSTALLER
+if (-not (Test-Path "$DOWNLOADS_PATH\$UNIVERSE_INSTALLER")) { throw "Universe download failed" }
+aws s3 cp --no-progress s3://$INSTALLER_S3_BUCKET/Installers/$WEBVIEW2_INSTALLER $DOWNLOADS_PATH\$WEBVIEW2_INSTALLER
+if (-not (Test-Path "$DOWNLOADS_PATH\$WEBVIEW2_INSTALLER")) { throw "WebView2 Runtime download failed" }
 
 if ($INSTALL_BORIS_SAPPHIRE) {
-    aws s3 cp --no-progress s3://$INSTALLER_S3_BUCKET/Installers/$BORIS_SAPPHIRE_INSTALLER $downloadsPath\$BORIS_SAPPHIRE_INSTALLER
-    if (-not (Test-Path "$downloadsPath\$BORIS_SAPPHIRE_INSTALLER")) { throw "Boris Sapphire download failed" }
+    aws s3 cp --no-progress s3://$INSTALLER_S3_BUCKET/Installers/$BORIS_SAPPHIRE_INSTALLER $DOWNLOADS_PATH\$BORIS_SAPPHIRE_INSTALLER
+    if (-not (Test-Path "$DOWNLOADS_PATH\$BORIS_SAPPHIRE_INSTALLER")) { throw "Boris Sapphire download failed" }
 }
 
 if ($INSTALL_LENSCARE) {
-    aws s3 cp --no-progress s3://$INSTALLER_S3_BUCKET/Installers/$LENSCARE_INSTALLER $downloadsPath\$LENSCARE_INSTALLER
-    if (-not (Test-Path "$downloadsPath\$LENSCARE_INSTALLER")) { throw "Lenscare download failed" }
-    aws s3 cp --no-progress s3://$INSTALLER_S3_BUCKET/Installers/$LENSCARE_LICENSE $downloadsPath\$LENSCARE_LICENSE
-    if (-not (Test-Path "$downloadsPath\$LENSCARE_LICENSE")) { throw "Lenscare license download failed" }
+    aws s3 cp --no-progress s3://$INSTALLER_S3_BUCKET/Installers/$LENSCARE_INSTALLER $DOWNLOADS_PATH\$LENSCARE_INSTALLER
+    if (-not (Test-Path "$DOWNLOADS_PATH\$LENSCARE_INSTALLER")) { throw "Lenscare download failed" }
+    aws s3 cp --no-progress s3://$INSTALLER_S3_BUCKET/Installers/$LENSCARE_LICENSE $DOWNLOADS_PATH\$LENSCARE_LICENSE
+    if (-not (Test-Path "$DOWNLOADS_PATH\$LENSCARE_LICENSE")) { throw "Lenscare license download failed" }
 }
 
 $downloadEndTime = Get-Date
@@ -71,7 +72,7 @@ Write-Host "Downloads completed in: $($downloadDuration.ToString('hh\:mm\:ss'))"
 # Microsoft Edge WebView2 Runtime Installation
 $webview2StartTime = Get-Date
 Write-Host "Starting Microsoft Edge WebView2 Runtime installation..."
-Start-Process -FilePath "$downloadsPath\$WEBVIEW2_INSTALLER" -ArgumentList "/silent", "/install" -Wait
+Start-Process -FilePath "$DOWNLOADS_PATH\$WEBVIEW2_INSTALLER" -ArgumentList "/silent", "/install" -Wait
 $webview2EndTime = Get-Date
 $webview2Duration = $webview2EndTime - $webview2StartTime
 Write-Host "Microsoft Edge WebView2 Runtime installation completed in: $($webview2Duration.ToString('hh\:mm\:ss'))"
@@ -79,10 +80,10 @@ Write-Host "Microsoft Edge WebView2 Runtime installation completed in: $($webvie
 # After Effects Installation
 $aeStartTime = Get-Date
 Write-Host "Extracting After Effects zip file..."
-Expand-Archive -Path "$downloadsPath\$AE_INSTALLER" -DestinationPath $downloadsPath -Force
+Expand-Archive -Path "$DOWNLOADS_PATH\$AE_INSTALLER" -DestinationPath $DOWNLOADS_PATH -Force
 Write-Host "Starting After Effects installation..."
-if (-not (Test-Path "$downloadsPath\After Effects\Build\setup.exe")) { throw "After Effects installer not found" }
-Start-Process -FilePath "$downloadsPath\After Effects\Build\setup.exe" -ArgumentList "--silent" -Wait
+if (-not (Test-Path "$DOWNLOADS_PATH\After Effects\Build\setup.exe")) { throw "After Effects installer not found" }
+Start-Process -FilePath "$DOWNLOADS_PATH\After Effects\Build\setup.exe" -ArgumentList "--silent" -Wait
 $aeEndTime = Get-Date
 $aeDuration = $aeEndTime - $aeStartTime
 Write-Host "After Effects installation completed in: $($aeDuration.ToString('hh\:mm\:ss'))"
@@ -90,7 +91,7 @@ Write-Host "After Effects installation completed in: $($aeDuration.ToString('hh\
 # Maxon App Installation
 $maxonStartTime = Get-Date
 Write-Host "Starting Maxon App installation..."
-Start-Process -FilePath "$downloadsPath\$MAXON_APP_INSTALLER" -ArgumentList "--mode", "unattended", "--unattendedmodeui", "none" -Wait
+Start-Process -FilePath "$DOWNLOADS_PATH\$MAXON_APP_INSTALLER" -ArgumentList "--mode", "unattended", "--unattendedmodeui", "none" -Wait
 $maxonEndTime = Get-Date
 $maxonDuration = $maxonEndTime - $maxonStartTime
 Write-Host "Maxon App installation completed in: $($maxonDuration.ToString('hh\:mm\:ss'))"
@@ -98,7 +99,7 @@ Write-Host "Maxon App installation completed in: $($maxonDuration.ToString('hh\:
 # Red Giant Installation
 $rgStartTime = Get-Date
 Write-Host "Starting Red Giant installation..."
-Start-Process -FilePath "$downloadsPath\$REDGIANT_INSTALLER" -ArgumentList "--mode", "unattended", "--unattendedmodeui", "none" -Wait
+Start-Process -FilePath "$DOWNLOADS_PATH\$REDGIANT_INSTALLER" -ArgumentList "--mode", "unattended", "--unattendedmodeui", "none" -Wait
 $rgEndTime = Get-Date
 $rgDuration = $rgEndTime - $rgStartTime
 Write-Host "Red Giant installation completed in: $($rgDuration.ToString('hh\:mm\:ss'))"
@@ -112,7 +113,7 @@ if ($is_cmf) {
 # Universe Installation
 $universeStartTime = Get-Date
 Write-Host "Starting Universe installation..."
-Start-Process -FilePath "$downloadsPath\$UNIVERSE_INSTALLER" -ArgumentList "--mode", "unattended", "--unattendedmodeui", "none" -Wait
+Start-Process -FilePath "$DOWNLOADS_PATH\$UNIVERSE_INSTALLER" -ArgumentList "--mode", "unattended", "--unattendedmodeui", "none" -Wait
 $universeEndTime = Get-Date
 $universeDuration = $universeEndTime - $universeStartTime
 Write-Host "Universe installation completed in: $($universeDuration.ToString('hh\:mm\:ss'))"
@@ -121,8 +122,8 @@ if ($INSTALL_BORIS_SAPPHIRE) {
     # Boris FX Sapphire Installation
     $bsStartTime = Get-Date
     Write-Host "Starting Boris Sapphire installation..."
-    if (-not (Test-Path "$downloadsPath\$BORIS_SAPPHIRE_INSTALLER")) { throw "Boris Sapphire installer not found" }
-    Start-Process -FilePath "$downloadsPath\$BORIS_SAPPHIRE_INSTALLER" -ArgumentList "/VERYSILENT" -Wait
+    if (-not (Test-Path "$DOWNLOADS_PATH\$BORIS_SAPPHIRE_INSTALLER")) { throw "Boris Sapphire installer not found" }
+    Start-Process -FilePath "$DOWNLOADS_PATH\$BORIS_SAPPHIRE_INSTALLER" -ArgumentList "/VERYSILENT" -Wait
 
     Write-Host "Setting Boris FX license server..."
     [System.Environment]::SetEnvironmentVariable("genarts_LICENSE", $BORIS_LICENSE_SERVER, [System.EnvironmentVariableTarget]::Machine)
@@ -136,14 +137,14 @@ if ($INSTALL_LENSCARE) {
     # Lenscare Installation
     $lenscareStartTime = Get-Date
     Write-Host "Extracting Lenscare zip file..."
-    if (-not (Test-Path "$downloadsPath\$LENSCARE_INSTALLER")) { throw "Lenscare zip file not found" }
-    $lenscareTempExtract = "$downloadsPath\lenscare_temp"
-    Expand-Archive -Path "$downloadsPath\$LENSCARE_INSTALLER" -DestinationPath $lenscareTempExtract -Force
+    if (-not (Test-Path "$DOWNLOADS_PATH\$LENSCARE_INSTALLER")) { throw "Lenscare zip file not found" }
+    $lenscareTempExtract = "$DOWNLOADS_PATH\lenscare_temp"
+    Expand-Archive -Path "$DOWNLOADS_PATH\$LENSCARE_INSTALLER" -DestinationPath $lenscareTempExtract -Force
     Write-Host "Starting Lenscare installation..."
     Copy-Item -Path "$lenscareTempExtract\*" -Destination "$AE_PLUGIN_LOCATION" -Recurse -Force
     Write-Host "Copying Lenscare license file..."
-    if (-not (Test-Path "$downloadsPath\$LENSCARE_LICENSE")) { throw "Lenscare license file not found" }
-    Copy-Item -Path "$downloadsPath\$LENSCARE_LICENSE" -Destination "$AE_PLUGIN_LOCATION\$LENSCARE_LICENSE" -Force
+    if (-not (Test-Path "$DOWNLOADS_PATH\$LENSCARE_LICENSE")) { throw "Lenscare license file not found" }
+    Copy-Item -Path "$DOWNLOADS_PATH\$LENSCARE_LICENSE" -Destination "$AE_PLUGIN_LOCATION\$LENSCARE_LICENSE" -Force
     $lenscareEndTime = Get-Date
     $lenscareDuration = $lenscareEndTime - $lenscareStartTime
     Write-Host "Lenscare installation completed in: $($lenscareDuration.ToString('hh\:mm\:ss'))"

--- a/host_configuration_scripts/cinema4d/cinema4d_redgiant/install-software.ps1
+++ b/host_configuration_scripts/cinema4d/cinema4d_redgiant/install-software.ps1
@@ -7,7 +7,7 @@ $REDGIANT_INSTALLER = "RedGiant-2026.0.0-Win.exe"
 $MAXON_APP_INSTALLER = "Maxon_App_2026.0.0_Win.exe"
 $WEBVIEW2_INSTALLER = "MicrosoftEdgeWebView2RuntimeInstallerX64.exe"
 
-$downloadsPath = "C:\Temp"
+$DOWNLOADS_PATH = "C:\Temp"
 
 # Start overall timing
 $scriptStartTime = Get-Date
@@ -15,12 +15,12 @@ $scriptStartTime = Get-Date
 # Download installers from S3
 $downloadStartTime = Get-Date
 Write-Host "Downloading installers from S3..."
-aws s3 cp --no-progress s3://$INSTALLER_S3_BUCKET/Installers/$REDGIANT_INSTALLER $downloadsPath\$REDGIANT_INSTALLER
-if (-not (Test-Path "$downloadsPath\$REDGIANT_INSTALLER")) { throw "Red Giant download failed" }
-aws s3 cp --no-progress s3://$INSTALLER_S3_BUCKET/Installers/$MAXON_APP_INSTALLER $downloadsPath\$MAXON_APP_INSTALLER
-if (-not (Test-Path "$downloadsPath\$MAXON_APP_INSTALLER")) { throw "Maxon App download failed" }
-aws s3 cp --no-progress s3://$INSTALLER_S3_BUCKET/Installers/$WEBVIEW2_INSTALLER $downloadsPath\$WEBVIEW2_INSTALLER
-if (-not (Test-Path "$downloadsPath\$WEBVIEW2_INSTALLER")) { throw "WebView2 Runtime download failed" }
+aws s3 cp --no-progress s3://$INSTALLER_S3_BUCKET/Installers/$REDGIANT_INSTALLER $DOWNLOADS_PATH\$REDGIANT_INSTALLER
+if (-not (Test-Path "$DOWNLOADS_PATH\$REDGIANT_INSTALLER")) { throw "Red Giant download failed" }
+aws s3 cp --no-progress s3://$INSTALLER_S3_BUCKET/Installers/$MAXON_APP_INSTALLER $DOWNLOADS_PATH\$MAXON_APP_INSTALLER
+if (-not (Test-Path "$DOWNLOADS_PATH\$MAXON_APP_INSTALLER")) { throw "Maxon App download failed" }
+aws s3 cp --no-progress s3://$INSTALLER_S3_BUCKET/Installers/$WEBVIEW2_INSTALLER $DOWNLOADS_PATH\$WEBVIEW2_INSTALLER
+if (-not (Test-Path "$DOWNLOADS_PATH\$WEBVIEW2_INSTALLER")) { throw "WebView2 Runtime download failed" }
 $downloadEndTime = Get-Date
 $downloadDuration = $downloadEndTime - $downloadStartTime
 Write-Host "Downloads completed in: $($downloadDuration.ToString('hh\:mm\:ss'))"
@@ -28,7 +28,7 @@ Write-Host "Downloads completed in: $($downloadDuration.ToString('hh\:mm\:ss'))"
 # Microsoft Edge WebView2 Runtime Installation
 $webview2StartTime = Get-Date
 Write-Host "Starting Microsoft Edge WebView2 Runtime installation..."
-Start-Process -FilePath "$downloadsPath\$WEBVIEW2_INSTALLER" -ArgumentList "/silent", "/install" -Wait
+Start-Process -FilePath "$DOWNLOADS_PATH\$WEBVIEW2_INSTALLER" -ArgumentList "/silent", "/install" -Wait
 $webview2EndTime = Get-Date
 $webview2Duration = $webview2EndTime - $webview2StartTime
 Write-Host "Microsoft Edge WebView2 Runtime installation completed in: $($webview2Duration.ToString('hh\:mm\:ss'))"
@@ -36,7 +36,7 @@ Write-Host "Microsoft Edge WebView2 Runtime installation completed in: $($webvie
 # Maxon App Installation
 $maxonStartTime = Get-Date
 Write-Host "Starting Maxon App installation..."
-Start-Process -FilePath "$downloadsPath\$MAXON_APP_INSTALLER" -ArgumentList "--mode", "unattended", "--unattendedmodeui", "none" -Wait
+Start-Process -FilePath "$DOWNLOADS_PATH\$MAXON_APP_INSTALLER" -ArgumentList "--mode", "unattended", "--unattendedmodeui", "none" -Wait
 $maxonEndTime = Get-Date
 $maxonDuration = $maxonEndTime - $maxonStartTime
 Write-Host "Maxon App installation completed in: $($maxonDuration.ToString('hh\:mm\:ss'))"
@@ -44,7 +44,7 @@ Write-Host "Maxon App installation completed in: $($maxonDuration.ToString('hh\:
 # Red Giant Installation
 $rgStartTime = Get-Date
 Write-Host "Starting Red Giant installation..."
-Start-Process -FilePath "$downloadsPath\$REDGIANT_INSTALLER" -ArgumentList "--mode", "unattended", "--unattendedmodeui", "none" -Wait
+Start-Process -FilePath "$DOWNLOADS_PATH\$REDGIANT_INSTALLER" -ArgumentList "--mode", "unattended", "--unattendedmodeui", "none" -Wait
 $rgEndTime = Get-Date
 $rgDuration = $rgEndTime - $rgStartTime
 Write-Host "Red Giant installation completed in: $($rgDuration.ToString('hh\:mm\:ss'))"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We had a customer request After Effects with Red Giant, Boris FX Sapphire, and Frischluft Lenscare on Windows service-managed fleets. To unblock their workflows, we have created a host config that will install all the software and connect licensing for it.

Also updated the sample to reference 2026 packages.

### How was this change tested?
Ran After Effects jobs with the plugins on Windows SMF. They all had correct output!

### Was this change documented?
Yup! The README has been updated with instructions about how to get installers for Boris FX Sapphire and Frischluft Lenscare as well as how to license them.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*