### PR TITLE
feat: add ReelSmart Motion Blur sample for After Effects

### DIFF
--- a/host_configuration_scripts/aftereffects/aftereffects_redgiant/README.md
+++ b/host_configuration_scripts/aftereffects/aftereffects_redgiant/README.md
@@ -9,8 +9,8 @@ This guide covers setting up the required software installers for the After Effe
 - AWS CLI configured with appropriate permissions
 - S3 bucket for storing installers (can use your job-attachments bucket)
 - Enterprise Adobe account with Admin access to Admin Console and Adobe After Effects license
-- Red Giant and Universe licenses
 - AWS Deadline Cloud farm, Windows GPU SMF (service-managed fleet) with latest driver, queue, and queue-fleet association set up. No need to add conda queue environment to your queue.
+- Licenses for any plugins being used
 
 ## Required Installers
 
@@ -29,12 +29,18 @@ Download from Adobe Admin Console (make sure you're using an enterprise account 
 
 See the [Adobe pre-generated packages documentation](https://helpx.adobe.com/enterprise/using/pre-generated-packages.html) for more information.
 
-### 2. Red Giant
+Make sure to update the `$AE_INSTALLER` variable with the name of the package zip file  in the script configuration section.
+
+### 2. Red Giant (Optional)
 
 Download from Red Giant:
 1. Log into your Maxon account
 2. Navigate to the [Maxon Downloads](https://www.maxon.net/en/downloads) section
 3. Download `RedGiant-2025.6.0-Win.exe` (or latest version) for Windows from the section Red Giant
+
+To enable Red Giant installation, set `$INSTALL_RED_GIANT = $true` in the script configuration section.
+
+Make sure to update the `$RED_GIANT_INSTALLER` variable with the name of the Red Giant installer.
 
 ### 3. Universe (Optional)
 
@@ -45,7 +51,11 @@ Download from Red Giant:
 2. Navigate to the [Maxon Downloads](https://www.maxon.net/en/downloads) section
 3. Download `Universe-2025.3.3_Win.exe` (or latest version) for Windows under the section Red Giant
 
-### 4. Maxon App
+To enable standalone Universe installation, set `$INSTALL_UNIVERSE = $true` in the script configuration section.
+
+Make sure to update the `$UNIVERSE_INSTALLER` variable with the name of the Universe installer.
+
+### 4. Maxon App (required for Red Giant)
 
 This is needed to support Red Giant + Universe licensing since it serves as a proxy between your licensing server and the plugins being run.
 Download from Maxon:
@@ -53,11 +63,15 @@ Download from Maxon:
 2. Navigate to the [Maxon App](https://www.maxon.net/en/downloads) section after you scroll down a bit
 2. Download `Maxon_App_2025.4.2_Win.exe` (or latest version) for Windows under the section Maxon App
 
-### 5. Microsoft Edge WebView2 Runtime
+Make sure to update the `$MAXON_APP_INSTALLER` variable with the name of the Maxon App installer.
+
+### 5. Microsoft Edge WebView2 Runtime (required for Red Giant)
 
 This is needed for the Maxon App installation to go smoothly. Download from Microsoft:
 1. Visit the [Microsoft Edge WebView2 download page](https://developer.microsoft.com/en-us/microsoft-edge/webview2?form=MA13LH#download)
 2. Download `MicrosoftEdgeWebView2RuntimeInstallerX64.exe` (x64 version) under the "Evergreen Standalone Installer" section
+
+Make sure to update the `$WEBVIEW2_INSTALLER` variable with the name of the WebView2 installer.
 
 ### 6. Boris FX Sapphire (optional)
 
@@ -70,6 +84,8 @@ For Boris FX Sapphire, you will need to bring your own licenses. We recommend se
 
 To enable Boris FX Sapphire installation, set `$INSTALL_BORIS_SAPPHIRE = $true` in the script configuration section.
 
+Make sure to update the `$BORIS_SAPPHIRE_INSTALLER` variable with the name of the Boris FX Sapphire installer.
+
 ### 7. Frischluft Lenscare (optional)
 
 Download from Frischluft:
@@ -80,6 +96,23 @@ Download from Frischluft:
 For Frischluft Lenscare, you will need to bring your own licenses. Lenscare is licensed by copying the `Lenscare_ae.key` license file to the same folder as the plugin. In this sample host config script, you will upload your license file to S3 and the host config script will download the license file from S3 to `C:\Program Files\Adobe\Common\Plug-ins\7.0\MediaCore\Lenscare_ae.key` on the worker. For more information about licensing Lenscare, review the "Install Key File" section of the `readme.txt` inside the downloaded Lenscare zip file.
 
 To enable Lenscare installation, set `$INSTALL_LENSCARE = $true` in the script configuration section.
+
+Make sure to update the `$LENSCARE_INSTALLER` variable with the name of the Lenscare installer.
+
+### 8. RE:Vision Effects ReelSmart Motion Blur
+
+Download from RE:Vision Effects:
+1. Go to https://revisionfx.com/products/rsmb/after-effects/
+2. Scroll down to the Download section on the page and download the Windows installer (`RSMB6AEInstaller.zip`)
+3. Go to https://revisionfx.com/faq/setting-up-your-site-for-floating-licenses/
+4. Download the floating license software for Windows (`FloatingLicensing.zip`)
+
+For ReelSmart Motion Blur, you will need to bring your own licenses. We recommend setting the `RVL_SERVER` environment variable to license the software. This can be set either inside the host config script by configuring the `$RVL_SERVER` variable (e.g., `$RVL_SERVER = "<license-server-hostname>"`), or in a queue environment. See the ["Setting up floating license clients" page from RE:Vision](https://revisionfx.com/faq/setting-floating-license-clients/#Windows) for more details on the format of the environment variable.
+
+To enable ReelSmart Motion Blur installation, set `$INSTALL_RSMB = $true` in the script configuration section.
+
+Make sure to update the `$RSMB_INSTALLER` variable with the name of the ReelSmart Motion Blur installer.
+
 
 ## S3 Bucket Setup
 
@@ -100,6 +133,8 @@ To upload the installers to S3, you can upload the `.zip` and `.exe` files to yo
 export INSTALLER_S3_BUCKET=your-installer-bucket
 
 aws s3 cp "After Effects_en_US_WIN_64.zip" s3://$INSTALLER_S3_BUCKET/Installers/
+
+# Optional, use if installing Red Giant
 aws s3 cp "RedGiant-2026.3.0-Win.exe" s3://$INSTALLER_S3_BUCKET/Installers/
 aws s3 cp "Maxon_App_2026.0.1_Win.exe" s3://$INSTALLER_S3_BUCKET/Installers/
 aws s3 cp "MicrosoftEdgeWebView2RuntimeInstallerX64.exe" s3://$INSTALLER_S3_BUCKET/Installers/
@@ -113,6 +148,10 @@ aws s3 cp "sapphire-ae-install-2026.exe" s3://$INSTALLER_S3_BUCKET/Installers/
 # Optional, use if installing Frischluft Lenscare
 aws s3 cp "lenscare_ae_v1.5.5(win).zip" s3://$INSTALLER_S3_BUCKET/Installers/
 aws s3 cp "Lenscare_ae.key" s3://$INSTALLER_S3_BUCKET/Installers/
+
+# Optional, use if installing ReelSmart Motion Blur
+aws s3 cp "RSMB6AEInstaller.zip" s3://$INSTALLER_S3_BUCKET/Installers/
+aws s3 cp "FloatingLicensing.zip" s3://$INSTALLER_S3_BUCKET/Installers/
 ```
 
 ### 3. Update IAM Role Permissions

--- a/host_configuration_scripts/aftereffects/aftereffects_redgiant/install-software.ps1
+++ b/host_configuration_scripts/aftereffects/aftereffects_redgiant/install-software.ps1
@@ -1,31 +1,60 @@
 # Sequential Software Installation Script
 # Downloads installers from S3 and installs Adobe After Effects, Red Giant, Universe (optional), Boris Sapphire (optional), and Lenscare (optional) in order
+Set-PSDebug -Trace 2
 
 # Stop after first failing command
 $ErrorActionPreference = "Stop"
 
-# Script Configuration Variables - Update these for your environment
-$is_cmf = $false  # Set to $true for Customer Managed Fleet (CMF), $false for Service Managed Fleet (SMF)
-$vpc_endpoint = "<vpc_endpoint>"  # Replace with actual VPC endpoint for CMF Red Giant license server
-$AE_VERSION = "2025"  # After Effects version year
+# SCRIPT CONFIGURATION VARIABLES - Update these for your environment
+# ------------------------------------------------------------------
+
 $INSTALLER_S3_BUCKET = "<your-installer-bucket>"  # Your S3 bucket name
+
+$AE_VERSION = "2025"  # After Effects version year
 $AE_INSTALLER = "After Effects_en_US_WIN_64.zip"
-$REDGIANT_INSTALLER = "RedGiant-2026.3.0-Win.exe"
-$MAXON_APP_INSTALLER = "Maxon_App_2026.1.0_Win.exe"
-$WEBVIEW2_INSTALLER = "MicrosoftEdgeWebView2RuntimeInstallerX64.exe"
 
 # Optional Plugin Configuration
-$INSTALL_UNIVERSE = $false  # Set to $true to install Universe (included by default in Red Giant 2026)
-$UNIVERSE_INSTALLER = "Universe-2026.0.1_Win.exe"
+$INSTALL_RED_GIANT = $true  # Set to $true to install Red Giant, Maxon App, and WebView2 Runtime
+if ($INSTALL_RED_GIANT) {
+    $WEBVIEW2_INSTALLER = "MicrosoftEdgeWebView2RuntimeInstallerX64.exe"
+    $MAXON_APP_INSTALLER = "Maxon_App_2026.1.0_Win.exe"
+    $RED_GIANT_INSTALLER = "RedGiant-2026.3.0-Win.exe"
+
+    $is_cmf = $false  # Set to $true for Customer Managed Fleet (CMF), $false for Service Managed Fleet (SMF)
+    if ($is_cmf) {
+        $vpc_endpoint = "<vpc_endpoint>"  # Replace with actual VPC endpoint for CMF Red Giant license server
+    }
+}
+
+# Universe is included by default in Red Giant 2026.2.0, so no need to install separately for new versions of Red Giant
+$INSTALL_UNIVERSE = $false  # Set to $true to install standalone Universe
+if ($INSTALL_UNIVERSE) {
+    $UNIVERSE_INSTALLER = "Universe-2026.0.1_Win.exe"
+}
 
 $INSTALL_BORIS_SAPPHIRE = $false  # Set to $true to install Boris FX Sapphire
-$BORIS_SAPPHIRE_INSTALLER = "sapphire-ae-install-2026.exe"
-# custom licensing is required for Boris FX, as it is not currently supported by Deadline Cloud Usage Based Licensing
-$BORIS_LICENSE_SERVER = "5053@<license-server-hostname>"
+if ($INSTALL_BORIS_SAPPHIRE) {
+    $BORIS_SAPPHIRE_INSTALLER = "sapphire-ae-install-2026.exe"
+    # custom licensing is required for Boris FX, as it is not currently supported by Deadline Cloud Usage Based Licensing
+    $BORIS_LICENSE_SERVER = "5052@<license-server-hostname>"
+}
 
 $INSTALL_LENSCARE = $false  # Set to $true to install Frischluft Lenscare
-$LENSCARE_INSTALLER = "lenscare_ae_v1.5.5(win).zip"
-$LENSCARE_LICENSE = "Lenscare_ae.key"
+if ($INSTALL_LENSCARE) {
+    $LENSCARE_INSTALLER = "lenscare_ae_v1.5.5(win).zip"
+    $LENSCARE_LICENSE = "Lenscare_ae.key"
+}
+
+$INSTALL_RSMB = $false  # Set to $true to install RE:Vision Effects ReelSmart Motion Blur
+if ($INSTALL_RSMB) {
+    $RSMB_INSTALLER = "RSMB6AEInstaller.zip"
+    $RSMB_LICENSING = "FloatingLicensing.zip"
+    # custom licensing is required for RSMB, as it is not currently supported by Deadline Cloud Usage Based Licensing
+    $RSMB_LICENSE_SERVER = "<license-server-hostname>"
+}
+
+# END SCRIPT CONFIGURATION SECTION
+# ------------------------------------------------------------------
 
 $AE_PLUGIN_LOCATION = "C:\Program Files\Adobe\Common\Plug-ins\7.0\MediaCore"
 $DOWNLOADS_PATH = "C:\Temp"
@@ -46,12 +75,14 @@ $downloadStartTime = Get-Date
 Write-Host "Downloading installers from S3..."
 aws s3 cp --no-progress "s3://$INSTALLER_S3_BUCKET/Installers/$AE_INSTALLER" "$DOWNLOADS_PATH\$AE_INSTALLER"
 if (-not (Test-Path "$DOWNLOADS_PATH\$AE_INSTALLER")) { throw "After Effects download failed" }
-aws s3 cp --no-progress s3://$INSTALLER_S3_BUCKET/Installers/$REDGIANT_INSTALLER $DOWNLOADS_PATH\$REDGIANT_INSTALLER
-if (-not (Test-Path "$DOWNLOADS_PATH\$REDGIANT_INSTALLER")) { throw "Red Giant download failed" }
-aws s3 cp --no-progress s3://$INSTALLER_S3_BUCKET/Installers/$MAXON_APP_INSTALLER $DOWNLOADS_PATH\$MAXON_APP_INSTALLER
-if (-not (Test-Path "$DOWNLOADS_PATH\$MAXON_APP_INSTALLER")) { throw "Maxon App download failed" }
-aws s3 cp --no-progress s3://$INSTALLER_S3_BUCKET/Installers/$WEBVIEW2_INSTALLER $DOWNLOADS_PATH\$WEBVIEW2_INSTALLER
-if (-not (Test-Path "$DOWNLOADS_PATH\$WEBVIEW2_INSTALLER")) { throw "WebView2 Runtime download failed" }
+if ($INSTALL_RED_GIANT) {
+    aws s3 cp --no-progress s3://$INSTALLER_S3_BUCKET/Installers/$RED_GIANT_INSTALLER $DOWNLOADS_PATH\$RED_GIANT_INSTALLER
+    if (-not (Test-Path "$DOWNLOADS_PATH\$RED_GIANT_INSTALLER")) { throw "Red Giant download failed" }
+    aws s3 cp --no-progress s3://$INSTALLER_S3_BUCKET/Installers/$MAXON_APP_INSTALLER $DOWNLOADS_PATH\$MAXON_APP_INSTALLER
+    if (-not (Test-Path "$DOWNLOADS_PATH\$MAXON_APP_INSTALLER")) { throw "Maxon App download failed" }
+    aws s3 cp --no-progress s3://$INSTALLER_S3_BUCKET/Installers/$WEBVIEW2_INSTALLER $DOWNLOADS_PATH\$WEBVIEW2_INSTALLER
+    if (-not (Test-Path "$DOWNLOADS_PATH\$WEBVIEW2_INSTALLER")) { throw "WebView2 Runtime download failed" }
+}
 
 if ($INSTALL_UNIVERSE) {
     aws s3 cp --no-progress s3://$INSTALLER_S3_BUCKET/Installers/$UNIVERSE_INSTALLER $DOWNLOADS_PATH\$UNIVERSE_INSTALLER
@@ -70,17 +101,16 @@ if ($INSTALL_LENSCARE) {
     if (-not (Test-Path "$DOWNLOADS_PATH\$LENSCARE_LICENSE")) { throw "Lenscare license download failed" }
 }
 
+if ($INSTALL_RSMB) {
+    aws s3 cp --no-progress s3://$INSTALLER_S3_BUCKET/Installers/$RSMB_INSTALLER $DOWNLOADS_PATH\$RSMB_INSTALLER
+    if (-not (Test-Path "$DOWNLOADS_PATH\$RSMB_INSTALLER")) { throw "RSMB download failed" }
+    aws s3 cp --no-progress s3://$INSTALLER_S3_BUCKET/Installers/$RSMB_LICENSING $DOWNLOADS_PATH\$RSMB_LICENSING
+    if (-not (Test-Path "$DOWNLOADS_PATH\$RSMB_LICENSING")) { throw "RSMB floating licensing download failed" }
+}
+
 $downloadEndTime = Get-Date
 $downloadDuration = $downloadEndTime - $downloadStartTime
 Write-Host "Downloads completed in: $($downloadDuration.ToString('hh\:mm\:ss'))"
-
-# Microsoft Edge WebView2 Runtime Installation
-$webview2StartTime = Get-Date
-Write-Host "Starting Microsoft Edge WebView2 Runtime installation..."
-Start-Process -FilePath "$DOWNLOADS_PATH\$WEBVIEW2_INSTALLER" -ArgumentList "/silent", "/install" -Wait
-$webview2EndTime = Get-Date
-$webview2Duration = $webview2EndTime - $webview2StartTime
-Write-Host "Microsoft Edge WebView2 Runtime installation completed in: $($webview2Duration.ToString('hh\:mm\:ss'))"
 
 # After Effects Installation
 $aeStartTime = Get-Date
@@ -93,26 +123,36 @@ $aeEndTime = Get-Date
 $aeDuration = $aeEndTime - $aeStartTime
 Write-Host "After Effects installation completed in: $($aeDuration.ToString('hh\:mm\:ss'))"
 
-# Maxon App Installation
-$maxonStartTime = Get-Date
-Write-Host "Starting Maxon App installation..."
-Start-Process -FilePath "$DOWNLOADS_PATH\$MAXON_APP_INSTALLER" -ArgumentList "--mode", "unattended", "--unattendedmodeui", "none" -Wait
-$maxonEndTime = Get-Date
-$maxonDuration = $maxonEndTime - $maxonStartTime
-Write-Host "Maxon App installation completed in: $($maxonDuration.ToString('hh\:mm\:ss'))"
+if ($INSTALL_RED_GIANT) {
+    # Microsoft Edge WebView2 Runtime Installation
+    $webview2StartTime = Get-Date
+    Write-Host "Starting Microsoft Edge WebView2 Runtime installation..."
+    Start-Process -FilePath "$DOWNLOADS_PATH\$WEBVIEW2_INSTALLER" -ArgumentList "/silent", "/install" -Wait
+    $webview2EndTime = Get-Date
+    $webview2Duration = $webview2EndTime - $webview2StartTime
+    Write-Host "Microsoft Edge WebView2 Runtime installation completed in: $($webview2Duration.ToString('hh\:mm\:ss'))"
 
-# Red Giant Installation
-$rgStartTime = Get-Date
-Write-Host "Starting Red Giant installation..."
-Start-Process -FilePath "$DOWNLOADS_PATH\$REDGIANT_INSTALLER" -ArgumentList "--mode", "unattended", "--unattendedmodeui", "none" -Wait
-$rgEndTime = Get-Date
-$rgDuration = $rgEndTime - $rgStartTime
-Write-Host "Red Giant installation completed in: $($rgDuration.ToString('hh\:mm\:ss'))"
+    # Maxon App Installation
+    $maxonStartTime = Get-Date
+    Write-Host "Starting Maxon App installation..."
+    Start-Process -FilePath "$DOWNLOADS_PATH\$MAXON_APP_INSTALLER" -ArgumentList "--mode", "unattended", "--unattendedmodeui", "none" -Wait
+    $maxonEndTime = Get-Date
+    $maxonDuration = $maxonEndTime - $maxonStartTime
+    Write-Host "Maxon App installation completed in: $($maxonDuration.ToString('hh\:mm\:ss'))"
 
-# Set Red Giant license servers for Customer Managed Fleets (CMF)
-if ($is_cmf) {
-    Write-Host "Setting Red Giant license server for CMF..."
-    [System.Environment]::SetEnvironmentVariable("redshift_LICENSE", "7055@$vpc_endpoint", [System.EnvironmentVariableTarget]::Machine)
+    # Red Giant Installation
+    $rgStartTime = Get-Date
+    Write-Host "Starting Red Giant installation..."
+    Start-Process -FilePath "$DOWNLOADS_PATH\$RED_GIANT_INSTALLER" -ArgumentList "--mode", "unattended", "--unattendedmodeui", "none" -Wait
+    $rgEndTime = Get-Date
+    $rgDuration = $rgEndTime - $rgStartTime
+    Write-Host "Red Giant installation completed in: $($rgDuration.ToString('hh\:mm\:ss'))"
+
+    # Set Red Giant license servers for Customer Managed Fleets (CMF)
+    if ($is_cmf) {
+        Write-Host "Setting Red Giant license server for CMF..."
+        [System.Environment]::SetEnvironmentVariable("redshift_LICENSE", "7055@$vpc_endpoint", [System.EnvironmentVariableTarget]::Machine)
+    }
 }
 
 if ($INSTALL_UNIVERSE) {
@@ -157,23 +197,56 @@ if ($INSTALL_LENSCARE) {
     Write-Host "Lenscare installation completed in: $($lenscareDuration.ToString('hh\:mm\:ss'))"
 }
 
+if ($INSTALL_RSMB) {
+    # RE:Vision Effects ReelSmart Motion Blur Installation
+    $rsmbStartTime = Get-Date
+    Write-Host "Extracting RSMB zip file..."
+    if (-not (Test-Path "$DOWNLOADS_PATH\$RSMB_INSTALLER")) { throw "RSMB zip file not found" }
+    $rsmbTempExtract = "$DOWNLOADS_PATH\rsmb_temp"
+    Expand-Archive -Path "$DOWNLOADS_PATH\$RSMB_INSTALLER" -DestinationPath $rsmbTempExtract -Force
+    Write-Host "Starting RSMB installation..."
+    $rsmbExe = Get-ChildItem -Path $rsmbTempExtract -Filter "*.exe" -Recurse | Select-Object -First 1
+    if (-not $rsmbExe) { throw "RSMB installer executable not found in zip" }
+    Start-Process -FilePath $rsmbExe.FullName -ArgumentList "--mode", "unattended", "--unattendedmodeui", "none" -Wait
+
+    Write-Host "Extracting RSMB floating licensing..."
+    $rsmbLicenseTempExtract = "$DOWNLOADS_PATH\rsmb_licensing_temp"
+    Expand-Archive -Path "$DOWNLOADS_PATH\$RSMB_LICENSING" -DestinationPath $rsmbLicenseTempExtract -Force
+    Write-Host "Installing RSMB floating license client..."
+    $rsmbLicenseExe = Get-ChildItem -Path $rsmbLicenseTempExtract -Filter "*.exe" -Recurse | Select-Object -First 1
+    if (-not $rsmbLicenseExe) { throw "RSMB floating license installer not found in zip" }
+    Start-Process -FilePath $rsmbLicenseExe.FullName -ArgumentList "--mode", "unattended", "--unattendedmodeui", "none", "--acceptEULA", "1", "--clientOrServer", "client" -Wait
+
+    Write-Host "Setting RSMB license server..."
+    [System.Environment]::SetEnvironmentVariable("RVL_SERVER", $RSMB_LICENSE_SERVER, [System.EnvironmentVariableTarget]::Machine)
+
+    $rsmbEndTime = Get-Date
+    $rsmbDuration = $rsmbEndTime - $rsmbStartTime
+    Write-Host "RSMB installation completed in: $($rsmbDuration.ToString('hh\:mm\:ss'))"
+}
+
 # Calculate and display total time
 $scriptEndTime = Get-Date
 $totalDuration = $scriptEndTime - $scriptStartTime
 Write-Host "=== Installation Summary ==="
 Write-Host "Downloads: $($downloadDuration.ToString('hh\:mm\:ss'))"
-Write-Host "WebView2 Runtime: $($webview2Duration.ToString('hh\:mm\:ss'))"
-Write-Host "After Effects: $($aeDuration.ToString('hh\:mm\:ss'))"
-Write-Host "Maxon App: $($maxonDuration.ToString('hh\:mm\:ss'))"
-Write-Host "Red Giant: $($rgDuration.ToString('hh\:mm\:ss'))"
+Write-Host "Adobe After Effects: $($aeDuration.ToString('hh\:mm\:ss'))"
+if ($INSTALL_RED_GIANT) {
+    Write-Host "Microsoft WebView2 Runtime: $($webview2Duration.ToString('hh\:mm\:ss'))"
+    Write-Host "Maxon App: $($maxonDuration.ToString('hh\:mm\:ss'))"
+    Write-Host "Maxon Red Giant: $($rgDuration.ToString('hh\:mm\:ss'))"
+}
 if ($INSTALL_UNIVERSE) {
     Write-Host "Universe: $($universeDuration.ToString('hh\:mm\:ss'))"
 }
 if ($INSTALL_BORIS_SAPPHIRE) {
-    Write-Host "Boris Sapphire: $($bsDuration.ToString('hh\:mm\:ss'))"
+    Write-Host "Boris FX Sapphire: $($bsDuration.ToString('hh\:mm\:ss'))"
 }
 if ($INSTALL_LENSCARE) {
-    Write-Host "Lenscare: $($lenscareDuration.ToString('hh\:mm\:ss'))"
+    Write-Host "Frischluft Lenscare: $($lenscareDuration.ToString('hh\:mm\:ss'))"
+}
+if ($INSTALL_RSMB) {
+    Write-Host "Re:Vision Effects ReelSmart Motion Blur: $($rsmbDuration.ToString('hh\:mm\:ss'))"
 }
 Write-Host "Total Time: $($totalDuration.ToString('hh\:mm\:ss'))"
 Write-Host "All installations completed!"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Added sample for RE:Vision Effects ReelSmart Motion Blur installation via host config. Also cleaned up other portions of the host config and README instructions to clarify how to use the sample.

### How was this change tested?
Added this to the host config script on a Windows service-managed fleet on Deadline Cloud. The fleet spun up and ran Red Giant, Boris FX Sapphire, Frischluft Lenscare, and RE:Vision Effects ReelSmart Motion Blur successfully.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*