### PR TITLE
feat: Update Blender recipes to use env_vars.d

### DIFF
--- a/conda_recipes/blender-4.2/recipe/build.sh
+++ b/conda_recipes/blender-4.2/recipe/build.sh
@@ -14,25 +14,17 @@ for BINARY in blender blender-launcher blender-softwaregl blender-thumbnailer; d
     ln -r -s $PREFIX/opt/blender/$BINARY $PREFIX/bin/$BINARY
 done
 
-# See https://docs.conda.io/projects/conda/en/latest/dev-guide/deep-dives/activation.html
-# for details on activation.
-
-mkdir -p $PREFIX/etc/conda/activate.d
-cat <<EOF > $PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.sh
-export "BLENDER_LOCATION=\$CONDA_PREFIX/opt/blender"
-export "BLENDER_VERSION=$BLENDER_VERSION"
-export "BLENDER_LIBRARY_PATH=\$BLENDER_LOCATION/lib"
-export "BLENDER_SCRIPTS_PATH=\$BLENDER_LOCATION/\$BLENDER_VERSION/scripts"
-export "BLENDER_PYTHON_PATH=\$BLENDER_LOCATION/\$BLENDER_VERSION/python"
-export "BLENDER_DATAFILES_PATH=\$BLENDER_LOCATION/\$BLENDER_VERSION/datafiles"
-EOF
-
-mkdir -p $PREFIX/etc/conda/deactivate.d
-cat <<EOF > $PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.sh
-unset BLENDER_DATAFILES_PATH
-unset BLENDER_PYTHON_PATH
-unset BLENDER_SCRIPTS_PATH
-unset BLENDER_LIBRARY_PATH
-unset BLENDER_VERSION
-unset BLENDER_LOCATION
+# Set environment variables using the JSON env_vars.d mechanism.
+# See https://rattler-build.prefix.dev/latest/special_files/ for details.
+# This is more portable than activation scripts and works with pixi trampolines.
+mkdir -p $PREFIX/etc/conda/env_vars.d
+cat > $PREFIX/etc/conda/env_vars.d/$PKG_NAME-$PKG_VERSION.json << EOF
+{
+  "BLENDER_LOCATION": "$PREFIX/opt/blender",
+  "BLENDER_VERSION": "$BLENDER_VERSION",
+  "BLENDER_LIBRARY_PATH": "$PREFIX/opt/blender/lib",
+  "BLENDER_SCRIPTS_PATH": "$PREFIX/opt/blender/$BLENDER_VERSION/scripts",
+  "BLENDER_PYTHON_PATH": "$PREFIX/opt/blender/$BLENDER_VERSION/python",
+  "BLENDER_DATAFILES_PATH": "$PREFIX/opt/blender/$BLENDER_VERSION/datafiles"
+}
 EOF

--- a/conda_recipes/blender-4.2/recipe/build_win.sh
+++ b/conda_recipes/blender-4.2/recipe/build_win.sh
@@ -8,53 +8,44 @@ cp -r $SRC_DIR/blender $PREFIX/opt/
 # The version without the build number
 BLENDER_VERSION=${PKG_VERSION%.*}
 
-# See https://docs.conda.io/projects/conda/en/latest/dev-guide/deep-dives/activation.html
-# for details on activation. The Deadline Cloud sample queue environments use bash
-# to activate environments on Windows, so we recommend always producing both .bat and .sh files.
+# Set environment variables using the JSON env_vars.d mechanism.
+# See https://rattler-build.prefix.dev/latest/special_files/ for details.
+# This is more portable than activation scripts and works with pixi trampolines.
+mkdir -p $PREFIX/etc/conda/env_vars.d
+cat > $PREFIX/etc/conda/env_vars.d/$PKG_NAME-$PKG_VERSION.json << EOF
+{
+  "BLENDER_LOCATION": "$PREFIX/opt/blender",
+  "BLENDER_VERSION": "$BLENDER_VERSION",
+  "BLENDER_LIBRARY_PATH": "$PREFIX/opt/blender/lib",
+  "BLENDER_SCRIPTS_PATH": "$PREFIX/opt/blender/$BLENDER_VERSION/scripts",
+  "BLENDER_PYTHON_PATH": "$PREFIX/opt/blender/$BLENDER_VERSION/python",
+  "BLENDER_DATAFILES_PATH": "$PREFIX/opt/blender/$BLENDER_VERSION/datafiles"
+}
+EOF
+cat $PREFIX/etc/conda/env_vars.d/$PKG_NAME-$PKG_VERSION.json
 
+# Add blender to PATH via activation scripts.
+# The Deadline Cloud sample queue environments use bash to activate environments
+# on Windows, so we produce both .bat and .sh files.
 mkdir -p $PREFIX/etc/conda/activate.d
 mkdir -p $PREFIX/etc/conda/deactivate.d
 
 cat <<EOF > "$PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.bat"
-set "BLENDER_LOCATION=$PREFIX/opt/blender"
-set "BLENDER_VERSION=$BLENDER_VERSION"
-set "BLENDER_LIBRARY_PATH=%BLENDER_LOCATION%/lib"
-set "BLENDER_SCRIPTS_PATH=%BLENDER_LOCATION%/%BLENDER_VERSION%/scripts"
-set "BLENDER_PYTHON_PATH=%BLENDER_LOCATION%/%BLENDER_VERSION%/python"
-set "BLENDER_DATAFILES_PATH=%BLENDER_LOCATION%/%BLENDER_VERSION%/datafiles"
 set "PATH=$PREFIX/opt/blender;%PATH%"
 EOF
 cat "$PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.bat"
 
 cat <<EOF > $PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.sh
-export "BLENDER_LOCATION=\$CONDA_PREFIX/opt/blender"
-export "BLENDER_VERSION=$BLENDER_VERSION"
-export "BLENDER_LIBRARY_PATH=\$BLENDER_LOCATION/lib"
-export "BLENDER_SCRIPTS_PATH=\$BLENDER_LOCATION/\$BLENDER_VERSION/scripts"
-export "BLENDER_PYTHON_PATH=\$BLENDER_LOCATION/\$BLENDER_VERSION/python"
-export "BLENDER_DATAFILES_PATH=\$BLENDER_LOCATION/\$BLENDER_VERSION/datafiles"
 export PATH="\$(cygpath '$PREFIX/opt/blender'):\$PATH"
 EOF
 cat $PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.sh
 
 cat <<EOF > "$PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.bat"
 set "PATH=%PATH:$PREFIX/opt/blender;=%"
-set BLENDER_DATAFILES_PATH=
-set BLENDER_PYTHON_PATH=
-set BLENDER_SCRIPTS_PATH=
-set BLENDER_LIBRARY_PATH=
-set BLENDER_VERSION=
-set BLENDER_LOCATION=
 EOF
 cat "$PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.bat"
 
 cat <<EOF > $PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.sh
 export PATH="\${PATH/\$(cygpath '$PREFIX/opt/blender'):/}"
-unset BLENDER_DATAFILES_PATH
-unset BLENDER_PYTHON_PATH
-unset BLENDER_SCRIPTS_PATH
-unset BLENDER_LIBRARY_PATH
-unset BLENDER_VERSION
-unset BLENDER_LOCATION
 EOF
 cat $PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.sh

--- a/conda_recipes/blender-4.3/recipe/build.sh
+++ b/conda_recipes/blender-4.3/recipe/build.sh
@@ -14,25 +14,17 @@ for BINARY in blender blender-launcher blender-softwaregl blender-thumbnailer; d
     ln -r -s $PREFIX/opt/blender/$BINARY $PREFIX/bin/$BINARY
 done
 
-# See https://docs.conda.io/projects/conda/en/latest/dev-guide/deep-dives/activation.html
-# for details on activation.
-
-mkdir -p $PREFIX/etc/conda/activate.d
-cat <<EOF > $PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.sh
-export "BLENDER_LOCATION=\$CONDA_PREFIX/opt/blender"
-export "BLENDER_VERSION=$BLENDER_VERSION"
-export "BLENDER_LIBRARY_PATH=\$BLENDER_LOCATION/lib"
-export "BLENDER_SCRIPTS_PATH=\$BLENDER_LOCATION/\$BLENDER_VERSION/scripts"
-export "BLENDER_PYTHON_PATH=\$BLENDER_LOCATION/\$BLENDER_VERSION/python"
-export "BLENDER_DATAFILES_PATH=\$BLENDER_LOCATION/\$BLENDER_VERSION/datafiles"
-EOF
-
-mkdir -p $PREFIX/etc/conda/deactivate.d
-cat <<EOF > $PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.sh
-unset BLENDER_DATAFILES_PATH
-unset BLENDER_PYTHON_PATH
-unset BLENDER_SCRIPTS_PATH
-unset BLENDER_LIBRARY_PATH
-unset BLENDER_VERSION
-unset BLENDER_LOCATION
+# Set environment variables using the JSON env_vars.d mechanism.
+# See https://rattler-build.prefix.dev/latest/special_files/ for details.
+# This is more portable than activation scripts and works with pixi trampolines.
+mkdir -p $PREFIX/etc/conda/env_vars.d
+cat > $PREFIX/etc/conda/env_vars.d/$PKG_NAME-$PKG_VERSION.json << EOF
+{
+  "BLENDER_LOCATION": "$PREFIX/opt/blender",
+  "BLENDER_VERSION": "$BLENDER_VERSION",
+  "BLENDER_LIBRARY_PATH": "$PREFIX/opt/blender/lib",
+  "BLENDER_SCRIPTS_PATH": "$PREFIX/opt/blender/$BLENDER_VERSION/scripts",
+  "BLENDER_PYTHON_PATH": "$PREFIX/opt/blender/$BLENDER_VERSION/python",
+  "BLENDER_DATAFILES_PATH": "$PREFIX/opt/blender/$BLENDER_VERSION/datafiles"
+}
 EOF

--- a/conda_recipes/blender-4.3/recipe/build_win.sh
+++ b/conda_recipes/blender-4.3/recipe/build_win.sh
@@ -8,53 +8,44 @@ cp -r $SRC_DIR/blender $PREFIX/opt/
 # The version without the build number
 BLENDER_VERSION=${PKG_VERSION%.*}
 
-# See https://docs.conda.io/projects/conda/en/latest/dev-guide/deep-dives/activation.html
-# for details on activation. The Deadline Cloud sample queue environments use bash
-# to activate environments on Windows, so we recommend always producing both .bat and .sh files.
+# Set environment variables using the JSON env_vars.d mechanism.
+# See https://rattler-build.prefix.dev/latest/special_files/ for details.
+# This is more portable than activation scripts and works with pixi trampolines.
+mkdir -p $PREFIX/etc/conda/env_vars.d
+cat > $PREFIX/etc/conda/env_vars.d/$PKG_NAME-$PKG_VERSION.json << EOF
+{
+  "BLENDER_LOCATION": "$PREFIX/opt/blender",
+  "BLENDER_VERSION": "$BLENDER_VERSION",
+  "BLENDER_LIBRARY_PATH": "$PREFIX/opt/blender/lib",
+  "BLENDER_SCRIPTS_PATH": "$PREFIX/opt/blender/$BLENDER_VERSION/scripts",
+  "BLENDER_PYTHON_PATH": "$PREFIX/opt/blender/$BLENDER_VERSION/python",
+  "BLENDER_DATAFILES_PATH": "$PREFIX/opt/blender/$BLENDER_VERSION/datafiles"
+}
+EOF
+cat $PREFIX/etc/conda/env_vars.d/$PKG_NAME-$PKG_VERSION.json
 
+# Add blender to PATH via activation scripts.
+# The Deadline Cloud sample queue environments use bash to activate environments
+# on Windows, so we produce both .bat and .sh files.
 mkdir -p $PREFIX/etc/conda/activate.d
 mkdir -p $PREFIX/etc/conda/deactivate.d
 
 cat <<EOF > "$PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.bat"
-set "BLENDER_LOCATION=$PREFIX/opt/blender"
-set "BLENDER_VERSION=$BLENDER_VERSION"
-set "BLENDER_LIBRARY_PATH=%BLENDER_LOCATION%/lib"
-set "BLENDER_SCRIPTS_PATH=%BLENDER_LOCATION%/%BLENDER_VERSION%/scripts"
-set "BLENDER_PYTHON_PATH=%BLENDER_LOCATION%/%BLENDER_VERSION%/python"
-set "BLENDER_DATAFILES_PATH=%BLENDER_LOCATION%/%BLENDER_VERSION%/datafiles"
 set "PATH=$PREFIX/opt/blender;%PATH%"
 EOF
 cat "$PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.bat"
 
 cat <<EOF > $PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.sh
-export "BLENDER_LOCATION=\$CONDA_PREFIX/opt/blender"
-export "BLENDER_VERSION=$BLENDER_VERSION"
-export "BLENDER_LIBRARY_PATH=\$BLENDER_LOCATION/lib"
-export "BLENDER_SCRIPTS_PATH=\$BLENDER_LOCATION/\$BLENDER_VERSION/scripts"
-export "BLENDER_PYTHON_PATH=\$BLENDER_LOCATION/\$BLENDER_VERSION/python"
-export "BLENDER_DATAFILES_PATH=\$BLENDER_LOCATION/\$BLENDER_VERSION/datafiles"
 export PATH="\$(cygpath '$PREFIX/opt/blender'):\$PATH"
 EOF
 cat $PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.sh
 
 cat <<EOF > "$PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.bat"
 set "PATH=%PATH:$PREFIX/opt/blender;=%"
-set BLENDER_DATAFILES_PATH=
-set BLENDER_PYTHON_PATH=
-set BLENDER_SCRIPTS_PATH=
-set BLENDER_LIBRARY_PATH=
-set BLENDER_VERSION=
-set BLENDER_LOCATION=
 EOF
 cat "$PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.bat"
 
 cat <<EOF > $PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.sh
 export PATH="\${PATH/\$(cygpath '$PREFIX/opt/blender'):/}"
-unset BLENDER_DATAFILES_PATH
-unset BLENDER_PYTHON_PATH
-unset BLENDER_SCRIPTS_PATH
-unset BLENDER_LIBRARY_PATH
-unset BLENDER_VERSION
-unset BLENDER_LOCATION
 EOF
 cat $PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.sh

--- a/conda_recipes/blender-4.4/recipe/build.sh
+++ b/conda_recipes/blender-4.4/recipe/build.sh
@@ -14,25 +14,17 @@ for BINARY in blender blender-launcher blender-softwaregl blender-thumbnailer; d
     ln -r -s $PREFIX/opt/blender/$BINARY $PREFIX/bin/$BINARY
 done
 
-# See https://docs.conda.io/projects/conda/en/latest/dev-guide/deep-dives/activation.html
-# for details on activation.
-
-mkdir -p $PREFIX/etc/conda/activate.d
-cat <<EOF > $PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.sh
-export "BLENDER_LOCATION=\$CONDA_PREFIX/opt/blender"
-export "BLENDER_VERSION=$BLENDER_VERSION"
-export "BLENDER_LIBRARY_PATH=\$BLENDER_LOCATION/lib"
-export "BLENDER_SCRIPTS_PATH=\$BLENDER_LOCATION/\$BLENDER_VERSION/scripts"
-export "BLENDER_PYTHON_PATH=\$BLENDER_LOCATION/\$BLENDER_VERSION/python"
-export "BLENDER_DATAFILES_PATH=\$BLENDER_LOCATION/\$BLENDER_VERSION/datafiles"
-EOF
-
-mkdir -p $PREFIX/etc/conda/deactivate.d
-cat <<EOF > $PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.sh
-unset BLENDER_DATAFILES_PATH
-unset BLENDER_PYTHON_PATH
-unset BLENDER_SCRIPTS_PATH
-unset BLENDER_LIBRARY_PATH
-unset BLENDER_VERSION
-unset BLENDER_LOCATION
+# Set environment variables using the JSON env_vars.d mechanism.
+# See https://rattler-build.prefix.dev/latest/special_files/ for details.
+# This is more portable than activation scripts and works with pixi trampolines.
+mkdir -p $PREFIX/etc/conda/env_vars.d
+cat > $PREFIX/etc/conda/env_vars.d/$PKG_NAME-$PKG_VERSION.json << EOF
+{
+  "BLENDER_LOCATION": "$PREFIX/opt/blender",
+  "BLENDER_VERSION": "$BLENDER_VERSION",
+  "BLENDER_LIBRARY_PATH": "$PREFIX/opt/blender/lib",
+  "BLENDER_SCRIPTS_PATH": "$PREFIX/opt/blender/$BLENDER_VERSION/scripts",
+  "BLENDER_PYTHON_PATH": "$PREFIX/opt/blender/$BLENDER_VERSION/python",
+  "BLENDER_DATAFILES_PATH": "$PREFIX/opt/blender/$BLENDER_VERSION/datafiles"
+}
 EOF

--- a/conda_recipes/blender-4.4/recipe/build_win.sh
+++ b/conda_recipes/blender-4.4/recipe/build_win.sh
@@ -8,53 +8,44 @@ cp -r $SRC_DIR/blender $PREFIX/opt/
 # The version without the build number
 BLENDER_VERSION=${PKG_VERSION%.*}
 
-# See https://docs.conda.io/projects/conda/en/latest/dev-guide/deep-dives/activation.html
-# for details on activation. The Deadline Cloud sample queue environments use bash
-# to activate environments on Windows, so we recommend always producing both .bat and .sh files.
+# Set environment variables using the JSON env_vars.d mechanism.
+# See https://rattler-build.prefix.dev/latest/special_files/ for details.
+# This is more portable than activation scripts and works with pixi trampolines.
+mkdir -p $PREFIX/etc/conda/env_vars.d
+cat > $PREFIX/etc/conda/env_vars.d/$PKG_NAME-$PKG_VERSION.json << EOF
+{
+  "BLENDER_LOCATION": "$PREFIX/opt/blender",
+  "BLENDER_VERSION": "$BLENDER_VERSION",
+  "BLENDER_LIBRARY_PATH": "$PREFIX/opt/blender/lib",
+  "BLENDER_SCRIPTS_PATH": "$PREFIX/opt/blender/$BLENDER_VERSION/scripts",
+  "BLENDER_PYTHON_PATH": "$PREFIX/opt/blender/$BLENDER_VERSION/python",
+  "BLENDER_DATAFILES_PATH": "$PREFIX/opt/blender/$BLENDER_VERSION/datafiles"
+}
+EOF
+cat $PREFIX/etc/conda/env_vars.d/$PKG_NAME-$PKG_VERSION.json
 
+# Add blender to PATH via activation scripts.
+# The Deadline Cloud sample queue environments use bash to activate environments
+# on Windows, so we produce both .bat and .sh files.
 mkdir -p $PREFIX/etc/conda/activate.d
 mkdir -p $PREFIX/etc/conda/deactivate.d
 
 cat <<EOF > "$PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.bat"
-set "BLENDER_LOCATION=$PREFIX/opt/blender"
-set "BLENDER_VERSION=$BLENDER_VERSION"
-set "BLENDER_LIBRARY_PATH=%BLENDER_LOCATION%/lib"
-set "BLENDER_SCRIPTS_PATH=%BLENDER_LOCATION%/%BLENDER_VERSION%/scripts"
-set "BLENDER_PYTHON_PATH=%BLENDER_LOCATION%/%BLENDER_VERSION%/python"
-set "BLENDER_DATAFILES_PATH=%BLENDER_LOCATION%/%BLENDER_VERSION%/datafiles"
 set "PATH=$PREFIX/opt/blender;%PATH%"
 EOF
 cat "$PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.bat"
 
 cat <<EOF > $PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.sh
-export "BLENDER_LOCATION=\$CONDA_PREFIX/opt/blender"
-export "BLENDER_VERSION=$BLENDER_VERSION"
-export "BLENDER_LIBRARY_PATH=\$BLENDER_LOCATION/lib"
-export "BLENDER_SCRIPTS_PATH=\$BLENDER_LOCATION/\$BLENDER_VERSION/scripts"
-export "BLENDER_PYTHON_PATH=\$BLENDER_LOCATION/\$BLENDER_VERSION/python"
-export "BLENDER_DATAFILES_PATH=\$BLENDER_LOCATION/\$BLENDER_VERSION/datafiles"
 export PATH="\$(cygpath '$PREFIX/opt/blender'):\$PATH"
 EOF
 cat $PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.sh
 
 cat <<EOF > "$PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.bat"
 set "PATH=%PATH:$PREFIX/opt/blender;=%"
-set BLENDER_DATAFILES_PATH=
-set BLENDER_PYTHON_PATH=
-set BLENDER_SCRIPTS_PATH=
-set BLENDER_LIBRARY_PATH=
-set BLENDER_VERSION=
-set BLENDER_LOCATION=
 EOF
 cat "$PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.bat"
 
 cat <<EOF > $PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.sh
 export PATH="\${PATH/\$(cygpath '$PREFIX/opt/blender'):/}"
-unset BLENDER_DATAFILES_PATH
-unset BLENDER_PYTHON_PATH
-unset BLENDER_SCRIPTS_PATH
-unset BLENDER_LIBRARY_PATH
-unset BLENDER_VERSION
-unset BLENDER_LOCATION
 EOF
 cat $PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.sh

--- a/conda_recipes/blender-4.5/recipe/build.sh
+++ b/conda_recipes/blender-4.5/recipe/build.sh
@@ -14,25 +14,17 @@ for BINARY in blender blender-launcher blender-softwaregl blender-thumbnailer; d
     ln -r -s $PREFIX/opt/blender/$BINARY $PREFIX/bin/$BINARY
 done
 
-# See https://docs.conda.io/projects/conda/en/latest/dev-guide/deep-dives/activation.html
-# for details on activation.
-
-mkdir -p $PREFIX/etc/conda/activate.d
-cat <<EOF > $PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.sh
-export "BLENDER_LOCATION=\$CONDA_PREFIX/opt/blender"
-export "BLENDER_VERSION=$BLENDER_VERSION"
-export "BLENDER_LIBRARY_PATH=\$BLENDER_LOCATION/lib"
-export "BLENDER_SCRIPTS_PATH=\$BLENDER_LOCATION/\$BLENDER_VERSION/scripts"
-export "BLENDER_PYTHON_PATH=\$BLENDER_LOCATION/\$BLENDER_VERSION/python"
-export "BLENDER_DATAFILES_PATH=\$BLENDER_LOCATION/\$BLENDER_VERSION/datafiles"
-EOF
-
-mkdir -p $PREFIX/etc/conda/deactivate.d
-cat <<EOF > $PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.sh
-unset BLENDER_DATAFILES_PATH
-unset BLENDER_PYTHON_PATH
-unset BLENDER_SCRIPTS_PATH
-unset BLENDER_LIBRARY_PATH
-unset BLENDER_VERSION
-unset BLENDER_LOCATION
+# Set environment variables using the JSON env_vars.d mechanism.
+# See https://rattler-build.prefix.dev/latest/special_files/ for details.
+# This is more portable than activation scripts and works with pixi trampolines.
+mkdir -p $PREFIX/etc/conda/env_vars.d
+cat > $PREFIX/etc/conda/env_vars.d/$PKG_NAME-$PKG_VERSION.json << EOF
+{
+  "BLENDER_LOCATION": "$PREFIX/opt/blender",
+  "BLENDER_VERSION": "$BLENDER_VERSION",
+  "BLENDER_LIBRARY_PATH": "$PREFIX/opt/blender/lib",
+  "BLENDER_SCRIPTS_PATH": "$PREFIX/opt/blender/$BLENDER_VERSION/scripts",
+  "BLENDER_PYTHON_PATH": "$PREFIX/opt/blender/$BLENDER_VERSION/python",
+  "BLENDER_DATAFILES_PATH": "$PREFIX/opt/blender/$BLENDER_VERSION/datafiles"
+}
 EOF

--- a/conda_recipes/blender-4.5/recipe/build_win.sh
+++ b/conda_recipes/blender-4.5/recipe/build_win.sh
@@ -8,53 +8,44 @@ cp -r $SRC_DIR/blender $PREFIX/opt/
 # The version without the build number
 BLENDER_VERSION=${PKG_VERSION%.*}
 
-# See https://docs.conda.io/projects/conda/en/latest/dev-guide/deep-dives/activation.html
-# for details on activation. The Deadline Cloud sample queue environments use bash
-# to activate environments on Windows, so we recommend always producing both .bat and .sh files.
+# Set environment variables using the JSON env_vars.d mechanism.
+# See https://rattler-build.prefix.dev/latest/special_files/ for details.
+# This is more portable than activation scripts and works with pixi trampolines.
+mkdir -p $PREFIX/etc/conda/env_vars.d
+cat > $PREFIX/etc/conda/env_vars.d/$PKG_NAME-$PKG_VERSION.json << EOF
+{
+  "BLENDER_LOCATION": "$PREFIX/opt/blender",
+  "BLENDER_VERSION": "$BLENDER_VERSION",
+  "BLENDER_LIBRARY_PATH": "$PREFIX/opt/blender/lib",
+  "BLENDER_SCRIPTS_PATH": "$PREFIX/opt/blender/$BLENDER_VERSION/scripts",
+  "BLENDER_PYTHON_PATH": "$PREFIX/opt/blender/$BLENDER_VERSION/python",
+  "BLENDER_DATAFILES_PATH": "$PREFIX/opt/blender/$BLENDER_VERSION/datafiles"
+}
+EOF
+cat $PREFIX/etc/conda/env_vars.d/$PKG_NAME-$PKG_VERSION.json
 
+# Add blender to PATH via activation scripts.
+# The Deadline Cloud sample queue environments use bash to activate environments
+# on Windows, so we produce both .bat and .sh files.
 mkdir -p $PREFIX/etc/conda/activate.d
 mkdir -p $PREFIX/etc/conda/deactivate.d
 
 cat <<EOF > "$PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.bat"
-set "BLENDER_LOCATION=$PREFIX/opt/blender"
-set "BLENDER_VERSION=$BLENDER_VERSION"
-set "BLENDER_LIBRARY_PATH=%BLENDER_LOCATION%/lib"
-set "BLENDER_SCRIPTS_PATH=%BLENDER_LOCATION%/%BLENDER_VERSION%/scripts"
-set "BLENDER_PYTHON_PATH=%BLENDER_LOCATION%/%BLENDER_VERSION%/python"
-set "BLENDER_DATAFILES_PATH=%BLENDER_LOCATION%/%BLENDER_VERSION%/datafiles"
 set "PATH=$PREFIX/opt/blender;%PATH%"
 EOF
 cat "$PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.bat"
 
 cat <<EOF > $PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.sh
-export "BLENDER_LOCATION=\$CONDA_PREFIX/opt/blender"
-export "BLENDER_VERSION=$BLENDER_VERSION"
-export "BLENDER_LIBRARY_PATH=\$BLENDER_LOCATION/lib"
-export "BLENDER_SCRIPTS_PATH=\$BLENDER_LOCATION/\$BLENDER_VERSION/scripts"
-export "BLENDER_PYTHON_PATH=\$BLENDER_LOCATION/\$BLENDER_VERSION/python"
-export "BLENDER_DATAFILES_PATH=\$BLENDER_LOCATION/\$BLENDER_VERSION/datafiles"
 export PATH="\$(cygpath '$PREFIX/opt/blender'):\$PATH"
 EOF
 cat $PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.sh
 
 cat <<EOF > "$PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.bat"
 set "PATH=%PATH:$PREFIX/opt/blender;=%"
-set BLENDER_DATAFILES_PATH=
-set BLENDER_PYTHON_PATH=
-set BLENDER_SCRIPTS_PATH=
-set BLENDER_LIBRARY_PATH=
-set BLENDER_VERSION=
-set BLENDER_LOCATION=
 EOF
 cat "$PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.bat"
 
 cat <<EOF > $PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.sh
 export PATH="\${PATH/\$(cygpath '$PREFIX/opt/blender'):/}"
-unset BLENDER_DATAFILES_PATH
-unset BLENDER_PYTHON_PATH
-unset BLENDER_SCRIPTS_PATH
-unset BLENDER_LIBRARY_PATH
-unset BLENDER_VERSION
-unset BLENDER_LOCATION
 EOF
 cat $PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.sh


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Conda packages can have a .json file specify environment variables as an alternative to activation scripts. This is simpler and more portable than activation script files.

### What was the solution? (How)

Edit the Blender recipe samples to use this feature. This changes all but the PATH edits to use this instead of activation scripts.

### What is the impact of this change?

The Blender sample recipes show a better pattern to copy.

### How was this change tested?

Built 8 packages (windows, linux) * (4 different Blender versions). Submitted 8 jobs to a farm, saw them succeed. Confirmed in the logs that they used the right package, and the env vars were set.

### Was this change documented?

No, the sample illustrates the feature. We can consider updating docs as a follow-up.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*