### PR TITLE
feat: Add Arnold standalone render job bundle

### DIFF
--- a/job_bundles/README.md
+++ b/job_bundles/README.md
@@ -54,6 +54,7 @@ The step definition includes a parameter space to define a task for each frame f
 and a short script that substitutes job parameters and the Frame task parameter into a script command for each task.
 
 * [3dsmax_vray_denoiser_example](3dsmax_vray_denoiser_example) - 3ds Max V-Ray rendering with smart frame chunking and VRIMG to EXR conversion
+* [arnold_standalone_render](arnold_standalone_render) - Arnold standalone rendering of .ass files using `kick`
 * [blender_render](blender_render/template.yaml)
 * [keyshot_standalone](keyshot_standalone)
 * [afterfx_render_one_task](afterfx_render_one_task)
@@ -68,6 +69,13 @@ If you've created a similar job for your favorite DCC, see [CONTRIBUTING.md](../
 
 The [gsplat_pipeline](gsplat_pipeline/README.md) job bundle can take a video file as input and train a 3D Gaussian Splatting point cloud.
 This example shows Deadline Cloud running a 3D reconstruction workload that uses CUDA GPUs for acceleration.
+
+### Arnold standalone render
+
+The [arnold_standalone_render](arnold_standalone_render) job bundle renders Arnold `.ass` (Arnold Scene Source) files
+using the `kick` command-line renderer from MtoA. This is useful for batch rendering pre-exported Arnold scenes without
+requiring a full Maya session. It includes a sample Cornell box `.ass` file for testing. You can also download sample
+scenes from the [Autodesk Arnold learning scenes page](https://help.autodesk.com/view/MAYAUL/2024/ENU/?guid=arnold_for_maya_tutorials_am_Learning_Scenes_html).
 
 ### Turntable job with Maya/Arnold
 

--- a/job_bundles/arnold_standalone_render/README.md
+++ b/job_bundles/arnold_standalone_render/README.md
@@ -1,0 +1,58 @@
+# Arnold Standalone Render
+
+## Job summary
+
+This job bundle renders Arnold `.ass` (Arnold Scene Source) files using the Arnold
+`kick` command-line renderer that ships with MtoA (Arnold for Maya).
+
+The `kick` command is Arnold's standalone renderer. It reads `.ass` files and produces
+rendered images without requiring a full Maya session, making it ideal for batch rendering
+pre-exported scenes.
+
+## Prerequisites
+
+To run this job, you need:
+
+* A Deadline Cloud queue with a **conda queue environment** configured. The job's
+  `CondaPackages` parameter defaults to `maya-mtoa`, which provides the `kick` binary.
+  On service-managed fleets, the `deadline-cloud` channel provides this package.
+* A Linux fleet associated with the queue (the job specifies `attr.worker.os.family: linux`).
+
+## Getting sample .ass files
+
+You can download sample Arnold scene files from the Autodesk Arnold learning scenes page:
+
+**[Arnold Learning Scenes](https://help.autodesk.com/view/MAYAUL/2024/ENU/?guid=arnold_for_maya_tutorials_am_Learning_Scenes_html)**
+
+The page provides scenes like `cornell.ass` (a Cornell box) that work well for testing.
+
+You can also export `.ass` files from Maya using Arnold's scene export:
+`Arnold > Export Scene...` or via MEL: `arnoldExportAss -f "scene.ass"`.
+
+## Submitting the job
+
+### GUI submission
+
+```bash
+deadline bundle gui-submit arnold_standalone_render/
+```
+
+### CLI submission
+
+```bash
+deadline bundle submit arnold_standalone_render/ \
+    -p ArnoldFile=/path/to/scene.ass \
+    -p OutputDir=/path/to/output
+```
+
+## How it works
+
+The job has a single step that:
+
+1. Locates the `kick` binary using the `$MTOA` environment variable set by the
+   `maya-mtoa` conda package.
+2. Prints the Arnold version for reference.
+3. Runs `kick -i <input> -o <output>` to render the scene.
+
+The output format is inferred from the `OutputFileName` extension (default: `.exr`).
+Arnold supports EXR, PNG, JPEG, TIFF, and other formats.

--- a/job_bundles/arnold_standalone_render/README.md
+++ b/job_bundles/arnold_standalone_render/README.md
@@ -16,6 +16,9 @@ To run this job, you need:
 * A Deadline Cloud queue with a **conda queue environment** configured. The job's
   `CondaPackages` parameter defaults to `maya-mtoa`, which provides the `kick` binary.
   On service-managed fleets, the `deadline-cloud` channel provides this package.
+  If you need a specific MtoA version, see the
+  [maya-mtoa conda recipe](https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/conda_recipes/maya-mtoa-2026)
+  for building a custom package.
 * A Linux fleet associated with the queue (the job specifies `attr.worker.os.family: linux`).
 
 ## Getting sample .ass files

--- a/job_bundles/arnold_standalone_render/cornell.ass
+++ b/job_bundles/arnold_standalone_render/cornell.ass
@@ -1,0 +1,143 @@
+### Arnold Scene Source (.ass) - Minimal Cornell Box
+### This is a simplified test scene for Arnold's kick renderer
+
+options
+{
+ xres 320
+ yres 240
+ AA_samples 3
+ outputs "RGBA RGBA defaultFilter defaultDriver"
+ camera "camera1"
+}
+
+gaussian_filter
+{
+ name defaultFilter
+}
+
+driver_exr
+{
+ name defaultDriver
+ filename output.exr
+}
+
+persp_camera
+{
+ name camera1
+ position 0 1 3.5
+ look_at 0 1 0
+ fov 60
+}
+
+distant_light
+{
+ name light1
+ color 1 1 1
+ intensity 3
+ direction 0 -1 -1
+}
+
+skydome_light
+{
+ name skylight
+ intensity 0.3
+ color 0.8 0.9 1.0
+}
+
+polymesh
+{
+ name floor
+ nsides 1 1 UINT 4
+ vidxs 4 1 UINT 0 1 2 3
+ vlist 4 1 VECTOR
+  -2 0 -2
+  2 0 -2
+  2 0 2
+  -2 0 2
+ shader "grey_shader"
+}
+
+polymesh
+{
+ name back_wall
+ nsides 1 1 UINT 4
+ vidxs 4 1 UINT 0 1 2 3
+ vlist 4 1 VECTOR
+  -2 0 -2
+  2 0 -2
+  2 2 -2
+  -2 2 -2
+ shader "grey_shader"
+}
+
+polymesh
+{
+ name left_wall
+ nsides 1 1 UINT 4
+ vidxs 4 1 UINT 0 1 2 3
+ vlist 4 1 VECTOR
+  -2 0 -2
+  -2 0 2
+  -2 2 2
+  -2 2 -2
+ shader "red_shader"
+}
+
+polymesh
+{
+ name right_wall
+ nsides 1 1 UINT 4
+ vidxs 4 1 UINT 0 1 2 3
+ vlist 4 1 VECTOR
+  2 0 -2
+  2 0 2
+  2 2 2
+  2 2 -2
+ shader "green_shader"
+}
+
+polymesh
+{
+ name box1
+ nsides 6 1 UINT 4 4 4 4 4 4
+ vidxs 24 1 UINT
+  0 1 2 3
+  4 5 6 7
+  0 1 5 4
+  2 3 7 6
+  0 3 7 4
+  1 2 6 5
+ vlist 8 1 VECTOR
+  -0.5 0 -0.5
+  0.5 0 -0.5
+  0.5 0 0.5
+  -0.5 0 0.5
+  -0.5 1 -0.5
+  0.5 1 -0.5
+  0.5 1 0.5
+  -0.5 1 0.5
+ matrix
+  0.7 0 0.3 0
+  0 1 0 0
+  -0.3 0 0.7 0
+  -0.5 0 -0.3 1
+ shader "grey_shader"
+}
+
+standard_surface
+{
+ name grey_shader
+ base_color 0.7 0.7 0.7
+}
+
+standard_surface
+{
+ name red_shader
+ base_color 0.8 0.1 0.1
+}
+
+standard_surface
+{
+ name green_shader
+ base_color 0.1 0.8 0.1
+}

--- a/job_bundles/arnold_standalone_render/template.yaml
+++ b/job_bundles/arnold_standalone_render/template.yaml
@@ -1,0 +1,121 @@
+specificationVersion: 'jobtemplate-2023-09'
+name: Arnold Standalone Render
+description: |
+  This job renders Arnold .ass (Arnold Scene Source) files using the Arnold `kick`
+  command-line renderer that ships with MtoA (Arnold for Maya).
+
+  To run it, you need the maya-mtoa conda package available through a conda queue
+  environment on your Deadline Cloud queue. On service-managed fleets, the
+  "deadline-cloud" channel provides this package.
+
+  You can download sample .ass files such as cornell.ass from the Autodesk Arnold
+  learning scenes page:
+  https://help.autodesk.com/view/MAYAUL/2024/ENU/?guid=arnold_for_maya_tutorials_am_Learning_Scenes_html
+
+parameterDefinitions:
+
+# Render Parameters
+- name: ArnoldFile
+  type: PATH
+  objectType: FILE
+  dataFlow: IN
+  userInterface:
+    control: CHOOSE_INPUT_FILE
+    label: Arnold Scene File
+    groupLabel: Render Parameters
+    fileFilters:
+    - label: Arnold Scene Files
+      patterns: ["*.ass", "*.ass.gz"]
+    - label: All Files
+      patterns: ["*"]
+  description: >
+    Choose the Arnold .ass scene file to render.
+
+    Use the 'Job Attachments' tab to add textures and other files that the scene references.
+  default: ./cornell.ass
+- name: OutputDir
+  type: PATH
+  objectType: DIRECTORY
+  dataFlow: OUT
+  userInterface:
+    control: CHOOSE_DIRECTORY
+    label: Output Directory
+    groupLabel: Render Parameters
+  description: Choose the render output directory.
+  default: ./output
+- name: OutputFileName
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Output File Name
+    groupLabel: Render Parameters
+  description: The output filename (with extension). The format is inferred from the extension.
+  default: output.exr
+- name: Message
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Message
+    groupLabel: Render Parameters
+  description: A message to display in the job log.
+  default: Welcome to Amazon Deadline Cloud!
+
+# Software Environment
+- name: CondaPackages
+  type: STRING
+  userInterface:
+    control: HIDDEN
+  description: >
+    Conda packages to install. Requires a conda queue environment to process the value.
+    The maya-mtoa package provides the Arnold `kick` renderer.
+  default: maya-mtoa
+- name: CondaChannels
+  type: STRING
+  userInterface:
+    control: HIDDEN
+  description: >
+    Space-separated list of Conda channels. Deadline Cloud SMF packages are installed
+    from the "deadline-cloud" channel.
+  default: deadline-cloud
+
+steps:
+- name: Arnold Kick Render
+  script:
+    actions:
+      onRun:
+        command: bash
+        args: ['{{Task.File.Run}}']
+    embeddedFiles:
+    - name: Run
+      type: TEXT
+      data: |
+        set -xeuo pipefail
+
+        echo "{{Param.Message}}"
+
+        mkdir -p '{{Param.OutputDir}}'
+
+        # Find kick from MTOA env var, or by searching the conda prefix
+        if [ -n "${MTOA:-}" ] && [ -f "${MTOA}/bin/kick" ]; then
+            kick="${MTOA}/bin/kick"
+        elif [ -n "${CONDA_PREFIX:-}" ]; then
+            kick=$(find "${CONDA_PREFIX}" -name kick -type f -path "*/bin/kick" | head -1)
+        fi
+
+        if [ -z "${kick:-}" ] || [ ! -f "${kick}" ]; then
+            echo "ERROR: Could not find Arnold kick binary"
+            echo "MTOA=${MTOA:-unset}"
+            echo "CONDA_PREFIX=${CONDA_PREFIX:-unset}"
+            exit 1
+        fi
+
+        echo "Using kick from: $kick"
+
+        "$kick" -i '{{Param.ArnoldFile}}' -o '{{Param.OutputDir}}/{{Param.OutputFileName}}'
+
+        echo "Render complete. Output: {{Param.OutputDir}}/{{Param.OutputFileName}}"
+  hostRequirements:
+    attributes:
+    - name: attr.worker.os.family
+      anyOf:
+      - linux


### PR DESCRIPTION
Add a new job bundle that renders Arnold .ass (Arnold Scene Source) files using the kick command-line renderer from MtoA (Arnold for Maya).

Includes:
- OpenJD job template with conda package support (maya-mtoa)
- Sample Cornell box .ass scene file for testing
- README with prerequisites, submission instructions, and links to Autodesk Arnold learning scenes for additional test files
- Updated job_bundles/README.md index with new entry


### How was this change tested?

Submitted and ran the bundle and verified the downloaded ouptut image and logs.

### Was this change documented?

Yup.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*