### PR TITLE
chore: Convert sample job templates to use task chunking for Nuke, Maya, VRED and 3dsMax/Vray

### DIFF
--- a/job_bundles/3dsmax_vray_denoiser/README.md
+++ b/job_bundles/3dsmax_vray_denoiser/README.md
@@ -1,14 +1,41 @@
 # 3ds Max V-Ray Denoiser Example
 
-This job bundle demonstrates rendering 3ds Max scenes with V-Ray, including automatic VRIMG to EXR conversion with denoising preservation and intelligent frame chunking.
+This job bundle demonstrates rendering 3ds Max scenes with V-Ray, including automatic VRIMG to EXR conversion with denoising preservation, using the Open Job Description task chunking extension to reduce scheduling overhead for multi-frame rendering.
+
+## Task Chunking
+
+This job bundle uses the [Task Chunking](https://github.com/OpenJobDescription/openjd-specifications/blob/mainline/rfcs/0001-task-chunking.md) extension with `rangeConstraint: CONTIGUOUS` to reduce scheduling overhead by grouping frames together into chunks.
+
+```yaml
+extensions:
+  - TASK_CHUNKING
+
+steps:
+- name: Render EXRs
+  parameterSpace:
+    taskParameterDefinitions:
+    - name: Frame
+      type: CHUNK[INT]
+      range: "{{Param.Frames}}"
+      chunks:
+        defaultTaskCount: "{{Param.ChunkSize}}"
+        targetRuntimeSeconds: "{{Param.TargetRuntime}}"
+        rangeConstraint: CONTIGUOUS
+```
+
+Each chunk expands to a contiguous range like `"0-4"` or `"5-9"`, which maps directly to `3dsmaxcmd.exe -start:N -end:N`.
+
+## Job summary
+
+This job bundle renders 3ds Max scenes with V-Ray, including automatic VRIMG to EXR conversion with denoising preservation. Task chunking amortizes 3ds Max's startup and scene loading time by rendering multiple frames per invocation.
 
 ## Features
 
-- **Smart Frame Chunking**: Automatically handles both contiguous ranges (e.g., `1-100`) and non-contiguous ranges (e.g., `1-5,10,15-20`)
+- **Task Chunking**: Uses `CHUNK[INT]` with contiguous frame ranges to reduce scheduling overhead by rendering multiple frames per task
+- **Adaptive Chunking**: Optional target runtime allows the scheduler to adjust chunk sizes dynamically
 - **VRIMG to EXR Conversion**: Converts V-Ray's native VRIMG format to industry-standard EXR while preserving denoising data
 - **Automatic Cleanup**: Removes temporary VRIMG files after successful conversion
 - **Error Handling**: Validates output directories and checks for required V-Ray tools
-- **Flexible Output**: Supports custom output directories and frame ranges
 
 ## Requirements
 
@@ -22,18 +49,12 @@ This job bundle demonstrates rendering 3ds Max scenes with V-Ray, including auto
 - **Scene File**: 3ds Max scene file (.max) to render
 - **Frames**: Frame range specification (supports both `1-100` and `1,5,10-20` formats)
 - **Output Directory**: Directory where final EXR files will be saved
-- **Frames Per Task**: Number of frames to render per task (automatically adjusted for non-contiguous ranges to 1)
-
-## Frame Chunking Behavior
-
-The template intelligently handles different frame range formats:
-
-- **Contiguous ranges** (e.g., `1-100`): Uses the specified Frames Per Task for efficient chunking
-- **Non-contiguous ranges** (e.g., `1-5,10,15-20`): Automatically renders one frame per task regardless of Frames Per Task setting
+- **Chunk Size**: Number of frames to render per chunk (default: 5)
+- **Target Runtime (Seconds)**: Target runtime per chunk (default: 180, set to 0 to use fixed chunk sizes)
 
 ## Output Format
 
-The job renders to V-Ray's native VRIMG format in a temporary directory, then converts to EXR format in the specified output directory. VRIMG files conserve all denoising elements including noise passes, beauty passes, and denoising data. This workflow preserves:
+The job renders to V-Ray's native VRIMG format in a temporary directory, then converts to EXR format in the specified output directory. This workflow preserves:
 
 - All denoising elements and passes
 - Multi-channel data
@@ -45,7 +66,7 @@ The job renders to V-Ray's native VRIMG format in a temporary directory, then co
 ### Scene Tweaks
 
 **Max > Render Setup > V-Ray > Enable built-in frame buffer > Save raw image output:**
-- Give it a local location on the Worker: `C:\Temp\<output>.vrimg` 
+- Give it a local location on the Worker: `C:\Temp\<output>.vrimg`
 - You can use any name instead of the `<output>` placeholder
 
 **Render Elements Configuration:**
@@ -64,7 +85,7 @@ The job renders to V-Ray's native VRIMG format in a temporary directory, then co
 1. **Fill in job details** - You will see a GUI submission window
 2. **Configure scene parameters:**
    - Fill in the scene file location
-   - Set start and end frame
+   - Set the frame range
    - Specify the output directory
 3. **Select job attachments:**
    - Select all the assets in the job attachments which scene needs to render

--- a/job_bundles/3dsmax_vray_denoiser/template.yaml
+++ b/job_bundles/3dsmax_vray_denoiser/template.yaml
@@ -1,14 +1,16 @@
 specificationVersion: 'jobtemplate-2023-09'
+extensions:
+  - TASK_CHUNKING
 name: 3ds Max V-Ray Render
 description: |
-  This job bundle renders a 3ds Max scene using V-Ray with frame chunking support.
-  
+  This job bundle renders a 3ds Max scene using V-Ray with task chunking support.
+
   Features:
-  - Frame chunking for efficient parallel rendering
+  - Contiguous task chunking
   - VRIMG to EXR conversion with denoising preservation
   - Automatic cleanup of temporary files
   - Error handling and validation
-  
+
   Requirements:
   - 3ds Max 2025 installed on Windows worker hosts
   - V-Ray plugin for 3ds Max
@@ -38,8 +40,7 @@ parameterDefinitions:
     label: Frames
     groupLabel: Render Parameters
   default: "0-10"
-  description: Frame range to render (e.g., 1-100, 1,5,10-20)
-
+  description: Frame range to render (e.g., 1-100, 1,5,10-20).
 - name: OutputDirectory
   type: PATH
   objectType: DIRECTORY
@@ -50,22 +51,36 @@ parameterDefinitions:
     groupLabel: Render Parameters
   description: Choose the render output directory.
 
-- name: FramesPerTask
+- name: ChunkSize
   type: INT
   userInterface:
     control: SPIN_BOX
-    label: Frames Per Task
+    label: Chunk Size
     groupLabel: Render Parameters
-  default: 1
+  default: 5
   minValue: 1
-  description: Number of frames to render per task
+  description: Number of frames to render per chunk.
+
+- name: TargetRuntime
+  type: INT
+  userInterface:
+    control: SPIN_BOX
+    label: Target Runtime (Seconds)
+    groupLabel: Render Parameters
+  default: 180
+  description: Target runtime per chunk in seconds (0 to disable adaptive chunking).
+
 steps:
 - name: Render EXRs
   parameterSpace:
     taskParameterDefinitions:
     - name: Frame
-      type: INT
-      range: "{{Param.Frames}}:{{Param.FramesPerTask}}"
+      type: CHUNK[INT]
+      range: "{{Param.Frames}}"
+      chunks:
+        defaultTaskCount: "{{Param.ChunkSize}}"
+        targetRuntimeSeconds: "{{Param.TargetRuntime}}"
+        rangeConstraint: CONTIGUOUS
   script:
     embeddedFiles:
     - name: render_script
@@ -77,27 +92,15 @@ steps:
         setlocal enabledelayedexpansion
         echo Starting 3ds Max render...
         echo Scene: {{Param.SceneFile}}
-        echo Original Frame Range: {{Param.Frames}}
-        
-        set /a taskStart={{Task.Param.Frame}}
-        
-        REM Check if this is a non-contiguous range (contains commas)
-        echo {{Param.Frames}} | findstr "," >nul
-        if !errorlevel! equ 0 (
-          REM Non-contiguous range - always render single frame
-          set /a taskEnd=!taskStart!
-          echo Non-contiguous range detected - rendering single frame: !taskStart!
-        ) else (
-          REM Contiguous range - check if we need to limit the end frame
-          set /a taskEnd=!taskStart!+{{Param.FramesPerTask}}-1
-          
-          REM Extract the actual end frame from the range to avoid going beyond it
-          for /f "tokens=2 delims=-" %%a in ("{{Param.Frames}}") do set maxFrame=%%a
-          if !taskEnd! gtr !maxFrame! set taskEnd=!maxFrame!
-          
-          echo Contiguous range - rendering frames !taskStart! to !taskEnd!
+
+        REM Parse contiguous chunk range "START-END"
+        for /f "tokens=1,2 delims=-" %%a in ("{{Task.Param.Frame}}") do (
+          set /a taskStart=%%a
+          set /a taskEnd=%%b
         )
-        
+
+        echo Rendering frames !taskStart! to !taskEnd!
+
         REM Validate output directory
         mkdir "{{Param.OutputDirectory}}" 2>nul
         echo test > "{{Param.OutputDirectory}}\test.tmp" 2>nul || (
@@ -105,25 +108,21 @@ steps:
           exit /b 1
         )
         del "{{Param.OutputDirectory}}\test.tmp" 2>nul
-        
+
         REM Check vrimg2exr exists
         if not exist "C:\ProgramData\Autodesk\ApplicationPlugins\VRay3dsMax2025\bin\vrimg2exr.exe" (
           echo ERROR: vrimg2exr.exe not found
           exit /b 1
         )
-        
+
         REM Render frame range for this chunk
         "C:\Program Files\Autodesk\3ds Max 2025\3dsmaxcmd.exe" -start:!taskStart! -end:!taskEnd! "{{Param.SceneFile}}"
         if %ERRORLEVEL% NEQ 0 (
           echo ERROR: 3dsmaxcmd failed with exit code %ERRORLEVEL%
           exit /b %ERRORLEVEL%
         )
-        
-        if !taskStart! equ !taskEnd! (
-          echo 3ds Max render completed successfully for frame !taskStart!
-        ) else (
-          echo 3ds Max render completed successfully for frames !taskStart! to !taskEnd!
-        )
+
+        echo 3ds Max render completed successfully for frames !taskStart! to !taskEnd!
         echo Converting .vrimg files to .exr and moving to output...
         set converted=0
         for %%f in ("C:\temp\*.vrimg") do (

--- a/job_bundles/maya_cli_render/README.md
+++ b/job_bundles/maya_cli_render/README.md
@@ -1,24 +1,70 @@
-# Maya CLI Render
-
-## Job summary
+# Maya CLI Render with Contiguous Chunks
 
 This job bundle renders a Maya software renderer scene with the
-[Maya CLI `Render` command](https://help.autodesk.com/view/MAYAUL/2025/ENU/?guid=GUID-EB558BC0-5C2B-439C-9B00-F97BCB9688E4).
+[Maya CLI `Render` command](https://help.autodesk.com/view/MAYAUL/2025/ENU/?guid=GUID-EB558BC0-5C2B-439C-9B00-F97BCB9688E4)
+using the [Task Chunking](https://github.com/OpenJobDescription/openjd-specifications/blob/mainline/rfcs/0001-task-chunking.md)
+extension to reduce scheduling overhead by grouping frames into chunks.
+
+## Features
+
+- **Task Chunking**: Uses `CHUNK[INT]` with contiguous frame ranges to reduce scheduling overhead by rendering multiple frames per chunk
+- **Adaptive Chunking**: Optional target runtime allows the scheduler to adjust chunk sizes dynamically
+
+## Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| Maya Scene File | Maya scene file (.ma, .mb) to render | `fallinggears.ma` |
+| Frames | Frame range (e.g., `1-60`) | `1-60` |
+| Chunk Size | Number of frames per chunk | `10` |
+| Target Runtime | Target seconds per chunk (0 to use fixed chunk sizes) | `180` |
+| Camera Name | Camera to render | `persp` |
+| Image Width | Output image width | `960` |
+| Image Height | Output image height | `540` |
+| Output Directory | Render output directory | `output` |
+| Project Path | Maya project directory | `.` |
+
+## Task Chunking
+
+This template uses the `TASK_CHUNKING` extension with `rangeConstraint: CONTIGUOUS`:
+
+```yaml
+extensions:
+  - TASK_CHUNKING
+
+steps:
+- name: Render
+  parameterSpace:
+    taskParameterDefinitions:
+    - name: Frame
+      type: CHUNK[INT]
+      range: "{{Param.Frames}}"
+      chunks:
+        defaultTaskCount: "{{Param.ChunkSize}}"
+        targetRuntimeSeconds: "{{Param.TargetRuntime}}"
+        rangeConstraint: CONTIGUOUS
+```
+
+Each chunk expands to a contiguous range like `"1-10"` or `"11-20"`, which maps directly to Maya's `-s` (start) and `-e` (end) arguments.
+
+Reference: [Maya Common Renderer Flags](https://help.autodesk.com/view/MAYAUL/2025/ENU/?guid=GUID-0280AB86-8ABE-4F75-B1B9-D5B7DBB7E25A)
+
+## Usage
 
 To run it, you will need a Maya installation available in the PATH in one of the following ways:
 * As a conda package when your queue has a conda queue environment set up to
   provide virtual environments for jobs. For more information see the developer guide section
-  [Provide applications for yor jobs](https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/provide-applications.html).
+  [Provide applications for your jobs](https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/provide-applications.html).
 * Installed on the worker hosts that run the job. You can customize your Deadline Cloud
   queues, fleets, and this job to fit your own production pipeline.
 
 The core of this job is an embedded template file called `render.sh` that invokes
 the Maya CLI `Render` command. The command is a template that substitutes job parameters and the
-frame task parameter.
+frame chunk parameter.
 
-The `Render` command is part of an Open Job Description step. It expands to a task per frame by
-defining a parameter space using the Frames job parameter. It limits the fleets it will run on
-by including host requirements for Linux.
+The `Render` command is part of an Open Job Description step. It groups frames into contiguous
+chunks using the task chunking extension, and each chunk is rendered in a single Maya invocation.
+It limits the fleets it will run on by including host requirements for Linux.
 
 The rest of the job template consists of the parameter definitions. This metadata specifies
 the names, types, and descriptions of each parameter, along with information on what user

--- a/job_bundles/maya_cli_render/template.yaml
+++ b/job_bundles/maya_cli_render/template.yaml
@@ -1,7 +1,11 @@
 specificationVersion: 'jobtemplate-2023-09'
+extensions:
+  - TASK_CHUNKING
 name: Maya CLI Render
 description: |
-  This job bundle renders a Maya software renderer scene with the Maya CLI `Render` command.
+  This job bundle renders a Maya software renderer scene with the Maya CLI `Render` command,
+  using contiguous task chunking to amortize Maya's startup and scene loading time across
+  multiple frames.
 
   To run it, you will need a Maya installation available in the PATH in one of the following ways:
     * As a conda package when your queue has a conda queue environment set up to
@@ -40,6 +44,22 @@ parameterDefinitions:
     label: Frames
     groupLabel: Render Parameters
   default: 1-60
+- name: ChunkSize
+  type: INT
+  userInterface:
+    control: SPIN_BOX
+    label: Chunk Size
+    groupLabel: Render Parameters
+  default: 10
+  description: Number of frames to render per chunk.
+- name: TargetRuntime
+  type: INT
+  userInterface:
+    control: SPIN_BOX
+    label: Target Runtime (Seconds)
+    groupLabel: Render Parameters
+  default: 180
+  description: Target runtime per chunk in seconds (0 to disable adaptive chunking).
 - name: CameraName
   type: STRING
   userInterface:
@@ -97,8 +117,12 @@ steps:
   parameterSpace:
     taskParameterDefinitions:
     - name: Frame
-      type: INT
+      type: CHUNK[INT]
       range: "{{Param.Frames}}"
+      chunks:
+        defaultTaskCount: "{{Param.ChunkSize}}"
+        targetRuntimeSeconds: "{{Param.TargetRuntime}}"
+        rangeConstraint: CONTIGUOUS
   script:
     embeddedFiles:
     - name: Render
@@ -109,12 +133,16 @@ steps:
 
         cd '{{Param.ProjectPath}}'
 
+        # Extract start and end frames from the contiguous chunk range "START-END"
+        START_FRAME="$(echo '{{Task.Param.Frame}}' | cut -d- -f1)"
+        END_FRAME="$(echo '{{Task.Param.Frame}}' | cut -d- -f2)"
+
         set -x
         Render -r sw \
             -proj '{{Param.ProjectPath}}' \
             -rd '{{Param.OutputDir}}' \
-            -s {{Task.Param.Frame}} \
-            -e {{Task.Param.Frame}} \
+            -s "$START_FRAME" \
+            -e "$END_FRAME" \
             -pad 4 \
             -fnc "name.#.ext" \
             -cam {{Param.CameraName}} \

--- a/job_bundles/nuke_render/README.md
+++ b/job_bundles/nuke_render/README.md
@@ -1,8 +1,34 @@
 # Nuke Render Job Bundle
 
+## Task Chunking
+
+This job bundle uses the [Task Chunking](https://github.com/OpenJobDescription/openjd-specifications/blob/mainline/rfcs/0001-task-chunking.md) extension with `rangeConstraint: NONCONTIGUOUS` to reduce scheduling overhead by grouping frames into chunks.
+
+```yaml
+extensions:
+  - TASK_CHUNKING
+
+steps:
+- name: NukeRender
+  parameterSpace:
+    taskParameterDefinitions:
+    - name: Frame
+      type: CHUNK[INT]
+      range: "{{Param.Frames}}"
+      chunks:
+        defaultTaskCount: "{{Param.ChunkSize}}"
+        targetRuntimeSeconds: "{{Param.TargetRuntime}}"
+        rangeConstraint: NONCONTIGUOUS
+```
+
+Each chunk expands to an arbitrary frame set like `"1-3,5,7-20:2"`. The embedded bash script converts this to Nuke's `-F` flag syntax (e.g., `-F 1-3 -F 5 -F 7-20x2`).
+
+Reference: [Nuke Command Line Operations](https://learn.foundry.com/nuke/content/comp_environment/configuring_nuke/command_line_operations.html)
+
 ## Job summary
 
 This job bundle renders Nuke scripts using Nuke's headless rendering mode with the `nuke -x` command.
+Task chunking amortizes Nuke's startup and scene loading time by rendering multiple frames per invocation.
 
 To run it, you will need a Nuke installation available in the PATH in one of the following ways:
 * As a conda package when your queue has a conda queue environment set up to
@@ -11,22 +37,17 @@ To run it, you will need a Nuke installation available in the PATH in one of the
 * Installed on the worker hosts that run the job. You can customize your Deadline Cloud
   queues, fleets, and this job to fit your own production pipeline.
 
-The core of this job is an embedded bash script that runs the `nuke` command with these flags:
-* `-F {frame}` - Renders a specific frame number
-* `--sro` - Skip render output logging
+Nuke flags used:
+* `-F` - Frame range segments (converted from the chunk's range expression)
+* `--sro` - Forces render order of Write nodes
 * `-V 2` - Set verbosity level to 2
 * `-x` - Execute the script without opening the GUI
 
-The job creates one task per frame using Open Job Description's parameter space feature,
-where the Frames parameter (e.g. "1-10") gets expanded into individual frame tasks.
-The job is restricted to Linux workers through host requirements.
-
 ## What this sample does
 
-This job bundle takes a Nuke script file and renders it frame by frame using Nuke's command-line interface. The sample includes:
+This job bundle takes a Nuke script file and renders it using Nuke's command-line interface. The sample includes:
 
 - **MotionBlur3D Scene**: A pre-configured Nuke script that demonstrates 3D motion blur effects
-- **Frame-based rendering**: Supports single frames or frame ranges
 - **Flexible output**: Configurable output directory and project paths
 - **Environment support**: Works with both Conda and Rez package management systems
 
@@ -58,7 +79,9 @@ Submit with custom parameters:
 ```bash
 deadline bundle submit job_bundles/nuke_render \
   --name "My Nuke Render" \
-  -p Frames="1-10" \
+  -p Frames="1-3,5,6-20:2" \
+  -p ChunkSize=10 \
+  -p TargetRuntime=300 \
   -p NukeScript="/path/to/my/script.nk" \
   -p OutputDir="/path/to/output"
 ```
@@ -76,7 +99,9 @@ deadline bundle gui-submit job_bundles/nuke_render
 ### Render Parameters
 
 - **Nuke Script File**: Path to the .nk script file to render
-- **Frames**: Frame range (e.g., "1-10", "1,5,10", or "1")
+- **Frames**: Frame range expression (e.g., "1-3,5,6-20:2")
+- **Chunk Size**: Number of frames per chunk (default: 5)
+- **Target Runtime (Seconds)**: Target runtime per chunk (default: 180, set to 0 to use fixed chunk sizes)
 - **Project Directory**: Working directory containing the script and assets
 - **Output Directory**: Where rendered frames will be saved
 
@@ -98,5 +123,6 @@ To use this template with your own Nuke scripts:
 
 1. Replace the sample scene file or point to your own .nk file
 2. Adjust the frame range as needed
-3. Configure output paths and directories
-4. Add any additional assets via job attachments
+3. Tune the chunk size and target runtime based on your scene's render time per frame
+4. Configure output paths and directories
+5. Add any additional assets via job attachments

--- a/job_bundles/nuke_render/template.yaml
+++ b/job_bundles/nuke_render/template.yaml
@@ -1,4 +1,6 @@
 specificationVersion: 'jobtemplate-2023-09'
+extensions:
+  - TASK_CHUNKING
 name: Nuke Render
 description: |
   This job bundle renders Nuke scripts using Nuke's headless rendering mode.
@@ -36,8 +38,24 @@ parameterDefinitions:
     control: LINE_EDIT
     label: Frames
     groupLabel: Render Parameters
-  default: "1"
-  description: Frame range to render (e.g., "1-10" or "1,5,10").
+  default: "1-3,5,6-20:2"
+  description: Frame range to render (e.g., "1-10", "1,5,10", or "1-100:2").
+- name: ChunkSize
+  type: INT
+  userInterface:
+    control: SPIN_BOX
+    label: Chunk Size
+    groupLabel: Render Parameters
+  default: 5
+  description: Number of frames to render per chunk.
+- name: TargetRuntime
+  type: INT
+  userInterface:
+    control: SPIN_BOX
+    label: Target Runtime (Seconds)
+    groupLabel: Render Parameters
+  default: 180
+  description: Target runtime per chunk in seconds (0 to disable adaptive chunking).
 - name: ProjectPath
   type: PATH
   objectType: DIRECTORY
@@ -86,8 +104,12 @@ steps:
   parameterSpace:
     taskParameterDefinitions:
     - name: Frame
-      type: INT
+      type: CHUNK[INT]
       range: "{{Param.Frames}}"
+      chunks:
+        defaultTaskCount: "{{Param.ChunkSize}}"
+        targetRuntimeSeconds: "{{Param.TargetRuntime}}"
+        rangeConstraint: NONCONTIGUOUS
   script:
     actions:
       onRun:
@@ -108,8 +130,16 @@ steps:
         # Create output directory if it doesn't exist
         mkdir -p '{{Param.OutputDir}}'
 
-        # Render the frame using Nuke
-        nuke -F {{Task.Param.Frame}} \
+        # Convert OpenJD range expression to Nuke -F flags.
+        # E.g. "1-3,5,7-20:2" becomes "-F 1-3 -F 5 -F 7-20x2"
+        NUKE_FRAMES=""
+        IFS=',' read -ra SEGMENTS <<< "{{Task.Param.Frame}}"
+        for seg in "${SEGMENTS[@]}"; do
+          NUKE_FRAMES="$NUKE_FRAMES -F $(echo "$seg" | tr ':' 'x')"
+        done
+
+        # Render the chunk using Nuke
+        nuke $NUKE_FRAMES \
              --sro -V 2 \
              -x '{{Param.NukeScript}}'
   hostRequirements:

--- a/job_bundles/vred_render/README.md
+++ b/job_bundles/vred_render/README.md
@@ -1,5 +1,34 @@
 # VRED Renderer Job Bundle
 
+## Task Chunking
+
+This job bundle uses the [Task Chunking](https://github.com/OpenJobDescription/openjd-specifications/blob/mainline/rfcs/0001-task-chunking.md) extension with `rangeConstraint: CONTIGUOUS` to reduce scheduling overhead by grouping frames into chunks.
+
+```yaml
+extensions:
+  - TASK_CHUNKING
+
+steps:
+- name: VRED Render
+  parameterSpace:
+    taskParameterDefinitions:
+    - name: Frame
+      type: CHUNK[INT]
+      range: "{{Param.Frames}}"
+      chunks:
+        defaultTaskCount: "{{Param.ChunkSize}}"
+        targetRuntimeSeconds: "{{Param.TargetRuntime}}"
+        rangeConstraint: CONTIGUOUS
+    - name: TileNumberX
+      type: INT
+      range: "1-{{Param.NumXTiles}}"
+    - name: TileNumberY
+      type: INT
+      range: "1-{{Param.NumYTiles}}"
+```
+
+Each chunk expands to a contiguous range like `"0-4"` or `"5-9"`. The Python render parameter script parses this into start/end frames for VRED's API.
+
 ## Overview
 
 This job bundle is for rendering VRED scenes using either VRED Core or VRED Pro in headless mode. It uses VRED's Python API through the `VRED_RenderScript_DeadlineCloud.py` script, which:
@@ -87,15 +116,9 @@ Note: All `PATH` type parameters must use relative paths from the current workin
 - **SSQuality**: Supersampling quality setting (Off, Low, Medium, High, Ultra High)
 
 ### Frame Control Settings
-- **StartFrame**: First frame to render (default: 0)
-- **EndFrame**: Last frame to render (default: 20)
-- **FrameStep**: Frame increment - e.g., 2 for rendering every second frame (default: 1)
-- **FramesPerTask**: Number of consecutive frames to render in a single Task (default: 1)
-    This can improve rendering efficiency by reducing overhead from task initialization.
-    Example with `FramesPerTask=5`:
-    - Task 1 renders frames 1-5
-    - Task 2 renders frames 6-10
-    - And so on...
+- **Frames**: Frame range to render (default: "0-20")
+- **ChunkSize**: Number of frames to render per chunk (default: 5)
+- **TargetRuntime**: Target runtime per chunk in seconds (default: 180, set to 0 to use fixed chunk sizes)
 
 ### Animation Settings
 - **RenderAnimation**: Enable animation rendering (true/false)

--- a/job_bundles/vred_render/template.yaml
+++ b/job_bundles/vred_render/template.yaml
@@ -1,4 +1,6 @@
 specificationVersion: jobtemplate-2023-09
+extensions:
+  - TASK_CHUNKING
 name: VRED Renderer
 description: |
   This render job template depends on Autodesk VRED Core (or optionally VRED Pro) to perform rendering and supports
@@ -212,39 +214,31 @@ parameterDefinitions:
       groupLabel: Render Options
     default: ""
     description: The name of the animation clip to render.
-  - name: StartFrame
-    type: INT
+  - name: Frames
+    type: STRING
     userInterface:
-      control: SPIN_BOX
-      label: Start Frame
+      control: LINE_EDIT
+      label: Frames
       groupLabel: Render Options
-    default: 0
-    description: The first frame of a range to render.
-  - name: EndFrame
+    default: "0-20"
+    description: The frame range to render (e.g., 0-20).
+  - name: ChunkSize
     type: INT
     userInterface:
       control: SPIN_BOX
-      label: End Frame
-      groupLabel: Render Options
-    default: 20
-    description: The last frame of a range to render.
-  - name: FrameStep
-    type: INT
-    userInterface:
-      control: SPIN_BOX
-      label: Frame Step
-      groupLabel: Render Options
-    default: 1
-    description: The frame step for the frame range (i.e. 2 for rendering every second frame).
-  - name: FramesPerTask
-    type: INT
-    userInterface:
-      control: SPIN_BOX
-      label: Frames Per Task
+      label: Chunk Size
       groupLabel: Render Options
     minValue: 1
-    default: 1
-    description: The number of frames that will be rendered at a time for each task within a render job.
+    default: 5
+    description: Number of frames to render per chunk.
+  - name: TargetRuntime
+    type: INT
+    userInterface:
+      control: SPIN_BOX
+      label: Target Runtime (Seconds)
+      groupLabel: Render Options
+    default: 180
+    description: Target runtime per chunk in seconds (0 to disable adaptive chunking).
   - name: IncludeAlphaChannel
     type: STRING
     userInterface:
@@ -363,9 +357,13 @@ steps:
   - name: VRED Render
     parameterSpace:
       taskParameterDefinitions:
-        - name: StartFrameFromCurrentChunk
-          type: INT
-          range: "{{Param.StartFrame}}-{{Param.EndFrame}}:{{Param.FramesPerTask}}"
+        - name: Frame
+          type: CHUNK[INT]
+          range: "{{Param.Frames}}"
+          chunks:
+            defaultTaskCount: "{{Param.ChunkSize}}"
+            targetRuntimeSeconds: "{{Param.TargetRuntime}}"
+            rangeConstraint: CONTIGUOUS
         - name: TileNumberX
           type: INT
           range: "1-{{Param.NumXTiles}}"
@@ -393,20 +391,18 @@ steps:
                 :return: a dictionary containing appropriately-typed values (non-inferred) for use in VRED API calls.
                 """
 
-                # Depending on implementation, a frame chunk ID or an actual starting frame number that
-                # corresponds to that ID could be provided.
+                # Parse contiguous chunk range "START-END" (e.g., "0-4" or "5-5")
                 #
-                start_frame = int({{Task.Param.StartFrameFromCurrentChunk}})
-                frames_per_task = int({{Param.FramesPerTask}})
-                end_frame = min(start_frame + frames_per_task - 1, int({{Param.EndFrame}}))
+                chunk = "{{Task.Param.Frame}}"
+                start_frame, end_frame = (int(x) for x in chunk.split("-"))
                 return {
                     'AnimationClip': str('{{Param.AnimationClip}}'),
                     'AnimationType': str('{{Param.AnimationType}}'),
                     'DLSSQuality': str('{{Param.DLSSQuality}}'),
                     'DPI': int({{Param.DPI}}),
                     'EndFrame': int(end_frame),
-                    'FrameStep': int({{Param.FrameStep}}),
-                    'FramesPerTask': int(frames_per_task),
+                    'FrameStep': int(1),
+                    'FramesPerTask': int(end_frame - start_frame + 1),
                     'GPURaytracing': int(str_to_bool('{{Param.GPURaytracing}}')),
                     'ImageHeight': int({{Param.ImageHeight}}),
                     'ImageWidth': int({{Param.ImageWidth}}),


### PR DESCRIPTION
Convert sample job templates to use task chunking for Nuke, Maya, VRED and 3dsMax/Vray

### What was the problem/requirement? (What/Why)

Now we support [Task Chunking](https://github.com/OpenJobDescription/openjd-specifications/blob/mainline/rfcs/0001-task-chunking.md), we should update our sample job templates to use it.

### What was the solution? (How)

Convert sample job templates to use task chunking. In this PR, it converts sample job templates for Nuke, Maya, VRED, and 3dsMax/Vray

### What is the impact of this change?
User will have sample job templates using task chunking for the DCC they are working with.

### How was this change tested?
I submitted job using these job templates and here is the results:

- 3dsMax/Vray
<img width="1381" height="846" alt="Screenshot 2026-03-02 at 12 02 31 PM" src="https://github.com/user-attachments/assets/444fcee7-95ae-47a2-9588-7368f2b81b87" />

- VRED
<img width="1371" height="832" alt="Screenshot 2026-03-02 at 12 03 24 PM" src="https://github.com/user-attachments/assets/a9a80550-9289-4403-bdbc-2e04de4def93" />

- Nuke 
<img width="1374" height="839" alt="Screenshot 2026-03-02 at 12 04 21 PM" src="https://github.com/user-attachments/assets/d35beb03-231c-403a-807b-11d749e552a9" />

- Maya
<img width="1376" height="834" alt="Screenshot 2026-03-02 at 12 06 19 PM" src="https://github.com/user-attachments/assets/48bb8a0e-5b94-4ed2-805f-9779cecdf488" />

### Was this change documented?

Yes, this PR also included doc changes

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*