### PR TITLE
chore: Fix up Maya 2026 recipes for local rattler-build usage

### DIFF
--- a/conda_recipes/maya-2026/README.md
+++ b/conda_recipes/maya-2026/README.md
@@ -1,9 +1,5 @@
 # Maya 2026 conda build recipe
 
-## Requirements
-
-This recipe requires rattler-build version > 0.32.0 due to a bug fix for cleaning up .pyc files during the build process. Earlier versions may fail to build properly. See [rattler-build issue #1191](https://github.com/prefix-dev/rattler-build/issues/1191) for more details.
-
 ## Instructions for Maya plugin packages
 
 This Maya conda build recipe configures the `MAYA_MODULE_PATH` environment variable
@@ -16,7 +12,7 @@ package, place its `.mod` file in one of these so that Maya loads the plugin at 
 
 ## Download the archive file for Linux
 
-Download the Autodesk_Maya_2026_Linux_64bit.tgz full download file from Autodesk, and
+Download the Autodesk_Maya_2026_ML_Linux_64bit.tgz full download file from Autodesk, and
 place it in the `conda_recipes/archive_files` directory in your git clone of the
 [https://github.com/aws-deadline/deadline-cloud-samples](deadline-cloud-samples) repository for
 submitting package build jobs.

--- a/conda_recipes/maya-2026/deadline-cloud.yaml
+++ b/conda_recipes/maya-2026/deadline-cloud.yaml
@@ -2,8 +2,8 @@ condaPlatforms:
   - platform: linux-64
     defaultSubmit: true
     sourceArchiveFilename:
-    - Autodesk_Maya_2026_Linux_64bit.tgz
-    sourceDownloadInstructions: 'Download the Autodesk_Maya_2026_Linux_64bit.tgz full download file from Autodesk.'
+    - Autodesk_Maya_2026_ML_Linux_64bit.tgz
+    sourceDownloadInstructions: 'Download the Autodesk_Maya_2026_ML_Linux_64bit.tgz full download file from Autodesk.'
     buildTool: rattler-build
 jobParameters:
   # conda-forge is used to get patchelf on Linux

--- a/conda_recipes/maya-2026/recipe/build.sh
+++ b/conda_recipes/maya-2026/recipe/build.sh
@@ -28,7 +28,7 @@ ln -r -s "$INSTALL_DIR/bin/maya$MAYA_VERSION" "$INSTALL_DIR/bin/maya"
 mkdir -p "$SRC_DIR/download"
 cd "$SRC_DIR/download"
 dnf download --resolve -y freetype alsa-lib fontconfig harfbuzz libbrotli graphite2 \
-    libxkbfile xcb-util-cursor xcb-util-wm xcb-util-keysyms libxkbcommon-x11 \
+    libxkbfile xcb-util-wm xcb-util-keysyms libxkbcommon-x11 \
     libva libvdpau pciutils-libs
 
 for RPM_FILE in *.rpm; do
@@ -89,34 +89,17 @@ cat <<EOF > "$INSTALL_DIR"/AdlmThinClientCustomEnv.xml
 </ADLMCUSTOMENV>
 EOF
 
-# See https://docs.conda.io/projects/conda/en/latest/dev-guide/deep-dives/activation.html
-# for details on activation.
-
-# Activation scripts to set/unset environment variables
-mkdir -p "$PREFIX/etc/conda/activate.d"
-cat <<EOF > "$PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.sh"
-export MAYA_LOCATION="\$CONDA_PREFIX/$MAYA_ROOT"
-export MAYA_VERSION="$MAYA_VERSION"
-
-# Turn off the Maya application home for the render farm
-export MAYA_NO_HOME=1
-
-# Set the Maya module path to include the virtual environment equivalent of the default system module paths
-export MAYA_MODULE_PATH="\$CONDA_PREFIX/usr/autodesk/maya$MAYA_VERSION/modules:\$CONDA_PREFIX/usr/autodesk/modules/maya/$MAYA_VERSION:\$CONDA_PREFIX/usr/autodesk/modules/maya"
-
-# Set thin client mode to use the correct ProductInformation.pit file
-export AUTODESK_ADLM_THINCLIENT_ENV='$INSTALL_DIR/AdlmThinClientCustomEnv.xml'
-export MAYA_LEGACY_THINCLIENT=1
+# Set environment variables using the JSON env_vars.d mechanism.
+# See https://rattler-build.prefix.dev/latest/special_files/ for details.
+# This is more portable than activation scripts and works with pixi trampolines.
+mkdir -p "$PREFIX/etc/conda/env_vars.d"
+cat > "$PREFIX/etc/conda/env_vars.d/$PKG_NAME-$PKG_VERSION.json" << EOF
+{
+  "MAYA_LOCATION": "$PREFIX/$MAYA_ROOT",
+  "MAYA_VERSION": "$MAYA_VERSION",
+  "MAYA_NO_HOME": "1",
+  "MAYA_MODULE_PATH": "$PREFIX/usr/autodesk/maya$MAYA_VERSION/modules:$PREFIX/usr/autodesk/modules/maya/$MAYA_VERSION:$PREFIX/usr/autodesk/modules/maya",
+  "AUTODESK_ADLM_THINCLIENT_ENV": "$INSTALL_DIR/AdlmThinClientCustomEnv.xml",
+  "MAYA_LEGACY_THINCLIENT": "1"
+}
 EOF
-cat "$PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.sh"
-
-mkdir -p "$PREFIX/etc/conda/deactivate.d"
-cat <<EOF > "$PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.sh"
-unset MAYA_LEGACY_THINCLIENT
-unset AUTODESK_ADLM_THINCLIENT_ENV
-unset MAYA_MODULE_PATH
-unset MAYA_NO_HOME
-unset MAYA_VERSION
-unset MAYA_LOCATION
-EOF
-cat "$PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.sh"

--- a/conda_recipes/maya-2026/recipe/recipe.yaml
+++ b/conda_recipes/maya-2026/recipe/recipe.yaml
@@ -11,7 +11,7 @@ package:
   version: ${{ version }}
 
 source:
-  url: file://archive_files/Autodesk_Maya_{{ major_version }}_Linux_64bit.tgz
+  path: ../../archive_files/Autodesk_Maya_${{ major_version }}_ML_Linux_64bit.tgz
   sha256: d3e8cc63ea573383eb02046398a9f49c26cb55708eb8fb6266d04c46a5d6a48e
   target_directory: installer
 

--- a/conda_recipes/maya-mtoa-2026/deadline-cloud.yaml
+++ b/conda_recipes/maya-mtoa-2026/deadline-cloud.yaml
@@ -2,6 +2,6 @@ condaPlatforms:
   - platform: linux-64
     defaultSubmit: true
     sourceArchiveFilename:
-    - Autodesk_Maya_2026_Linux_64bit.tgz
-    sourceDownloadInstructions: 'Download the Autodesk_Maya_2026_Linux_64bit.tgz full download file from Autodesk.'
+    - Autodesk_Maya_2026_ML_Linux_64bit.tgz
+    sourceDownloadInstructions: 'Download the Autodesk_Maya_2026_ML_Linux_64bit.tgz full download file from Autodesk.'
     buildTool: rattler-build

--- a/conda_recipes/maya-mtoa-2026/recipe/build.sh
+++ b/conda_recipes/maya-mtoa-2026/recipe/build.sh
@@ -25,6 +25,11 @@ rm -r $PREFIX/$MTOA_ROOT/docs
 # to never use LD_LIBRARY_PATH in Conda environments.
 patchelf --add-rpath '$ORIGIN/../../maya2026/lib' $PREFIX/$MTOA_ROOT/bin/libai_renderview.so
 
+# Add RPATH for libraries in $MTOA_ROOT/procedurals to $MAYA_LOCATION/plug-ins/xgen/lib for libAdskSeExpr.so
+for file in "$PREFIX/$MTOA_ROOT/procedurals"/*.so; do
+    patchelf --set-rpath '$ORIGIN/../../maya2026/plug-ins/xgen/lib' "$file"
+done
+
 # Create symlinks for utilities allowing them to be run directly from the command line
 mkdir -p $PREFIX/bin
 ln -r -s $PREFIX/$MTOA_ROOT/bin/kick $PREFIX/bin/kick

--- a/conda_recipes/maya-mtoa-2026/recipe/recipe.yaml
+++ b/conda_recipes/maya-mtoa-2026/recipe/recipe.yaml
@@ -11,7 +11,7 @@ package:
   version: ${{ version }}
 
 source:
-  url: file://archive_files/Autodesk_Maya_${{ major_version }}_Linux_64bit.tgz
+  path: ../../archive_files/Autodesk_Maya_${{ major_version }}_ML_Linux_64bit.tgz
   sha256: d3e8cc63ea573383eb02046398a9f49c26cb55708eb8fb6266d04c46a5d6a48e
   target_directory: installer
 

--- a/job_bundles/turntable_with_maya_arnold/template.yaml
+++ b/job_bundles/turntable_with_maya_arnold/template.yaml
@@ -184,11 +184,22 @@ parameterDefinitions:
     - label: Maya Scene Files
       patterns: ["*.ma", "*.mb"]
 
+# Arnold
+- name: ErrorOnArnoldLicenseFail
+  description: When enabled, the render will fail if an Arnold license cannot be obtained instead of rendering with a watermark.
+  type: STRING
+  default: "true"
+  allowedValues: ["true", "false"]
+  userInterface:
+    control: CHECK_BOX
+    label: Error on Arnold License Fail
+    groupLabel: Advanced
+
 # Software Environment
 - name: CondaPackages
   type: STRING
   description: Choose which Conda packages to install for the render. Requires a conda queue environment to process the value.
-  default: maya>=2024 maya-mtoa maya-openjd=0.14 ffmpeg
+  default: maya>=2024 maya-mtoa maya-openjd=0.15 ffmpeg
   userInterface:
     # This parameter is for a queue environment, not used directly in the job,
     # so leave the GUI for the queue environment to display.
@@ -365,6 +376,7 @@ steps:
           output_file_prefix: '{{Param.SceneName}}'
           image_width: {{Param.ImageWidth}}
           image_height: {{Param.ImageHeight}}
+          error_on_arnold_license_fail: {{Param.ErrorOnArnoldLicenseFail}}
       actions:
         onEnter:
           command: maya-openjd


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

I tested the Maya 2026 sample recipe with local rattler-build, and found it needed tweaking to work.

### What was the solution? (How)

* Fix up the recipe, also switched it to use env_vars.d similar to the recent Blender recipe updates
* Updated the recipe to match the downloaded filename
* Also add an option in turntable_with_maya_arnold to allow watermark rendering when no license is available.
* Removed the reference to older rattler-build bug.

### What is the impact of this change?

The recipe works locally and on build farms.

### How was this change tested?

Tested the build on an Amazon Linux 2023 host, confirmed a local turntable render using it.

Tested the build to a Deadline Cloud build farm, confirmed a farm turntable render using it.

### Was this change documented?

N/A

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*