### PR TITLE
chore: make Universe installation optional in AE Red Giant host config script

### DIFF
--- a/host_configuration_scripts/aftereffects/aftereffects_redgiant/README.md
+++ b/host_configuration_scripts/aftereffects/aftereffects_redgiant/README.md
@@ -36,7 +36,9 @@ Download from Red Giant:
 2. Navigate to the [Maxon Downloads](https://www.maxon.net/en/downloads) section
 3. Download `RedGiant-2025.6.0-Win.exe` (or latest version) for Windows from the section Red Giant
 
-### 3. Universe
+### 3. Universe (Optional)
+
+Note that Universe is [now included in Red Giant 2026.2.0 and above by default](https://support.maxon.net/hc/en-us/articles/24114684657692-Red-Giant-2026-2-0-December-3-2025). For older versions of Red Giant, you can download Universe separately following the instructions below.
 
 Download from Red Giant:
 1. Log into your Maxon account
@@ -98,10 +100,19 @@ To upload the installers to S3, you can upload the `.zip` and `.exe` files to yo
 export INSTALLER_S3_BUCKET=your-installer-bucket
 
 aws s3 cp "After Effects_en_US_WIN_64.zip" s3://$INSTALLER_S3_BUCKET/Installers/
-aws s3 cp "RedGiant-2025.6.0-Win.exe" s3://$INSTALLER_S3_BUCKET/Installers/
-aws s3 cp "Universe-2025.3.3_Win.exe" s3://$INSTALLER_S3_BUCKET/Installers/
-aws s3 cp "Maxon_App_2025.4.2_Win.exe" s3://$INSTALLER_S3_BUCKET/Installers/
+aws s3 cp "RedGiant-2026.3.0-Win.exe" s3://$INSTALLER_S3_BUCKET/Installers/
+aws s3 cp "Maxon_App_2026.0.1_Win.exe" s3://$INSTALLER_S3_BUCKET/Installers/
 aws s3 cp "MicrosoftEdgeWebView2RuntimeInstallerX64.exe" s3://$INSTALLER_S3_BUCKET/Installers/
+
+# Optional, Maxon Universe is now included in Red Giant 2026.2.0 and above
+aws s3 cp "Universe-2026.0.1_Win.exe" s3://$INSTALLER_S3_BUCKET/Installers/
+
+# Optional, use if installing Boris FX Sapphire
+aws s3 cp "sapphire-ae-install-2026.exe" s3://$INSTALLER_S3_BUCKET/Installers/
+
+# Optional, use if installing Frischluft Lenscare
+aws s3 cp "lenscare_ae_v1.5.5(win).zip" s3://$INSTALLER_S3_BUCKET/Installers/
+aws s3 cp "Lenscare_ae.key" s3://$INSTALLER_S3_BUCKET/Installers/
 ```
 
 ### 3. Update IAM Role Permissions

--- a/host_configuration_scripts/aftereffects/aftereffects_redgiant/install-software.ps1
+++ b/host_configuration_scripts/aftereffects/aftereffects_redgiant/install-software.ps1
@@ -1,5 +1,5 @@
 # Sequential Software Installation Script
-# Downloads installers from S3 and installs Adobe After Effects, Red Giant, Universe, Boris Sapphire (optional), and Lenscare (optional) in order
+# Downloads installers from S3 and installs Adobe After Effects, Red Giant, Universe (optional), Boris Sapphire (optional), and Lenscare (optional) in order
 
 # Stop after first failing command
 $ErrorActionPreference = "Stop"
@@ -11,11 +11,13 @@ $AE_VERSION = "2025"  # After Effects version year
 $INSTALLER_S3_BUCKET = "<your-installer-bucket>"  # Your S3 bucket name
 $AE_INSTALLER = "After Effects_en_US_WIN_64.zip"
 $REDGIANT_INSTALLER = "RedGiant-2026.3.0-Win.exe"
-$UNIVERSE_INSTALLER = "Universe-2026.0.1_Win.exe"
 $MAXON_APP_INSTALLER = "Maxon_App_2026.1.0_Win.exe"
 $WEBVIEW2_INSTALLER = "MicrosoftEdgeWebView2RuntimeInstallerX64.exe"
 
 # Optional Plugin Configuration
+$INSTALL_UNIVERSE = $false  # Set to $true to install Universe (included by default in Red Giant 2026)
+$UNIVERSE_INSTALLER = "Universe-2026.0.1_Win.exe"
+
 $INSTALL_BORIS_SAPPHIRE = $false  # Set to $true to install Boris FX Sapphire
 $BORIS_SAPPHIRE_INSTALLER = "sapphire-ae-install-2026.exe"
 # custom licensing is required for Boris FX, as it is not currently supported by Deadline Cloud Usage Based Licensing
@@ -48,10 +50,13 @@ aws s3 cp --no-progress s3://$INSTALLER_S3_BUCKET/Installers/$REDGIANT_INSTALLER
 if (-not (Test-Path "$DOWNLOADS_PATH\$REDGIANT_INSTALLER")) { throw "Red Giant download failed" }
 aws s3 cp --no-progress s3://$INSTALLER_S3_BUCKET/Installers/$MAXON_APP_INSTALLER $DOWNLOADS_PATH\$MAXON_APP_INSTALLER
 if (-not (Test-Path "$DOWNLOADS_PATH\$MAXON_APP_INSTALLER")) { throw "Maxon App download failed" }
-aws s3 cp --no-progress s3://$INSTALLER_S3_BUCKET/Installers/$UNIVERSE_INSTALLER $DOWNLOADS_PATH\$UNIVERSE_INSTALLER
-if (-not (Test-Path "$DOWNLOADS_PATH\$UNIVERSE_INSTALLER")) { throw "Universe download failed" }
 aws s3 cp --no-progress s3://$INSTALLER_S3_BUCKET/Installers/$WEBVIEW2_INSTALLER $DOWNLOADS_PATH\$WEBVIEW2_INSTALLER
 if (-not (Test-Path "$DOWNLOADS_PATH\$WEBVIEW2_INSTALLER")) { throw "WebView2 Runtime download failed" }
+
+if ($INSTALL_UNIVERSE) {
+    aws s3 cp --no-progress s3://$INSTALLER_S3_BUCKET/Installers/$UNIVERSE_INSTALLER $DOWNLOADS_PATH\$UNIVERSE_INSTALLER
+    if (-not (Test-Path "$DOWNLOADS_PATH\$UNIVERSE_INSTALLER")) { throw "Universe download failed" }
+}
 
 if ($INSTALL_BORIS_SAPPHIRE) {
     aws s3 cp --no-progress s3://$INSTALLER_S3_BUCKET/Installers/$BORIS_SAPPHIRE_INSTALLER $DOWNLOADS_PATH\$BORIS_SAPPHIRE_INSTALLER
@@ -110,13 +115,15 @@ if ($is_cmf) {
     [System.Environment]::SetEnvironmentVariable("redshift_LICENSE", "7055@$vpc_endpoint", [System.EnvironmentVariableTarget]::Machine)
 }
 
-# Universe Installation
-$universeStartTime = Get-Date
-Write-Host "Starting Universe installation..."
-Start-Process -FilePath "$DOWNLOADS_PATH\$UNIVERSE_INSTALLER" -ArgumentList "--mode", "unattended", "--unattendedmodeui", "none" -Wait
-$universeEndTime = Get-Date
-$universeDuration = $universeEndTime - $universeStartTime
-Write-Host "Universe installation completed in: $($universeDuration.ToString('hh\:mm\:ss'))"
+if ($INSTALL_UNIVERSE) {
+    # Universe Installation
+    $universeStartTime = Get-Date
+    Write-Host "Starting Universe installation..."
+    Start-Process -FilePath "$DOWNLOADS_PATH\$UNIVERSE_INSTALLER" -ArgumentList "--mode", "unattended", "--unattendedmodeui", "none" -Wait
+    $universeEndTime = Get-Date
+    $universeDuration = $universeEndTime - $universeStartTime
+    Write-Host "Universe installation completed in: $($universeDuration.ToString('hh\:mm\:ss'))"
+}
 
 if ($INSTALL_BORIS_SAPPHIRE) {
     # Boris FX Sapphire Installation
@@ -159,7 +166,9 @@ Write-Host "WebView2 Runtime: $($webview2Duration.ToString('hh\:mm\:ss'))"
 Write-Host "After Effects: $($aeDuration.ToString('hh\:mm\:ss'))"
 Write-Host "Maxon App: $($maxonDuration.ToString('hh\:mm\:ss'))"
 Write-Host "Red Giant: $($rgDuration.ToString('hh\:mm\:ss'))"
-Write-Host "Universe: $($universeDuration.ToString('hh\:mm\:ss'))"
+if ($INSTALL_UNIVERSE) {
+    Write-Host "Universe: $($universeDuration.ToString('hh\:mm\:ss'))"
+}
 if ($INSTALL_BORIS_SAPPHIRE) {
     Write-Host "Boris Sapphire: $($bsDuration.ToString('hh\:mm\:ss'))"
 }


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
As of [Red Giant 2026.2.0](https://support.maxon.net/hc/en-us/articles/24114684657692-Red-Giant-2026-2-0-December-3-2025), Universe is now included in Red Giant and doesn't have to be installed separately. Updated the AE Red Giant installation script to reflect that.

### What is the impact of this change?
Reduces AE + Red Giant host config installation time!

### How was this change tested?
Ran as a host config on my Deadline Cloud farm

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*