### PR TITLE
feat: Add scheduled standby worker count CloudFormation template

### DIFF
--- a/cloudformation/README.md
+++ b/cloudformation/README.md
@@ -31,6 +31,13 @@ The [budget_events_notification](notification_templates/budget_events_notificati
 to receive notifications via email and Slack when a budget threshold is reached in the aws.deadline service. It creates an SNS topic,
 an EventBridge rule, and a Chatbot configuration to send the notifications.
 
+## Scheduled standby workers
+
+The [fleet_standby_scheduling](farm_templates/fleet_standby_scheduling/) sample CloudFormation template schedules
+standby worker count changes on a Deadline Cloud fleet based on a time schedule. It sets a warm standby pool
+during business hours and resets it outside business hours to save cost. Works with any existing fleet created
+via the console, CLI, or CloudFormation.
+
 ## Customer-managed fleet health checks
 
 The [cmf_templates](farm_templates/cmf_templates/) collection includes a fleet health check CloudFormation template that sets up

--- a/cloudformation/farm_templates/fleet_standby_scheduling/README.md
+++ b/cloudformation/farm_templates/fleet_standby_scheduling/README.md
@@ -1,0 +1,87 @@
+# Scheduled Standby Workers for Deadline Cloud Fleets
+
+## Overview
+
+This CloudFormation template schedules [standby worker count](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/auto-scaling-configuration.html)
+changes on a Deadline Cloud fleet based on a time schedule. Standby workers are a warm pool of idle workers
+that can start processing jobs immediately without waiting for new instances to launch. By scheduling
+standby workers only during business hours, you reduce job start latency when your team is active
+while avoiding the cost of idle workers overnight and on weekends.
+
+For example, with the default settings this template sets the standby worker count to 2 at 8:00 AM UTC
+Monday through Friday, and resets it to 0 at 5:00 PM UTC.
+
+This template works with any existing Deadline Cloud fleet — whether it was created via the AWS console,
+CLI, or another CloudFormation template. It supports both
+[service-managed fleets](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/smf-manage.html) and
+[customer-managed fleets](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/manage-cmf.html).
+Use this sample as a starting point and modify it to fit your own scheduling and cost optimization needs.
+
+## Resources Created
+
+1. **Lambda Function** — Updates the fleet's standby worker count by calling the Deadline Cloud
+   `UpdateFleet` API. It reads the fleet's current configuration first to avoid overwriting other settings.
+2. **IAM Roles** — A Lambda execution role with `deadline:GetFleet` and `deadline:UpdateFleet` permissions
+   scoped to the specified fleet, and a scheduler role to invoke the Lambda.
+3. **EventBridge Schedules** — Two schedules that trigger the Lambda at the start and end of business hours.
+
+## Prerequisites
+
+1. An existing Deadline Cloud farm and fleet. The fleet can be service-managed or customer-managed.
+2. The Farm ID and Fleet ID. You can find these in the
+   [Deadline Cloud console](https://console.aws.amazon.com/deadlinecloud/home) or by using the AWS CLI:
+   ```
+   aws deadline list-farms
+   aws deadline list-fleets --farm-id <FARM_ID>
+   ```
+
+## Customization
+
+- To schedule a different time window, update the `BusinessHoursStartCron` and `BusinessHoursEndCron`
+  parameters. For example, to run every day (including weekends) from 9 AM to 6 PM Pacific time:
+  - `BusinessHoursStartCron`: `cron(0 9 * * ? *)`
+  - `BusinessHoursEndCron`: `cron(0 18 * * ? *)`
+  - `ScheduleTimezone`: `US/Pacific`
+- To schedule multiple fleets, deploy one stack per fleet.
+
+## Deployment
+
+### AWS Console
+
+1. Download the [deadline-cloud-standby-scheduling-template.yaml](deadline-cloud-standby-scheduling-template.yaml)
+   CloudFormation template.
+2. From the [CloudFormation console](https://console.aws.amazon.com/cloudformation/), choose
+   Create Stack > With new resources (standard).
+3. Upload the template file and click Next.
+4. Enter a stack name (e.g. `StandbyScheduling`), your Farm ID, Fleet ID, and adjust the schedule
+   parameters as needed:
+   - **BusinessHoursStandbyWorkerCount** — Workers to keep warm during business hours (default: 2).
+   - **OffHoursStandbyWorkerCount** — Workers to keep warm outside business hours (default: 0).
+   - **BusinessHoursStartCron / BusinessHoursEndCron** — Cron expressions for the schedule.
+     Default is weekdays 8 AM–5 PM. Uses
+     [EventBridge Scheduler cron syntax](https://docs.aws.amazon.com/scheduler/latest/UserGuide/schedule-types.html#cron-based).
+   - **ScheduleTimezone** — Timezone for the cron expressions (default: UTC). Accepts any
+     [IANA timezone name](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) such as
+     `US/Pacific` or `Europe/London`.
+5. Click Next, acknowledge IAM resource creation, and create the stack.
+
+### AWS CLI
+
+```bash
+aws cloudformation create-stack \
+  --stack-name StandbyScheduling \
+  --template-body file://deadline-cloud-standby-scheduling-template.yaml \
+  --capabilities CAPABILITY_IAM \
+  --parameters \
+    ParameterKey=FarmId,ParameterValue=farm-0123456789abcdef0123456789abcdef \
+    ParameterKey=FleetId,ParameterValue=fleet-0123456789abcdef0123456789abcdef
+```
+
+## Cleanup
+
+```bash
+aws cloudformation delete-stack --stack-name StandbyScheduling
+```
+
+Deleting the stack removes the Lambda, IAM roles, and schedules. It does not modify your fleet's
+current standby worker count — the fleet retains whatever value was last set.

--- a/cloudformation/farm_templates/fleet_standby_scheduling/deadline-cloud-standby-scheduling-template.yaml
+++ b/cloudformation/farm_templates/fleet_standby_scheduling/deadline-cloud-standby-scheduling-template.yaml
@@ -1,0 +1,212 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: >
+  Schedule standby worker count on a Deadline Cloud fleet. Sets a warm standby pool during
+  business hours and resets it outside business hours to save cost. Works with any existing
+  fleet created via the console, CLI, or CloudFormation.
+
+Parameters:
+  FarmId:
+    Type: String
+    Description: Deadline Cloud Farm ID (e.g. farm-0123456789abcdef0123456789abcdef).
+    AllowedPattern: ^farm-[0-9a-f]{32}$
+  FleetId:
+    Type: String
+    Description: Deadline Cloud Fleet ID (e.g. fleet-0123456789abcdef0123456789abcdef).
+    AllowedPattern: ^fleet-[0-9a-f]{32}$
+  BusinessHoursStandbyWorkerCount:
+    Type: Number
+    Description: Standby worker count to set during business hours.
+    Default: 2
+    MinValue: 0
+  OffHoursStandbyWorkerCount:
+    Type: Number
+    Description: Standby worker count to set outside business hours.
+    Default: 0
+    MinValue: 0
+  BusinessHoursStartCron:
+    Type: String
+    Description: >
+      Cron expression for when business hours start.
+      Default is 8:00 AM Monday through Friday.
+      See the ScheduleTimezone parameter to change the time zone (default: UTC).
+    Default: "cron(0 8 ? * MON-FRI *)"
+  BusinessHoursEndCron:
+    Type: String
+    Description: >
+      Cron expression for when business hours end.
+      Default is 5:00 PM Monday through Friday.
+      See the ScheduleTimezone parameter to change the time zone (default: UTC).
+    Default: "cron(0 17 ? * MON-FRI *)"
+  ScheduleTimezone:
+    Type: String
+    Description: Timezone for the schedule expressions (e.g. UTC, US/Pacific, Europe/London).
+    Default: UTC
+
+Resources:
+  StandbySchedulerLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: !Sub ${AWS::StackName}-StandbyScheduler
+      Description: Updates standby worker count on a Deadline Cloud fleet.
+      Handler: index.handler
+      Role: !GetAtt LambdaRole.Arn
+      Timeout: 30
+      Runtime: python3.13
+      Code:
+        ZipFile: |
+          import os
+          import sys
+          import subprocess
+          import json
+          import logging
+
+          # Install the latest boto3 so that the autoScalingConfiguration API model is available.
+          # This is needed when the Lambda runtime's bundled SDK does not yet include it.
+          os.makedirs("/tmp/site-packages", exist_ok=True)
+          sys.path.insert(0, "/tmp/site-packages")
+          subprocess.check_call([sys.executable, "-m", "pip", "install", "--upgrade", "--target", "/tmp/site-packages", "boto3"])
+
+          import boto3
+
+          logger = logging.getLogger()
+          logger.setLevel(logging.INFO)
+
+          deadline = boto3.client("deadline")
+
+          def handler(event, context):
+              farm_id = event["FarmId"]
+              fleet_id = event["FleetId"]
+              standby_count = event["StandbyWorkerCount"]
+
+              logger.info(f"Setting standbyWorkerCount={standby_count} on {fleet_id}")
+
+              try:
+                  fleet = deadline.get_fleet(farmId=farm_id, fleetId=fleet_id)
+
+                  # Determine fleet type and build the configuration update
+                  config = fleet["configuration"]
+                  if "serviceManagedEc2" in config:
+                      sme = config["serviceManagedEc2"]
+                      auto_scaling = sme.get("autoScalingConfiguration", {})
+                      auto_scaling["standbyWorkerCount"] = standby_count
+                      sme["autoScalingConfiguration"] = auto_scaling
+                      update_config = {"serviceManagedEc2": sme}
+                  elif "customerManaged" in config:
+                      cm = config["customerManaged"]
+                      auto_scaling = cm.get("autoScalingConfiguration", {})
+                      auto_scaling["standbyWorkerCount"] = standby_count
+                      cm["autoScalingConfiguration"] = auto_scaling
+                      update_config = {"customerManaged": cm}
+                  else:
+                      raise ValueError(f"Unsupported fleet configuration type: {list(config.keys())}")
+
+                  deadline.update_fleet(
+                      farmId=farm_id,
+                      fleetId=fleet_id,
+                      configuration=update_config,
+                  )
+
+                  logger.info(f"Successfully set standbyWorkerCount={standby_count}")
+                  return {"standbyWorkerCount": standby_count}
+
+              except Exception as e:
+                  logger.exception(f"Failed to update standby worker count: {e}")
+                  raise
+
+  LambdaRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: !Sub lambda.${AWS::URLSuffix}
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+        - PolicyName: DeadlineFleetAccess
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - deadline:GetFleet
+                  - deadline:UpdateFleet
+                Resource:
+                  - !Sub arn:${AWS::Partition}:deadline:${AWS::Region}:${AWS::AccountId}:farm/${FarmId}/fleet/${FleetId}
+
+  SchedulerRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: !Sub scheduler.${AWS::URLSuffix}
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: InvokeLambda
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action: lambda:InvokeFunction
+                Resource: !GetAtt StandbySchedulerLambda.Arn
+
+  BusinessHoursStartSchedule:
+    Type: AWS::Scheduler::Schedule
+    Properties:
+      Name: !Sub ${AWS::StackName}-BusinessHoursStart
+      Description: Set standby worker count at the start of business hours.
+      ScheduleExpression: !Ref BusinessHoursStartCron
+      ScheduleExpressionTimezone: !Ref ScheduleTimezone
+      FlexibleTimeWindow:
+        Mode: "OFF"
+      State: ENABLED
+      Target:
+        Arn: !GetAtt StandbySchedulerLambda.Arn
+        RoleArn: !GetAtt SchedulerRole.Arn
+        Input: !Sub |
+          {
+            "FarmId": "${FarmId}",
+            "FleetId": "${FleetId}",
+            "StandbyWorkerCount": ${BusinessHoursStandbyWorkerCount}
+          }
+        RetryPolicy:
+          MaximumRetryAttempts: 3
+
+  BusinessHoursEndSchedule:
+    Type: AWS::Scheduler::Schedule
+    Properties:
+      Name: !Sub ${AWS::StackName}-BusinessHoursEnd
+      Description: Reset standby worker count at the end of business hours.
+      ScheduleExpression: !Ref BusinessHoursEndCron
+      ScheduleExpressionTimezone: !Ref ScheduleTimezone
+      FlexibleTimeWindow:
+        Mode: "OFF"
+      State: ENABLED
+      Target:
+        Arn: !GetAtt StandbySchedulerLambda.Arn
+        RoleArn: !GetAtt SchedulerRole.Arn
+        Input: !Sub |
+          {
+            "FarmId": "${FarmId}",
+            "FleetId": "${FleetId}",
+            "StandbyWorkerCount": ${OffHoursStandbyWorkerCount}
+          }
+        RetryPolicy:
+          MaximumRetryAttempts: 3
+
+Outputs:
+  LambdaFunctionArn:
+    Description: ARN of the standby scheduler Lambda function
+    Value: !GetAtt StandbySchedulerLambda.Arn
+  BusinessHoursStartScheduleArn:
+    Description: ARN of the business hours start schedule
+    Value: !GetAtt BusinessHoursStartSchedule.Arn
+  BusinessHoursEndScheduleArn:
+    Description: ARN of the business hours end schedule
+    Value: !GetAtt BusinessHoursEndSchedule.Arn


### PR DESCRIPTION

### What was the problem/requirement? (What/Why)

Customers want to reduce costs by only maintaining standby workers during business hours. Standby workers provide a warm pool that eliminates job start latency, but they incur charges even when idle. There was no sample showing how to schedule standby worker count changes on a Deadline Cloud fleet based on a time-of-day schedule.
### What was the solution? (How)

Added a new CloudFormation template (fleet_standby_scheduling) that uses EventBridge Scheduler and a Lambda function to update a fleet's standbyWorkerCount on a cron schedule. By default, it sets standby workers to 2 at 8:00 AM UTC Mon–Fri and resets to 0 at 5:00 PM UTC.

Key design decisions:

-  The template takes FarmId and FleetId as parameters rather than creating the fleet itself, so it works as an add-on for fleets created via the console, CLI, or CloudFormation.
-  The Lambda calls GetFleet first to read the current configuration, then merges in the standbyWorkerCount change via UpdateFleet. This avoids overwriting other fleet settings.
-  Supports both service-managed and customer-managed fleets.
-   Schedule timezone is configurable (defaults to UTC).

### What is the impact of this change?

New sample template only — no changes to existing templates. Adds:

-   cloudformation/farm_templates/fleet_standby_scheduling/deadline-cloud-standby-scheduling-template.yaml
-   cloudformation/farm_templates/fleet_standby_scheduling/README.md
-   Updated cloudformation/README.md with a link to the new template

### How was this change tested?

Deployed the template to a test AWS account with one-time cron schedules to verify end-to-end behavior:

- Created a test farm and service-managed fleet.
- Deployed the stack with start schedule at 21:41 UTC and end schedule at 21:49 UTC.
- Verified the start schedule fired and set standbyWorkerCount to 2:

Note: The Lambda runtime's bundled boto3 may not yet include the autoScalingConfiguration API model. A troubleshooting section in the README documents how to add a boto3 Lambda layer to resolve this.
### Was this change documented?

Yes. A README is included with:

-  Overview explaining the use case and that it supports both SMF and CMF fleets
-  Prerequisites
-  Deployment instructions (console and CLI)
-  Customization examples (different schedules, timezones)
-  Cleanup instructions
-  Troubleshooting section for the boto3 Lambda layer workaround