### PR TITLE
feat: Add Linux overcommit override script for SMF workers

### DIFF
--- a/host_configuration_scripts/overcommit_override_for_smf/README.md
+++ b/host_configuration_scripts/overcommit_override_for_smf/README.md
@@ -1,0 +1,36 @@
+# Override Memory Overcommit on Service Managed Fleet Workers
+
+Override the default `vm.overcommit_memory=2` (strict accounting) on Linux service managed fleet workers. Useful for memory-intensive workloads with large job attachments that cause malloc failures despite free physical RAM.
+
+## Why Override Overcommit?
+
+The default SMF worker AMI sets `vm.overcommit_memory=2`, which enforces: `CommitLimit = swap + RAM`. With 0 swap, the CommitLimit equals total RAM. Workloads with large job attachments (e.g. 134 GB of Blender scene files) can inflate committed memory beyond this limit, causing malloc failures even when 75%+ of physical RAM is free.
+
+Setting `vm.overcommit_memory=1` switches to heuristic overcommit, allowing allocations as long as physical RAM is available. The trade-off is that if a workload genuinely exceeds physical RAM, the OOM killer will terminate a process instead of returning a clean malloc failure.
+
+## What It Does
+
+1. Sets `vm.overcommit_memory=1` immediately via `sysctl`
+2. Persists the setting to `/etc/sysctl.d/99-overcommit.conf` for reboots
+
+## Configuration
+
+Edit `linux.sh` to change the overcommit mode:
+
+```
+OVERCOMMIT_MODE="1"  # 0=heuristic, 1=always allow, 2=strict (default on SMF)
+```
+
+## Usage
+
+1. Open the AWS Deadline Cloud console
+2. Navigate to your fleet
+3. Go to the "Host configuration" section
+4. Copy and paste the contents of `linux.sh` into the script field
+5. Save the configuration
+
+New fleet instances will automatically apply the overcommit override on startup.
+
+## Alternative: Swap
+
+If you prefer to keep `vm.overcommit_memory=2`, you can add swap instead to increase the CommitLimit. See [swap_for_smf](../swap_for_smf). Note that the EBS volume must be large enough to hold the swap file alongside job attachments.

--- a/host_configuration_scripts/overcommit_override_for_smf/linux.sh
+++ b/host_configuration_scripts/overcommit_override_for_smf/linux.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Override memory overcommit on Deadline Cloud service managed fleet workers.
+# Run this as a host configuration script (runs as root).
+#
+# The default SMF worker AMI sets vm.overcommit_memory=2 (strict accounting),
+# which limits total memory reservations to: CommitLimit = swap + RAM.
+# This can cause malloc failures for memory-intensive workloads with large
+# job attachments (e.g. Blender, Houdini) even when physical RAM is free.
+#
+# This script switches to heuristic overcommit (vm.overcommit_memory=1),
+# which allows allocations as long as physical RAM is available.
+
+set -e
+
+OVERCOMMIT_MODE="1"  # 0=heuristic, 1=always allow, 2=strict (default on SMF)
+
+echo "[$(date)] Configuring vm.overcommit_memory=${OVERCOMMIT_MODE}..."
+
+sysctl -w vm.overcommit_memory=${OVERCOMMIT_MODE}
+
+# Persist across reboots (SMF instances are currently ephemeral and don't reboot,
+# but this ensures the setting survives if worker restart becomes available)
+if ! grep -q "vm.overcommit_memory" /etc/sysctl.d/99-overcommit.conf 2>/dev/null; then
+    echo "vm.overcommit_memory=${OVERCOMMIT_MODE}" | tee /etc/sysctl.d/99-overcommit.conf
+    echo "Persisted to /etc/sysctl.d/99-overcommit.conf"
+fi
+
+echo "vm.overcommit_memory=$(sysctl -n vm.overcommit_memory)"
+echo "[$(date)] Overcommit configuration complete."


### PR DESCRIPTION
Add host configuration script to override vm.overcommit_memory=2 (default on SMF worker AMI) to vm.overcommit_memory=1. This prevents malloc failures for memory-intensive workloads with large job attachments (
e.g. Blender, Houdini) where strict commit accounting causes allocation failures despite free physical RAM.

Fixes: <insert link to GitHub issue here>

### What was the problem/requirement? (What/Why)

The default SMF worker AMI sets vm.overcommit_memory=2 (strict commit accounting). With this setting, the kernel enforces CommitLimit = swap + RAM. With 0 swap, the CommitLimit equals total RAM. Memory-intensive
workloads with large job attachments (e.g. 134 GB of Blender scene files) inflate committed memory beyond this limit, causing malloc failures even when 75%+ of physical RAM is free. In the observed case, 
Blender consistently crashed at ~42 GiB on a 128 GiB instance with most RAM unused.

### What was the solution? (How)

A host configuration script that sets vm.overcommit_memory=1 via sysctl -w at boot. This switches to heuristic overcommit, allowing allocations as long as physical RAM is available. The setting is also persisted
to /etc/sysctl.d/99-overcommit.conf for future-proofing if worker restart becomes available.

### What is the impact of this change?

- Workloads with large job attachments can use all available physical RAM instead of being limited by strict commit accounting
- Trade-off: if a workload genuinely exceeds physical RAM, the OOM killer will terminate a process instead of returning a clean malloc failure
- No impact on workloads that don't approach the memory limit

### How was this change tested?

1. Deployed the HC script to an SMF fleet via the Deadline Cloud console
2. Verified from worker agent log that the script ran successfully (exit code 0) and vm.overcommit_memory=1 was applied:
[Tue Mar 31 23:17:09 UTC 2026] Configuring vm.overcommit_memory=1...
vm.overcommit_memory = 1
Persisted to /etc/sysctl.d/99-overcommit.conf
vm.overcommit_memory=1
[Tue Mar 31 23:17:09 UTC 2026] Overcommit configuration complete.
--------- Finished running Host Configuration Script, exit code: 0 ---------

3. Submitted a Blender job (134 GB attachments, 5325×2808, Cycles) that previously crashed at ~42 GiB — rendered successfully past the barrier

### Was this change documented?

Yes, a README.md is included with the script explaining the problem, what the script does, configuration options, usage instructions, and a link to the swap alternative.

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
[ZainsADCFarm_worker-62dd9e332bc341d099b619ddd7e4a223.log](https://github.com/user-attachments/files/26392016/ZainsADCFarm_worker-62dd9e332bc341d099b619ddd7e4a223.log)
