### PR TITLE
feat: add Blender 5.0 conda recipe sample

### DIFF
--- a/conda_recipes/blender-5.0/README.md
+++ b/conda_recipes/blender-5.0/README.md
@@ -1,0 +1,149 @@
+# Blender 5.0 Conda Recipe for AWS Deadline Cloud
+
+This directory contains a conda build recipe for Blender 5.0, specifically configured for use with AWS Deadline Cloud.
+
+## Package Information
+
+- **Application**: Blender 5.0.1
+- **Platform**: Windows 64-bit (win-64) & Linux 
+- **Source**: https://download.blender.org/release/Blender5.0/blender-5.0.1-windows-x64.zip & https://download.blender.org/release/Blender5.0/blender-5.0.1-linux-x64.tar.xz
+- **License**: GPL3
+- **Build Tool**: conda-build/rattler-build
+
+## Prerequisites
+
+Before building this package, ensure you have:
+
+1. **AWS Deadline Cloud infrastructure** set up with:
+   - A farm configured for package building
+   - A queue for building the package (specify with `-q` option)
+
+2. **Deadline Cloud CLI** installed on your workstation
+
+3. **Source archive** downloaded
+
+## Building the  Package
+
+### Using the submit-package-job command
+
+From the `conda_recipes` directory in deadline-cloud-samples:
+
+```bash
+# Build for Windows 64-bit (default)
+./submit-package-job blender-5.0
+
+# Specify platform explicitly
+./submit-package-job blender-5.0 -p win-64
+
+# Submit to a specific queue
+./submit-package-job blender-5.0 -q "My Package Build Queue"
+
+# Build to a different S3 channel
+./submit-package-job blender-5.0 --s3-channel MyChannel
+```
+
+### Manual conda-build (for local testing)
+
+```bash
+# Build the package locally (requires conda-build)
+conda build recipe/ --platform <linux-64, win-64>
+```
+
+### Manual rattler-build (for local testing)
+
+```bash
+# Build the package locally (requires rattler-build)
+rattler-build build --recipe-dir recipe/ --target-platform <linux-64, win-64> --allow-symlinks-on-windows
+```
+
+## Usage After Installation
+
+Once installed in a conda environment:
+
+```bash
+# Activate environment with Blender
+conda activate my-blender-env
+
+# Run Blender
+blender
+
+# Run Blender with command line options
+blender --help
+blender --background --python my_script.py
+```
+
+## Using Addons
+
+To use a Blender addon, place the `.py` or `.zip` file into a known location in the $INSTALL_DIR folder.
+Create a Python file that uses the [Blender API](https://docs.blender.org/api/current/bpy.ops.preferences.html#bpy.ops.preferences.addon_install) that installs the addon and saves the user preferences. 
+
+Modify the activate script to run your python file with Blender's Python.
+
+```bash
+"\$BLENDER_LOCATION/blender" --background --python "$INSTALL_DIR/install_addon.py"
+```
+
+Next, create a Python file that uninstalls the addon. Remember to also save the user preferences. 
+Modify the deactivate script to run the uninstall script too.
+
+```bash
+"\$BLENDER_LOCATION/blender" --background --python "$INSTALL_DIR/uninstall_addon.py"
+```
+
+If you decide to make a separate conda package for your addon and you're addon requires any additional Python dependencies, place them in a known location in your $INSTALL_DIR.
+Have the activate script move them into Blender's Python. Likewise, change the deactivate to remove them. This way, you can make use of the environment variables that this recipe 
+sets for the location of Blender and it's Python.
+
+### Examples Blender Addons
+
+- [Blender - Flip Fluids](../blender-flipfluids/)
+- [Blender - Plugin Bundle](../blender-plugin-build/)
+
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Build fails with missing source archive**
+   - Ensure the source archive is downloaded to the `archive_files` directory
+   - Check that the URL in `deadline-cloud.yaml` is accessible
+
+2. **Package not found after build**
+   - Verify the S3 conda channel configuration
+   - Check that the build completed successfully in Deadline Cloud
+
+3. **Blender won't start after installation**
+   - Check that the conda environment is properly activated
+
+### Getting Help
+
+- Check the [Deadline Cloud Developer Guide](https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/)
+- Review the [conda-build documentation](https://docs.conda.io/projects/conda-build/)
+- Examine build logs in the Deadline Cloud console
+
+## Recipe Structure
+
+```
+blender-5.0/
+├── README.md                    # This file
+├── deadline-cloud.yaml          # Deadline Cloud configuration
+└── recipe/
+    ├── recipe.yaml             # Rattler package metadata
+    ├── build_win.sh            # Windows bash script 
+    └── build.sh                # Linux build script 
+```
+
+## License
+
+This recipe is provided under the same license terms as the deadline-cloud-samples repository. Blender itself is licensed under GPL3.
+
+## Contributing
+
+To modify this recipe:
+
+1. Update version numbers in `recipe.yaml` and `deadline-cloud.yaml`
+2. Update SHA256 hash for new source archives in `recipe.yaml`.
+3. Test the build process
+4. Update this README with any changes
+
+For questions or issues, please refer to the AWS Deadline Cloud documentation or community forums.

--- a/conda_recipes/blender-5.0/deadline-cloud.yaml
+++ b/conda_recipes/blender-5.0/deadline-cloud.yaml
@@ -1,0 +1,12 @@
+condaPlatforms:
+  - platform: linux-64
+    defaultSubmit: true
+    sourceArchiveFilename: blender-5.0.1-linux-x64.tar.xz
+    sourceDownloadInstructions: 'Run "curl -LO https://download.blender.org/release/Blender5.0/blender-5.0.1-linux-x64.tar.xz --output-dir archive_files"'
+    buildTool: rattler-build
+  - platform: win-64
+    defaultSubmit: false
+    sourceArchiveFilename: blender-5.0.1-windows-x64.zip
+    sourceDownloadInstructions: 'Run "curl -LO https://download.blender.org/release/Blender5.0/blender-5.0.1-windows-x64.zip --output-dir archive_files"'
+    buildTool: rattler-build
+

--- a/conda_recipes/blender-5.0/recipe/build.sh
+++ b/conda_recipes/blender-5.0/recipe/build.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+set -xeuo pipefail
+
+# Copy the Blender installation into the prefix
+mkdir -p $PREFIX/opt
+cp -r $SRC_DIR/blender $PREFIX/opt/
+
+# The version without the build number
+BLENDER_VERSION=${PKG_VERSION%.*}
+
+# Create symlinks to the Blender commands
+mkdir -p $PREFIX/bin
+for BINARY in blender blender-launcher blender-softwaregl blender-thumbnailer; do
+    ln -r -s $PREFIX/opt/blender/$BINARY $PREFIX/bin/$BINARY
+done
+
+# Set environment variables using the JSON env_vars.d mechanism.
+# See https://rattler-build.prefix.dev/latest/special_files/ for details.
+# This is more portable than activation scripts and works with pixi trampolines.
+mkdir -p $PREFIX/etc/conda/env_vars.d
+cat > $PREFIX/etc/conda/env_vars.d/$PKG_NAME-$PKG_VERSION.json << EOF
+{
+  "BLENDER_LOCATION": "$PREFIX/opt/blender",
+  "BLENDER_VERSION": "$BLENDER_VERSION",
+  "BLENDER_LIBRARY_PATH": "$PREFIX/opt/blender/lib",
+  "BLENDER_SCRIPTS_PATH": "$PREFIX/opt/blender/$BLENDER_VERSION/scripts",
+  "BLENDER_PYTHON_PATH": "$PREFIX/opt/blender/$BLENDER_VERSION/python",
+  "BLENDER_DATAFILES_PATH": "$PREFIX/opt/blender/$BLENDER_VERSION/datafiles"
+}
+EOF

--- a/conda_recipes/blender-5.0/recipe/build_win.sh
+++ b/conda_recipes/blender-5.0/recipe/build_win.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+set -xeuo pipefail
+
+# Copy the Blender installation into the prefix
+mkdir -p $PREFIX/opt
+cp -r $SRC_DIR/blender $PREFIX/opt/
+
+# The version without the build number
+BLENDER_VERSION=${PKG_VERSION%.*}
+
+# Set environment variables using the JSON env_vars.d mechanism.
+# See https://rattler-build.prefix.dev/latest/special_files/ for details.
+# This is more portable than activation scripts and works with pixi trampolines.
+mkdir -p $PREFIX/etc/conda/env_vars.d
+cat > $PREFIX/etc/conda/env_vars.d/$PKG_NAME-$PKG_VERSION.json << EOF
+{
+  "BLENDER_LOCATION": "$PREFIX/opt/blender",
+  "BLENDER_VERSION": "$BLENDER_VERSION",
+  "BLENDER_LIBRARY_PATH": "$PREFIX/opt/blender/lib",
+  "BLENDER_SCRIPTS_PATH": "$PREFIX/opt/blender/$BLENDER_VERSION/scripts",
+  "BLENDER_PYTHON_PATH": "$PREFIX/opt/blender/$BLENDER_VERSION/python",
+  "BLENDER_DATAFILES_PATH": "$PREFIX/opt/blender/$BLENDER_VERSION/datafiles"
+}
+EOF
+cat $PREFIX/etc/conda/env_vars.d/$PKG_NAME-$PKG_VERSION.json
+
+# Add blender to PATH via activation scripts.
+# The Deadline Cloud sample queue environments use bash to activate environments
+# on Windows, so we produce both .bat and .sh files.
+mkdir -p $PREFIX/etc/conda/activate.d
+mkdir -p $PREFIX/etc/conda/deactivate.d
+
+cat <<EOF > "$PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.bat"
+set "PATH=$PREFIX/opt/blender;%PATH%"
+EOF
+cat "$PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.bat"
+
+cat <<EOF > $PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.sh
+export PATH="\$(cygpath '$PREFIX/opt/blender'):\$PATH"
+EOF
+cat $PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.sh
+
+cat <<EOF > "$PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.bat"
+set "PATH=%PATH:$PREFIX/opt/blender;=%"
+EOF
+cat "$PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.bat"
+
+cat <<EOF > $PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.sh
+export PATH="\${PATH/\$(cygpath '$PREFIX/opt/blender'):/}"
+EOF
+cat $PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.sh

--- a/conda_recipes/blender-5.0/recipe/recipe.yaml
+++ b/conda_recipes/blender-5.0/recipe/recipe.yaml
@@ -1,0 +1,52 @@
+# Recipe in rattler-build format.
+# See https://prefix-dev.github.io/rattler-build/latest/
+
+context:
+  version: "5.0.1"
+  major_minor_version: "5.0"
+
+package:
+  name: blender
+  version: ${{ version }}
+
+source:
+  - if: linux
+    then:
+      url: https://download.blender.org/release/Blender${{ major_minor_version }}/blender-${{ version }}-linux-x64.tar.xz
+      sha256: 8019580ee1b7262e505f4196a00237ccf743c88d205b38d34201510676e60b09
+      target_directory: blender
+  - if: win
+    then:
+      url: https://download.blender.org/release/Blender${{ major_minor_version }}/blender-${{ version }}-windows-x64.zip
+      sha256: 921d77f6c505a35b2c2f6e67d4ad1c10b72418338ba0e0d3ea7f582a5e5fe46e
+      target_directory: blender
+
+build:
+  number: 0
+  script:
+    - if: unix
+      then:
+        - bash $RECIPE_DIR/build.sh
+    - if: win
+      then:
+        - bash %RECIPE_DIR%\build_win.sh
+  # These build options for repackaging an application
+  # https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html
+  prefix_detection:
+    ignore_binary_files: True
+  dynamic_linking:
+    binary_relocation: False
+    missing_dso_allowlist:
+    - "**"
+
+tests:
+  - script:
+    - blender -h
+
+about:
+  homepage: https://www.blender.org/
+  license: GPL-3.0-or-later
+  summary: >
+    Blender is the free and open source 3D creation suite. It supports the entirety of
+    the 3D pipeline—modeling, rigging, animation, simulation, rendering, compositing
+    and motion tracking, even video editing and game creation.


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Blender 5.0 is out, but we do not have Conda sample for it

### What was the solution? (How)
Add Blender 5.0 conda recipe sample for Windows and Linux

### What is the impact of this change?
We now have sample conda recciple for Blender 5.0

### How was this change tested?
- Running build using `./submit-package-job blender-5.0 --all-platforms
<img width="887" height="272" alt="Screenshot 2026-03-20 at 2 37 38 PM" src="https://github.com/user-attachments/assets/e38ebe48-54d2-4d8d-a13f-07454ae48e50" />
- Running job submission to make sure everything is working: 
<img width="861" height="348" alt="image" src="https://github.com/user-attachments/assets/90fa2c46-1816-480f-9683-e4abe99a3a89" />

### Was this change documented?
Yes

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*