### PR TITLE
feat: Add SMF fleet capacity manager CloudFormation template

### DIFF
--- a/cloudformation/README.md
+++ b/cloudformation/README.md
@@ -18,6 +18,13 @@ a service-managed fleet to private VPC resources using VPC Lattice. It deploys a
 and configures workers to mount it via a VPC resource endpoint. This pattern is useful for accessing shared
 storage, license servers, or other private resources from Deadline Cloud workers.
 
+## Service-managed fleet capacity manager
+
+The [smf_capacity_manager](farm_templates/smf_capacity_manager/) sample CloudFormation template implements automated
+capacity management for hybrid fleet setups that combine Wait and Save and Spot fleets. It uses AWS Lambda and
+Amazon EventBridge Scheduler to dynamically balance fleet sizes while maintaining constant total capacity,
+optimizing for cost-effective Wait and Save capacity while ensuring any deficit is covered by Spot instances.
+
 ## Budget events notification
 
 The [budget_events_notification](notification_templates/budget_events_notification/) CloudFormation template sets up an integration

--- a/cloudformation/farm_templates/smf_capacity_manager/README.md
+++ b/cloudformation/farm_templates/smf_capacity_manager/README.md
@@ -1,0 +1,134 @@
+# Service-managed fleet capacity manager
+
+## Introduction
+
+This CloudFormation template implements automated capacity management for hybrid fleet setups that combine
+Wait and Save and Spot fleets. It uses AWS Lambda and Amazon EventBridge Scheduler to dynamically balance
+fleet sizes while maintaining constant total capacity. The capacity manager monitors your Wait and Save fleet's active worker count and automatically adjusts your Spot fleet's maximum worker count to maintain your desired total capacity, optimizing for cost-effective Wait and Save capacity while ensuring any deficit is covered by
+Spot instances.
+
+```
+Total Capacity = Wait and Save Workers + Spot Workers (adjusted automatically)
+```
+
+For example, with a desired fleet size of 20 workers:
+- Wait and Save has 15 workers → Spot fleet max is set to 5
+- Wait and Save scales down to 8 → Spot fleet max increases to 12
+- Wait and Save scales up to 18 → Spot fleet max decreases to 2
+
+Workers are only terminated upon task completion, ensuring fleets balance for cost-effectiveness without
+losing rendering work.
+
+## Prerequisites
+
+Before deploying this CloudFormation template, ensure you have the following resources in your AWS Account
+in the same region where you'll deploy the template:
+
+1. **Deadline Cloud Farm**: An existing farm. Copy the Farm ID from the farm details page in the
+   [AWS Deadline Cloud management console](https://console.aws.amazon.com/deadlinecloud/home).
+
+2. **Wait and Save Fleet**: A Wait and Save service-managed fleet with `maxWorkerCount` set to your
+   desired total fleet size (e.g., 20 workers). Copy the Fleet ID from the fleet details page.
+
+3. **Spot Fleet**: A Spot service-managed fleet with the same worker capabilities as your Wait and Save fleet.
+
+   Set `minWorkerCount` to 0 to allow the capacity manager to scale down to zero when Wait and Save fleet
+   is at full capacity. The `maxWorkerCount` will be automatically managed. Copy the Fleet ID from the fleet details page.
+
+4. **Queue Configuration**: Both fleets should be associated with the same queue.
+
+## Setup Instructions
+
+### Using the CloudFormation Console
+
+1. Download the [deadline-cloud-smf-capacity-manager-template.yaml](deadline-cloud-smf-capacity-manager-template.yaml)
+   CloudFormation template.
+2. From the [CloudFormation management console](https://console.aws.amazon.com/cloudformation/),
+   navigate to **Create Stack > With new resources (standard)**.
+3. Upload the template file.
+4. Enter a stack name like "DeadlineCloudCapacityManager" and provide the parameters:
+   - **FarmId**: Your Deadline Cloud farm ID
+   - **WaitAndSaveFleetId**: Your Wait and Save fleet ID
+   - **SpotFleetId**: Your Spot fleet ID
+   - **DesiredFleetSize**: Total workers across both fleets (must match Wait and Save fleet's `maxWorkerCount`)
+   - **CapacityCheckRateMinutes**: Interval between capacity checks (default: 2 minutes)
+5. Check "I acknowledge that AWS CloudFormation might create IAM resources" and create the stack.
+
+### Using the CLI
+
+1. In your CLI, set the following environment variables with the values you have copied from the Prerequisites section.
+   ```bash
+   export FARM_ID=<your-farm-id>
+   export WAIT_AND_SAVE_FLEET_ID=<your-wait-and-save-fleet-id>
+   export SPOT_FLEET_ID=<your-spot-fleet-id>
+   export DESIRED_FLEET_SIZE=<total-desired-workers>
+   ```
+
+2. Deploy the Deadline Cloud capacity manager template with the parameters you specified in Step 1.
+
+   ```bash
+   aws cloudformation deploy \
+     --template-file deadline-cloud-smf-capacity-manager-template.yaml \
+     --stack-name DeadlineCloudCapacityManager \
+     --capabilities CAPABILITY_NAMED_IAM \
+     --parameter-overrides \
+       FarmId=$FARM_ID \
+       WaitAndSaveFleetId=$WAIT_AND_SAVE_FLEET_ID \
+       SpotFleetId=$SPOT_FLEET_ID \
+       DesiredFleetSize=$DESIRED_FLEET_SIZE
+   ```
+
+## Monitoring and Management
+
+### CloudWatch Metrics
+
+The capacity manager automatically publishes CloudWatch metrics to track fleet scaling over time. These metrics
+are published to the `AWS/DeadlineCloud` namespace:
+
+**Available Metrics:**
+- **WaitAndSaveWorkerCount**: Current worker count in the Wait and Save fleet
+  - Dimensions: FarmId, FleetId (Wait and Save)
+- **SpotWorkerCount**: Current worker count in the Spot fleet
+  - Dimensions: FarmId, FleetId (Spot)
+- **TotalWorkerCount**: Combined worker count across both fleets
+  - Dimensions: FarmId
+
+**Viewing Metrics:**
+
+From the [CloudWatch console](https://console.aws.amazon.com/cloudwatch/):
+1. Navigate to **Metrics > All metrics**
+2. Select the **AWS/DeadlineCloud** namespace
+3. View metrics by FarmId and FleetId dimensions
+
+### View Lambda Logs
+
+Monitor the capacity manager's operation from the [AWS Lambda console](https://console.aws.amazon.com/lambda/).
+Select the `FleetCapacityManager` function, click the **Monitor** tab, and select **View CloudWatch logs**
+to see capacity adjustments and worker counts.
+
+### Pause Capacity Management
+
+When not actively rendering, disable the EventBridge Scheduler to stop automated capacity management and
+avoid Lambda invocation costs:
+
+1. Navigate to the [Amazon EventBridge Scheduler console](https://console.aws.amazon.com/scheduler/home#schedules)
+2. Find the `FleetCapacityManager` schedule
+3. Select **Actions > Disable**
+
+Since `minWorkerCount` is 0 in the fleet configurations, no workers will start without jobs. To resume,
+simply enable the schedule again.
+
+## Cleanup
+
+To delete all resources created by this template:
+
+```bash
+aws cloudformation delete-stack --stack-name DeadlineCloudCapacityManager
+```
+
+## Related Documentation
+
+- [AWS Deadline Cloud Service-Managed Fleets](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/smf-manage.html)
+- [AWS Deadline Cloud Pricing](https://aws.amazon.com/deadline-cloud/pricing/)
+- [AWS Lambda Pricing](https://aws.amazon.com/lambda/pricing/)
+- [Amazon EventBridge Scheduler](https://docs.aws.amazon.com/scheduler/latest/UserGuide/what-is-scheduler.html)

--- a/cloudformation/farm_templates/smf_capacity_manager/README.md
+++ b/cloudformation/farm_templates/smf_capacity_manager/README.md
@@ -11,7 +11,7 @@ Spot instances.
 Total Capacity = Wait and Save Workers + Spot Workers (adjusted automatically)
 ```
 
-For example, with a desired fleet size of 20 workers:
+For example, with a target max worker count of 20 workers:
 - Wait and Save has 15 workers → Spot fleet max is set to 5
 - Wait and Save scales down to 8 → Spot fleet max increases to 12
 - Wait and Save scales up to 18 → Spot fleet max decreases to 2
@@ -28,7 +28,7 @@ in the same region where you'll deploy the template:
    [AWS Deadline Cloud management console](https://console.aws.amazon.com/deadlinecloud/home).
 
 2. **Wait and Save Fleet**: A Wait and Save service-managed fleet with `maxWorkerCount` set to your
-   desired total fleet size (e.g., 20 workers). Copy the Fleet ID from the fleet details page.
+   target max worker count (e.g., 20 workers). Copy the Fleet ID from the fleet details page.
 
 3. **Spot Fleet**: A Spot service-managed fleet with the same worker capabilities as your Wait and Save fleet.
 
@@ -50,7 +50,7 @@ in the same region where you'll deploy the template:
    - **FarmId**: Your Deadline Cloud farm ID
    - **WaitAndSaveFleetId**: Your Wait and Save fleet ID
    - **SpotFleetId**: Your Spot fleet ID
-   - **DesiredFleetSize**: Total workers across both fleets (must match Wait and Save fleet's `maxWorkerCount`)
+   - **TargetMaxWorkerCount**: Target maximum total worker count across both fleets (must match Wait and Save fleet's `maxWorkerCount`). Note that actual worker count may briefly exceed this target during scaling operations.
    - **CapacityCheckRateMinutes**: Interval between capacity checks (default: 2 minutes)
 5. Check "I acknowledge that AWS CloudFormation might create IAM resources" and create the stack.
 
@@ -61,7 +61,7 @@ in the same region where you'll deploy the template:
    export FARM_ID=<your-farm-id>
    export WAIT_AND_SAVE_FLEET_ID=<your-wait-and-save-fleet-id>
    export SPOT_FLEET_ID=<your-spot-fleet-id>
-   export DESIRED_FLEET_SIZE=<total-desired-workers>
+   export TARGET_MAX_WORKER_COUNT=<total-target-workers>
    ```
 
 2. Deploy the Deadline Cloud capacity manager template with the parameters you specified in Step 1.
@@ -75,7 +75,7 @@ in the same region where you'll deploy the template:
        FarmId=$FARM_ID \
        WaitAndSaveFleetId=$WAIT_AND_SAVE_FLEET_ID \
        SpotFleetId=$SPOT_FLEET_ID \
-       DesiredFleetSize=$DESIRED_FLEET_SIZE
+       TargetMaxWorkerCount=$TARGET_MAX_WORKER_COUNT
    ```
 
 ## Monitoring and Management

--- a/cloudformation/farm_templates/smf_capacity_manager/deadline-cloud-smf-capacity-manager-template.yaml
+++ b/cloudformation/farm_templates/smf_capacity_manager/deadline-cloud-smf-capacity-manager-template.yaml
@@ -1,0 +1,238 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: >
+  Deadline Cloud dynamic fleet capacity manager. Automatically balances fleet capacity between
+  Wait and Save and Spot fleets, optimizing for cost-effective Wait and Save while maintaining
+  constant total capacity.
+
+Parameters:
+  FarmId:
+    Type: String
+    Description: Deadline Cloud Farm ID
+  WaitAndSaveFleetId:
+    Type: String
+    Description: Wait and Save Fleet ID
+  SpotFleetId:
+    Type: String
+    Description: Spot Fleet ID
+  DesiredFleetSize:
+    Type: Number
+    Description: Total desired fleet size across both fleets
+  CapacityCheckRateMinutes:
+    Type: Number
+    Description: How many minutes between each capacity adjustment check.
+    Default: 2
+
+Resources:
+  capacityManagerLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: FleetCapacityManager
+      Handler: index.handler
+      Role: !GetAtt capacityManagerLambdaServiceRole.Arn
+      Timeout: 60
+      Runtime: python3.13
+      Code:
+        ZipFile: !Sub |
+          """
+          This lambda runs on a schedule to dynamically balance fleet capacity.
+          It gets the current worker count from the Wait and Save fleet,
+          then adjusts Spot fleet capacity to maintain a constant total fleet size of ${DesiredFleetSize}.
+          This automatically optimizes for cost-effective Wait and Save capacity.
+          """
+          import logging
+
+          logger = logging.getLogger()
+          logger.setLevel(logging.INFO)
+
+          import boto3
+
+          farm_id = "${FarmId}"
+          wait_and_save_fleet_id = "${WaitAndSaveFleetId}"
+          spot_fleet_id = "${SpotFleetId}"
+          desired_fleet_size = ${DesiredFleetSize}
+
+          session = boto3.Session()
+          deadline_client = session.client("deadline")
+          cloudwatch_client = boto3.client("cloudwatch")
+
+          def emit_worker_count_metrics(ws_workers, spot_workers):
+              """
+              Emit CloudWatch metrics for fleet worker counts.
+              This provides historical tracking of fleet scaling.
+              """
+              cloudwatch_client.put_metric_data(
+                  Namespace="AWS/DeadlineCloud",
+                  MetricData=[
+                      {
+                          "MetricName": "WaitAndSaveWorkerCount",
+                          "Dimensions": [
+                              {"Name": "FarmId", "Value": farm_id},
+                              {"Name": "FleetId", "Value": wait_and_save_fleet_id},
+                          ],
+                          "Unit": "Count",
+                          "Value": ws_workers,
+                      },
+                      {
+                          "MetricName": "SpotWorkerCount",
+                          "Dimensions": [
+                              {"Name": "FarmId", "Value": farm_id},
+                              {"Name": "FleetId", "Value": spot_fleet_id},
+                          ],
+                          "Unit": "Count",
+                          "Value": spot_workers,
+                      },
+                      {
+                          "MetricName": "TotalWorkerCount",
+                          "Dimensions": [
+                              {"Name": "FarmId", "Value": farm_id},
+                          ],
+                          "Unit": "Count",
+                          "Value": ws_workers + spot_workers,
+                      },
+                  ],
+              )
+
+          def handler(event, context):
+              logger.info(f"Starting capacity adjustment - Desired total: {desired_fleet_size}")
+              
+              try:
+                  # Get current worker count for Wait and Save fleet
+                  ws_fleet = deadline_client.get_fleet(
+                      farmId=farm_id,
+                      fleetId=wait_and_save_fleet_id
+                  )
+                  ws_size = ws_fleet["workerCount"]
+                  logger.info(f"Wait and Save current workers: {ws_size}")
+                  
+                  # Calculate how many spot workers we need
+                  spot_fleet_size = desired_fleet_size - ws_size
+                  logger.info(f"Spot target capacity: {spot_fleet_size}")
+                  
+                  # Get current spot fleet configuration
+                  spot_fleet = deadline_client.get_fleet(
+                      farmId=farm_id,
+                      fleetId=spot_fleet_id
+                  )
+                  current_spot_max = spot_fleet["maxWorkerCount"]
+                  current_spot_workers = spot_fleet["workerCount"]
+                  logger.info(f"Spot current maxWorkerCount: {current_spot_max}")
+                  
+                  # Only update if capacity needs to change
+                  if current_spot_max == spot_fleet_size:
+                      logger.info(f"Spot fleet already at target capacity ({spot_fleet_size}), no update needed")
+                      emit_worker_count_metrics(ws_size, current_spot_workers)
+                      return {
+                          "ws_workers": ws_size,
+                          "spot_target": spot_fleet_size,
+                          "spot_current": current_spot_max,
+                          "total": desired_fleet_size,
+                          "updated": False
+                      }
+                  
+                  # Update the fleet's maximum worker count
+                  response = deadline_client.update_fleet(
+                      farmId=farm_id,
+                      fleetId=spot_fleet_id,
+                      maxWorkerCount=spot_fleet_size
+                  )
+                  
+                  logger.info(f"Spot fleet updated from {current_spot_max} to {spot_fleet_size}")
+                  
+                  emit_worker_count_metrics(ws_size, current_spot_workers)
+                  
+                  return {
+                      "ws_workers": ws_size,
+                      "spot_target": spot_fleet_size,
+                      "spot_previous": current_spot_max,
+                      "total": desired_fleet_size,
+                      "updated": True
+                  }
+                  
+              except Exception as e:
+                  logger.exception(f"Error adjusting fleet capacity: {e}")
+                  raise
+
+  capacityManagerSchedule:
+    Type: AWS::Scheduler::Schedule
+    Properties:
+      Name: FleetCapacityManager
+      Description: Trigger fleet capacity adjustment
+      ScheduleExpression: !Sub "rate(${CapacityCheckRateMinutes} minutes)"
+      FlexibleTimeWindow:
+        Mode: "OFF"
+      State: ENABLED
+      Target:
+        Arn: !GetAtt capacityManagerLambda.Arn
+        RoleArn: !GetAtt capacityManagerScheduleRole.Arn
+        RetryPolicy:
+          MaximumRetryAttempts: 3
+
+  capacityManagerScheduleRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: FleetCapacityManagerScheduler
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: !Sub scheduler.${AWS::URLSuffix}
+      Policies:
+        - PolicyName: InvokeLambdaPolicy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Action:
+                  - lambda:InvokeFunction
+                Effect: Allow
+                Resource:
+                  - !GetAtt capacityManagerLambda.Arn
+
+  capacityManagerLambdaServiceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: FleetCapacityManager
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: !Sub lambda.${AWS::URLSuffix}
+      Policies:
+        - PolicyName: CapacityManagerLambdaPolicy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Action:
+                  - deadline:GetFleet
+                Effect: Allow
+                Resource:
+                  - !Sub arn:${AWS::Partition}:deadline:${AWS::Region}:${AWS::AccountId}:farm/${FarmId}/fleet/${WaitAndSaveFleetId}
+                  - !Sub arn:${AWS::Partition}:deadline:${AWS::Region}:${AWS::AccountId}:farm/${FarmId}/fleet/${SpotFleetId}
+              - Action:
+                  - deadline:UpdateFleet
+                Effect: Allow
+                Resource:
+                  - !Sub arn:${AWS::Partition}:deadline:${AWS::Region}:${AWS::AccountId}:farm/${FarmId}/fleet/${SpotFleetId}
+              - Action:
+                  - cloudwatch:PutMetricData
+                Effect: Allow
+                Resource: '*'
+                Condition:
+                  StringEquals:
+                    cloudwatch:namespace: AWS/DeadlineCloud
+      ManagedPolicyArns:
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+
+Outputs:
+  LambdaFunctionArn:
+    Description: ARN of the Capacity Manager Lambda function
+    Value: !GetAtt capacityManagerLambda.Arn
+  LambdaFunctionName:
+    Description: Name of the Capacity Manager Lambda function
+    Value: !Ref capacityManagerLambda
+  ScheduleArn:
+    Description: ARN of the EventBridge Scheduler schedule
+    Value: !GetAtt capacityManagerSchedule.Arn

--- a/cloudformation/farm_templates/smf_capacity_manager/deadline-cloud-smf-capacity-manager-template.yaml
+++ b/cloudformation/farm_templates/smf_capacity_manager/deadline-cloud-smf-capacity-manager-template.yaml
@@ -14,9 +14,9 @@ Parameters:
   SpotFleetId:
     Type: String
     Description: Spot Fleet ID
-  DesiredFleetSize:
+  TargetMaxWorkerCount:
     Type: Number
-    Description: Total desired fleet size across both fleets
+    Description: Target maximum total worker count across both fleets. Note that actual worker count may briefly exceed this target during scaling operations.
   CapacityCheckRateMinutes:
     Type: Number
     Description: How many minutes between each capacity adjustment check.
@@ -36,7 +36,7 @@ Resources:
           """
           This lambda runs on a schedule to dynamically balance fleet capacity.
           It gets the current worker count from the Wait and Save fleet,
-          then adjusts Spot fleet capacity to maintain a constant total fleet size of ${DesiredFleetSize}.
+          then adjusts Spot fleet capacity to maintain a constant total fleet size of ${TargetMaxWorkerCount}.
           This automatically optimizes for cost-effective Wait and Save capacity.
           """
           import logging
@@ -49,7 +49,7 @@ Resources:
           farm_id = "${FarmId}"
           wait_and_save_fleet_id = "${WaitAndSaveFleetId}"
           spot_fleet_id = "${SpotFleetId}"
-          desired_fleet_size = ${DesiredFleetSize}
+          target_max_worker_count = ${TargetMaxWorkerCount}
 
           session = boto3.Session()
           deadline_client = session.client("deadline")
@@ -93,7 +93,7 @@ Resources:
               )
 
           def handler(event, context):
-              logger.info(f"Starting capacity adjustment - Desired total: {desired_fleet_size}")
+              logger.info(f"Starting capacity adjustment - Target max: {target_max_worker_count}")
               
               try:
                   # Get current worker count for Wait and Save fleet
@@ -105,7 +105,7 @@ Resources:
                   logger.info(f"Wait and Save current workers: {ws_size}")
                   
                   # Calculate how many spot workers we need
-                  spot_fleet_size = desired_fleet_size - ws_size
+                  spot_fleet_size = target_max_worker_count - ws_size
                   logger.info(f"Spot target capacity: {spot_fleet_size}")
                   
                   # Get current spot fleet configuration
@@ -125,7 +125,7 @@ Resources:
                           "ws_workers": ws_size,
                           "spot_target": spot_fleet_size,
                           "spot_current": current_spot_max,
-                          "total": desired_fleet_size,
+                          "total": target_max_worker_count,
                           "updated": False
                       }
                   
@@ -144,7 +144,7 @@ Resources:
                       "ws_workers": ws_size,
                       "spot_target": spot_fleet_size,
                       "spot_previous": current_spot_max,
-                      "total": desired_fleet_size,
+                      "total": target_max_worker_count,
                       "updated": True
                   }
                   


### PR DESCRIPTION
feat: Add SMF fleet capacity manager CloudFormation template

### What was the problem/requirement? (What/Why)
Deadline Cloud users with hybrid Wait and Save + Spot fleet setups can configure automated capacity balancing to optimize costs while maintaining constant total capacity.

### What was the solution? (How)
CloudFormation template that deploys a Lambda function triggered by EventBridge Scheduler to:
- Monitor Wait and Save fleet worker count
- Automatically adjust Spot fleet max capacity to maintain desired total: `Total = Wait and Save Workers + Spot Workers`
- Publish CloudWatch metrics for monitoring

### What is the impact of this change?
Users can automatically optimize fleet costs by maximizing Wait and Save usage and fill capacity gaps with Spot instances.

### How was this change tested?
- Deployed stack with test fleets
- Verified Lambda correctly adjusts Spot fleet maxWorkerCount based on Wait and Save worker count
- Confirmed CloudWatch metrics are published and observed automated scaling between both fleets
- Validated EventBridge Scheduler triggers at configured intervals

<img width="1650" height="219" alt="Screenshot 2026-02-26 at 2 49 02 PM" src="https://github.com/user-attachments/assets/24d13ab6-a75a-44ca-b6f1-32598296d41a" />

### Was this change documented?

Yes, I added a README.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*