### PR TITLE
feat: Add host configuration script examples for docker nvidia toolki…

### DIFF
--- a/host_configuration_scripts/README.md
+++ b/host_configuration_scripts/README.md
@@ -6,9 +6,25 @@ This directory contains sample scripts for configuring Service Managed Fleets on
 
 Host Configuration Scripts allow you to perform administrative tasks, such as software installation, on your service-managed fleet workers. These scripts run with elevated privileges, giving you the flexibility to configure your workers for your system.
 
+## Examples
+
+| Example | Platform | Description |
+|---------|----------|-------------|
+| [3dsmax](3dsmax/) | Windows | Install and configure Autodesk 3ds Max with various renderer plugins (V-Ray, Corona, tyFlow, AEC) |
+| [aftereffects](aftereffects/) | Windows | Install After Effects with Red Giant plugins |
+| [cinema4d](cinema4d/) | Windows | Install Cinema 4D with Red Giant plugins |
+| [docker_nvidia_container_toolkit](docker_nvidia_container_toolkit/) | Linux | Install Docker and NVIDIA Container Toolkit for GPU-accelerated container workloads |
+| [linux_font_installation](linux_font_installation/) | Linux | Install custom fonts from S3 for rendering applications |
+| [sudo_for_job_user](sudo_for_job_user/) | Linux | Grant passwordless sudo to `job-user` for workloads that require root access |
+| [swap_for_smf](swap_for_smf/) | Linux | Enable swap for memory-intensive workloads like ComfyUI and large diffusion models |
+| [worker_configuration](worker_configuration/) | Windows | Configure Windows page file settings |
+| [worker_reboot](worker_reboot/) | Linux / Windows | Reboot the worker after host configuration (e.g. after driver installs or domain joins) |
+
 ## Common Uses
 - Installing software that requires administrator access
 - Installing Docker containers
+- Configuring GPU runtimes for containerized workloads
+- Enabling swap for memory-intensive jobs
 
 ## Setup
 

--- a/host_configuration_scripts/docker_nvidia_container_toolkit/README.md
+++ b/host_configuration_scripts/docker_nvidia_container_toolkit/README.md
@@ -1,0 +1,75 @@
+# Docker and NVIDIA Container Toolkit
+
+Install Docker and the NVIDIA Container Toolkit on Linux service managed fleet workers, enabling GPU-accelerated container workloads.
+
+## Why Docker on Deadline Cloud Workers?
+
+Many GPU workloads ship as container images — ComfyUI, Stable Diffusion inference servers, custom ML pipelines, etc. Running these on Deadline Cloud workers requires Docker with GPU passthrough. This host config script sets everything up so jobs can `docker run` GPU containers directly.
+
+Containers also provide a clean way to package complex dependency stacks (CUDA, Python, application-specific libraries) without polluting the host or conflicting with other jobs on the same fleet.
+
+## What It Does
+
+1. Installs Docker via `dnf` and starts the service
+2. Adds `job-user` to the `docker` group so jobs can run containers without sudo
+3. Installs the NVIDIA Container Toolkit from the official repository
+4. Configures the Docker daemon to use the NVIDIA runtime
+5. Generates the CDI (Container Device Interface) spec for GPU access
+6. Restarts Docker and verifies the setup
+
+## Prerequisites
+
+- The fleet AMI must have NVIDIA GPU drivers already installed (Deadline Cloud GPU AMIs include these)
+- The fleet must use a GPU instance type (e.g. g6.xlarge, g6e.xlarge, p4d.24xlarge)
+
+## Usage
+
+1. Open the AWS Deadline Cloud console
+2. Navigate to your fleet
+3. Go to the "Host configuration" section
+4. Copy and paste the contents of `linux.sh` into the script field
+5. Save the configuration
+
+New fleet instances will automatically install Docker and the NVIDIA Container Toolkit on startup.
+
+## Example: Running a GPU Container from a Job
+
+Once the host config has run, jobs can launch GPU containers. Here's an example running ComfyUI with GPU access, host networking, and license environment variables passed through:
+
+```bash
+docker run --rm \
+  --runtime=nvidia \
+  --gpus all \
+  --network host \
+  -e ADSKFLEX_LICENSE_FILE \
+  -e FLEXLM_TIMEOUT \
+  -e foundry_LICENSE \
+  -e PIXAR_LICENSE_FILE \
+  -e g_licenseServerRLM \
+  -e redshift_LICENSE \
+  -e SESI_LMHOST \
+  -e VRAY_AUTH_CLIENT_FILE_PATH \
+  -e VRAY_AUTH_CLIENT_SETTINGS \
+  your-image:latest
+```
+
+Key flags:
+- `--runtime=nvidia --gpus all` — passes the GPU through to the container
+- `--network host` — uses the host network stack (required for license servers and service discovery)
+- `-e VAR` — passes the environment variable from the worker into the container (when used without `=value`, Docker forwards the host's current value)
+
+### License Environment Variables
+
+Deadline Cloud queue environments typically set license server endpoints as environment variables. Using `-e` without a value forwards whatever the worker has set. Common variables:
+
+| Variable | Product |
+|----------|---------|
+| `ADSKFLEX_LICENSE_FILE` | Autodesk (Maya, 3ds Max, etc.) |
+| `FLEXLM_TIMEOUT` | FlexLM license timeout |
+| `foundry_LICENSE` | Foundry (Nuke, Mari, etc.) |
+| `PIXAR_LICENSE_FILE` | Pixar RenderMan |
+| `g_licenseServerRLM` | Maxon Cinema 4D |
+| `redshift_LICENSE` | Maxon Redshift / Red Giant |
+| `SESI_LMHOST` | SideFX Houdini |
+| `VRAY_AUTH_CLIENT_FILE_PATH` | Chaos V-Ray auth client file |
+| `VRAY_AUTH_CLIENT_SETTINGS` | Chaos V-Ray license endpoint |

--- a/host_configuration_scripts/docker_nvidia_container_toolkit/linux.sh
+++ b/host_configuration_scripts/docker_nvidia_container_toolkit/linux.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Install Docker and NVIDIA Container Toolkit on Deadline Cloud service managed fleet workers.
+# Run this as a host configuration script (runs as root).
+#
+# Tested on: Amazon Linux 2023 with NVIDIA GPU drivers pre-installed
+# Requires: GPU instance type (g6, g6e, p4d, etc.)
+
+set -e
+
+echo "[$(date)] Installing Docker and NVIDIA Container Toolkit..."
+
+# --- Docker ---
+echo "Installing Docker..."
+dnf install -y docker
+systemctl enable docker
+systemctl start docker
+
+# Allow job-user to run docker without sudo
+if id "job-user" &>/dev/null; then
+    usermod -aG docker job-user
+    echo "job-user added to docker group."
+else
+    echo "WARNING: job-user does not exist yet. Add job-user to the docker group after the worker agent starts."
+fi
+
+# --- NVIDIA Container Toolkit ---
+echo "Installing NVIDIA Container Toolkit..."
+curl -s -L https://nvidia.github.io/libnvidia-container/stable/rpm/nvidia-container-toolkit.repo | \
+    tee /etc/yum.repos.d/nvidia-container-toolkit.repo
+
+dnf install -y nvidia-container-toolkit
+
+# Configure Docker to use NVIDIA runtime
+nvidia-ctk runtime configure --runtime=docker
+
+# Generate CDI spec (required for --runtime=nvidia on newer drivers)
+mkdir -p /etc/cdi
+nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
+
+# Restart Docker to pick up NVIDIA runtime
+systemctl restart docker
+
+# --- Verify ---
+echo ""
+echo "=== Verification ==="
+echo "Docker: $(docker --version)"
+echo "NVIDIA driver: $(nvidia-smi --query-gpu=driver_version --format=csv,noheader 2>/dev/null || echo 'not found')"
+echo "GPU: $(nvidia-smi --query-gpu=name,memory.total --format=csv,noheader 2>/dev/null || echo 'not found')"
+echo "NVIDIA runtime: $(grep -c nvidia /etc/docker/daemon.json 2>/dev/null || echo '0') references in daemon.json"
+
+echo "[$(date)] Docker and NVIDIA Container Toolkit setup complete."

--- a/host_configuration_scripts/sudo_for_job_user/README.md
+++ b/host_configuration_scripts/sudo_for_job_user/README.md
@@ -1,0 +1,23 @@
+# Passwordless Sudo for Job User
+
+Grant the Deadline Cloud `job-user` passwordless sudo access on Linux service managed fleet workers.
+
+Some workloads require root privileges — for example, installing packages, mounting filesystems, or registering the worker as an SSM managed node. By default, `job-user` does not have sudo access.
+
+## What It Does
+
+The script adds a sudoers rule that allows `job-user` to run any command as root without a password prompt. If `job-user` does not exist yet (e.g. the worker agent hasn't created it), the script logs a warning and exits successfully so it doesn't block fleet provisioning.
+
+## Security Considerations
+
+Granting passwordless sudo to `job-user` means any job running on the worker can execute arbitrary commands as root. Only enable this on fleets where you trust the jobs being submitted, and consider scoping the sudoers rule to specific commands if your use case allows it.
+
+## Usage
+
+1. Open the AWS Deadline Cloud console
+2. Navigate to your fleet
+3. Go to the "Host configuration" section
+4. Copy and paste the contents of `linux.sh` into the script field
+5. Save the configuration
+
+New fleet instances will automatically configure passwordless sudo for `job-user` on startup.

--- a/host_configuration_scripts/sudo_for_job_user/linux.sh
+++ b/host_configuration_scripts/sudo_for_job_user/linux.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Grant passwordless sudo to job-user on Deadline Cloud service managed fleet workers.
+# Run this as a host configuration script (runs as root).
+
+set -e
+
+echo "[$(date)] Configuring passwordless sudo for job-user..."
+
+if id "job-user" &>/dev/null; then
+    echo "job-user ALL=(ALL) NOPASSWD:ALL" | tee /etc/sudoers.d/job-user
+    chmod 440 /etc/sudoers.d/job-user
+    echo "Passwordless sudo configured for job-user."
+else
+    echo "WARNING: job-user does not exist yet. This is expected if the worker agent has not started."
+    echo "The worker agent will create job-user on first job. Re-run this script or add it to fleet host config."
+fi
+
+echo "[$(date)] Done."

--- a/host_configuration_scripts/swap_for_smf/README.md
+++ b/host_configuration_scripts/swap_for_smf/README.md
@@ -1,0 +1,31 @@
+# Enable Swap on Service Managed Fleet Workers
+
+Create and enable a swap file on Linux service managed fleet workers. Useful for memory-intensive workloads jobs that temporarily exceed physical RAM. For example ComfyUI.
+
+## Why Swap?
+
+Some workloads need to memory-map large files through CPU RAM before loading them onto the GPU. For example, loading a 16GB diffusion model on a g6.xlarge instance (16GB RAM) can OOM-kill the process without swap. A swap file provides overflow capacity so these loads succeed.
+
+## What It Does
+
+1. Creates a 32GB swap file at `/swapfile` (skips if one already exists)
+2. Enables the swap file immediately
+3. Adds an `/etc/fstab` entry so swap persists across reboots
+
+## Configuration
+
+Edit `linux.sh` to change the swap size:
+
+```bash
+SWAP_SIZE="32G"  # Adjust as needed
+```
+
+## Usage
+
+1. Open the AWS Deadline Cloud console
+2. Navigate to your fleet
+3. Go to the "Host configuration" section
+4. Copy and paste the contents of `linux.sh` into the script field
+5. Save the configuration
+
+New fleet instances will automatically create and enable swap on startup.

--- a/host_configuration_scripts/swap_for_smf/linux.sh
+++ b/host_configuration_scripts/swap_for_smf/linux.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Enable swap on Deadline Cloud service managed fleet workers.
+# Run this as a host configuration script (runs as root).
+#
+# Useful for memory-intensive workloads (e.g. ComfyUI, large diffusion models)
+# that temporarily exceed physical RAM during model loading.
+
+set -e
+
+SWAP_SIZE="32G"
+
+echo "[$(date)] Configuring ${SWAP_SIZE} swap..."
+
+if [ -f /swapfile ]; then
+    echo "Swap file already exists."
+    swapon /swapfile 2>/dev/null || true
+else
+    echo "Creating ${SWAP_SIZE} swap file..."
+    fallocate -l "${SWAP_SIZE}" /swapfile
+    chmod 600 /swapfile
+    mkswap /swapfile
+    swapon /swapfile
+
+    # Persist across reboots
+    echo "/swapfile swap swap defaults 0 0" | tee -a /etc/fstab
+    echo "Swap file created and enabled."
+fi
+
+echo "Swap: $(free -h | grep Swap | awk '{print $2}')"
+echo "[$(date)] Swap configuration complete."


### PR DESCRIPTION
feat: host configuration examples for Docker + NVIDIA, sudo for job user, and swap for SMF

Fixes: *<insert link to GitHub issue here>*

### What was the problem/requirement? (What/Why)

There were no host configuration examples for common Linux GPU fleet setup tasks. Users setting up service managed fleets for containerized GPU workloads (e.g. ComfyUI, Stable Diffusion) had to figure out Docker + NVIDIA runtime installation, swap configuration, and job-user sudo access on their own.

### What was the solution? (How)

Added three new host configuration script examples:

- **docker_nvidia_container_toolkit** — Installs Docker and the NVIDIA Container Toolkit, configures the NVIDIA runtime and CDI spec, and adds `job-user` to the docker group. README includes a `docker run` example with GPU passthrough, host networking, and license environment variable forwarding.
- **sudo_for_job_user** — Grants `job-user` passwordless sudo via a sudoers.d drop-in. Includes security considerations in the README.
- **swap_for_smf** — Creates and enables a 32GB swap file. Useful for memory-intensive workloads like ComfyUI where large models are memory-mapped through CPU RAM before GPU load.

Also updated the root `host_configuration_scripts/README.md` with a table listing all available examples and their descriptions.

### What is the impact of this change?

No impact to existing examples. Adds new standalone host configuration scripts that users can copy into their fleet configuration.

### How was this change tested?

- Docker + NVIDIA Container Toolkit script tested on Amazon Linux 2023 g6.xlarge instances with Deadline Cloud GPU AMIs. Verified `docker run --runtime=nvidia --gpus all` successfully accesses the GPU.
- Swap script tested on Amazon Linux 2023 g6.xlarge (16GB RAM). Verified swap file creation, `swapon` activation, and persistence via `/etc/fstab`. Confirmed ComfyUI model loading succeeds with swap enabled where it previously OOM-killed without it.
- Sudo script tested on Amazon Linux 2023. Verified `/etc/sudoers.d/job-user` is created with correct permissions (440) and `job-user` can run `sudo` commands without a password prompt.

### Was this change documented?

- Each new example includes a README.md with usage instructions, prerequisites, and configuration details.
- The root `host_configuration_scripts/README.md` was updated with a table of all examples.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
