### PR TITLE
feat: support Blender 5.1 example

### DIFF
--- a/conda_recipes/blender-5.1/README.md
+++ b/conda_recipes/blender-5.1/README.md
@@ -1,0 +1,92 @@
+# Blender 5.1 Conda Recipe for AWS Deadline Cloud
+
+This directory contains a [rattler-build](https://prefix-dev.github.io/rattler-build/) recipe
+for packaging [Blender 5.1](https://www.blender.org/) for use with AWS Deadline Cloud.
+
+## Package Information
+
+- **Application**: Blender 5.1.1
+- **Platforms**: Linux 64-bit (linux-64), Windows 64-bit (win-64)
+- **Source**: [blender.org/release/Blender5.1](https://download.blender.org/release/Blender5.1/)
+- **License**: GPL-3.0-or-later
+- **Build Tool**: rattler-build
+
+## Building the Package
+
+### Local build and test
+
+Build and publish to a local filesystem channel:
+
+```bash
+cd conda_recipes
+rattler-build publish blender-5.1/recipe/recipe.yaml \
+    --to file://$HOME/my-conda-channel \
+    --build-number=+1
+```
+
+### Submit a build job to Deadline Cloud
+
+From the `conda_recipes` directory:
+
+```bash
+# Build for Linux (default)
+./submit-package-job blender-5.1
+
+# Build for a specific platform
+./submit-package-job blender-5.1 -p linux-64
+
+# Build for all platforms
+./submit-package-job blender-5.1 --all-platforms
+
+# Submit to a specific queue
+./submit-package-job blender-5.1 -q "My Package Build Queue"
+
+# Build to a different S3 channel
+./submit-package-job blender-5.1 --s3-channel MyChannel
+```
+
+## Testing with a Render Job
+
+### Local test with openjd-cli
+
+Install the CLI if you haven't already: `pip install openjd-cli`
+
+From the `job_bundles` directory:
+
+```bash
+openjd run blender_render/template.yaml \
+    --environment ../queue_environments/conda_queue_env_pyrattler.yaml \
+    -p CondaPackages=blender=5.1 \
+    -p CondaChannels=file://$HOME/my-conda-channel \
+    -p BlenderSceneFile=/path/to/scene.blend \
+    -p Frames=1
+```
+
+### Submit a render job to Deadline Cloud
+
+```bash
+deadline bundle submit blender_render \
+    -p CondaPackages=blender=5.1 \
+    -p BlenderSceneFile=/path/to/scene.blend \
+    -p Frames=1
+```
+
+Use the Deadline Cloud monitor to track progress. Select the task and choose
+**View logs** > **Launch Conda session** to verify the package was found.
+
+## Recipe Structure
+
+```
+blender-5.1/
+├── README.md               # This file
+├── deadline-cloud.yaml     # Deadline Cloud build job metadata
+└── recipe/
+    ├── recipe.yaml         # rattler-build package recipe
+    ├── build.sh            # Linux build script
+    └── build_win.sh        # Windows build script
+```
+
+## License
+
+This recipe is provided under the same license as the deadline-cloud-samples repository.
+Blender itself is licensed under [GPL-3.0-or-later](https://www.blender.org/about/license/).

--- a/conda_recipes/blender-5.1/deadline-cloud.yaml
+++ b/conda_recipes/blender-5.1/deadline-cloud.yaml
@@ -1,0 +1,11 @@
+condaPlatforms:
+  - platform: linux-64
+    defaultSubmit: true
+    sourceArchiveFilename: blender-5.1.1-linux-x64.tar.xz
+    sourceDownloadInstructions: 'Run "curl -LO https://download.blender.org/release/Blender5.1/blender-5.1.1-linux-x64.tar.xz --output-dir archive_files"'
+    buildTool: rattler-build
+  - platform: win-64
+    defaultSubmit: false
+    sourceArchiveFilename: blender-5.1.1-windows-x64.zip
+    sourceDownloadInstructions: 'Run "curl -LO https://download.blender.org/release/Blender5.1/blender-5.1.1-windows-x64.zip --output-dir archive_files"'
+    buildTool: rattler-build

--- a/conda_recipes/blender-5.1/recipe/build.sh
+++ b/conda_recipes/blender-5.1/recipe/build.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+set -xeuo pipefail
+
+# Copy the Blender installation into the prefix
+mkdir -p $PREFIX/opt
+cp -r $SRC_DIR/blender $PREFIX/opt/
+
+# The version without the build number
+BLENDER_VERSION=${PKG_VERSION%.*}
+
+# Create symlinks to the Blender commands
+mkdir -p $PREFIX/bin
+for BINARY in blender blender-launcher blender-softwaregl blender-thumbnailer; do
+    ln -r -s $PREFIX/opt/blender/$BINARY $PREFIX/bin/$BINARY
+done
+
+# Set environment variables using the JSON env_vars.d mechanism.
+# See https://rattler-build.prefix.dev/latest/special_files/ for details.
+# This is more portable than activation scripts and works with pixi trampolines.
+mkdir -p $PREFIX/etc/conda/env_vars.d
+cat > $PREFIX/etc/conda/env_vars.d/$PKG_NAME-$PKG_VERSION.json << EOF
+{
+  "BLENDER_LOCATION": "$PREFIX/opt/blender",
+  "BLENDER_VERSION": "$BLENDER_VERSION",
+  "BLENDER_LIBRARY_PATH": "$PREFIX/opt/blender/lib",
+  "BLENDER_SCRIPTS_PATH": "$PREFIX/opt/blender/$BLENDER_VERSION/scripts",
+  "BLENDER_PYTHON_PATH": "$PREFIX/opt/blender/$BLENDER_VERSION/python",
+  "BLENDER_DATAFILES_PATH": "$PREFIX/opt/blender/$BLENDER_VERSION/datafiles"
+}
+EOF

--- a/conda_recipes/blender-5.1/recipe/build_win.sh
+++ b/conda_recipes/blender-5.1/recipe/build_win.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+set -xeuo pipefail
+
+# Copy the Blender installation into the prefix
+mkdir -p $PREFIX/opt
+cp -r $SRC_DIR/blender $PREFIX/opt/
+
+# The version without the build number
+BLENDER_VERSION=${PKG_VERSION%.*}
+
+# Set environment variables using the JSON env_vars.d mechanism.
+# See https://rattler-build.prefix.dev/latest/special_files/ for details.
+# This is more portable than activation scripts and works with pixi trampolines.
+mkdir -p $PREFIX/etc/conda/env_vars.d
+cat > $PREFIX/etc/conda/env_vars.d/$PKG_NAME-$PKG_VERSION.json << EOF
+{
+  "BLENDER_LOCATION": "$PREFIX/opt/blender",
+  "BLENDER_VERSION": "$BLENDER_VERSION",
+  "BLENDER_LIBRARY_PATH": "$PREFIX/opt/blender/lib",
+  "BLENDER_SCRIPTS_PATH": "$PREFIX/opt/blender/$BLENDER_VERSION/scripts",
+  "BLENDER_PYTHON_PATH": "$PREFIX/opt/blender/$BLENDER_VERSION/python",
+  "BLENDER_DATAFILES_PATH": "$PREFIX/opt/blender/$BLENDER_VERSION/datafiles"
+}
+EOF
+cat $PREFIX/etc/conda/env_vars.d/$PKG_NAME-$PKG_VERSION.json
+
+# Add blender to PATH via activation scripts.
+# The Deadline Cloud sample queue environments use bash to activate environments
+# on Windows, so we produce both .bat and .sh files.
+mkdir -p $PREFIX/etc/conda/activate.d
+mkdir -p $PREFIX/etc/conda/deactivate.d
+
+cat <<EOF > "$PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.bat"
+set "PATH=$PREFIX/opt/blender;%PATH%"
+EOF
+cat "$PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.bat"
+
+cat <<EOF > $PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.sh
+export PATH="\$(cygpath '$PREFIX/opt/blender'):\$PATH"
+EOF
+cat $PREFIX/etc/conda/activate.d/$PKG_NAME-$PKG_VERSION-vars.sh
+
+cat <<EOF > "$PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.bat"
+set "PATH=%PATH:$PREFIX/opt/blender;=%"
+EOF
+cat "$PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.bat"
+
+cat <<EOF > $PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.sh
+export PATH="\${PATH/\$(cygpath '$PREFIX/opt/blender'):/}"
+EOF
+cat $PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.sh

--- a/conda_recipes/blender-5.1/recipe/recipe.yaml
+++ b/conda_recipes/blender-5.1/recipe/recipe.yaml
@@ -1,0 +1,52 @@
+# Recipe in rattler-build format.
+# See https://prefix-dev.github.io/rattler-build/latest/
+
+context:
+  version: "5.1.1"
+  major_minor_version: "5.1"
+
+package:
+  name: blender
+  version: ${{ version }}
+
+source:
+  - if: linux
+    then:
+      url: https://download.blender.org/release/Blender${{ major_minor_version }}/blender-${{ version }}-linux-x64.tar.xz
+      sha256: 6f9fff89fef154ef7974d1a1c4b916ab4bc1f5618bcb48d5befee1bd0a7c7f2a
+      target_directory: blender
+  - if: win
+    then:
+      url: https://download.blender.org/release/Blender${{ major_minor_version }}/blender-${{ version }}-windows-x64.zip
+      sha256: 307123caa3bad0c1d04ec373a2f22f622c403eecb34b9c646ede104906b04ced
+      target_directory: blender
+
+build:
+  number: 0
+  script:
+    - if: unix
+      then:
+        - bash $RECIPE_DIR/build.sh
+    - if: win
+      then:
+        - bash %RECIPE_DIR%\build_win.sh
+  # These build options for repackaging an application
+  # https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html
+  prefix_detection:
+    ignore_binary_files: True
+  dynamic_linking:
+    binary_relocation: False
+    missing_dso_allowlist:
+    - "**"
+
+tests:
+  - script:
+    - blender -h
+
+about:
+  homepage: https://www.blender.org/
+  license: GPL-3.0-or-later
+  summary: >
+    Blender is the free and open source 3D creation suite. It supports the entirety of
+    the 3D pipeline—modeling, rigging, animation, simulation, rendering, compositing
+    and motion tracking, even video editing and game creation.

--- a/job_bundles/blender_render/template.yaml
+++ b/job_bundles/blender_render/template.yaml
@@ -54,6 +54,30 @@ parameterDefinitions:
   description: Choose the file format to render as.
   default: JPEG
   allowedValues: [TGA, RAWTGA, JPEG, IRIS, IRIZ, PNG, HDR, TIFF, OPEN_EXR, OPEN_EXR_MULTILAYER, CINEON, DPX, DDS, JP2, WEBP]
+- name: ResolutionX
+  type: INT
+  userInterface:
+    control: SPIN_BOX
+    label: Resolution X
+    groupLabel: Render Parameters
+  description: Override the render resolution width. Set to 0 to use the scene default.
+  default: 0
+- name: ResolutionY
+  type: INT
+  userInterface:
+    control: SPIN_BOX
+    label: Resolution Y
+    groupLabel: Render Parameters
+  description: Override the render resolution height. Set to 0 to use the scene default.
+  default: 0
+- name: Samples
+  type: INT
+  userInterface:
+    control: SPIN_BOX
+    label: Render Samples
+    groupLabel: Render Parameters
+  description: Override the number of render samples (Cycles/EEVEE). Set to 0 to use the scene default.
+  default: 0
 
 # Software Environment
 - name: CondaPackages
@@ -98,8 +122,27 @@ steps:
 
           mkdir -p '{{Param.OutputDir}}'
 
+          # Build a Python expression to apply any overrides
+          PYTHON_OVERRIDES=""
+          if [ "{{Param.ResolutionX}}" -gt 0 ] 2>/dev/null && [ "{{Param.ResolutionY}}" -gt 0 ] 2>/dev/null; then
+            PYTHON_OVERRIDES="${PYTHON_OVERRIDES}bpy.context.scene.render.resolution_x={{Param.ResolutionX}}; "
+            PYTHON_OVERRIDES="${PYTHON_OVERRIDES}bpy.context.scene.render.resolution_y={{Param.ResolutionY}}; "
+            PYTHON_OVERRIDES="${PYTHON_OVERRIDES}bpy.context.scene.render.resolution_percentage=100; "
+          fi
+          if [ "{{Param.Samples}}" -gt 0 ] 2>/dev/null; then
+            PYTHON_OVERRIDES="${PYTHON_OVERRIDES}bpy.context.scene.cycles.samples={{Param.Samples}}; "
+            PYTHON_OVERRIDES="${PYTHON_OVERRIDES}bpy.context.scene.eevee.taa_render_samples={{Param.Samples}}; "
+            PYTHON_OVERRIDES="${PYTHON_OVERRIDES}bpy.context.scene.cycles.use_denoising=False; "
+          fi
+
+          OVERRIDE_ARGS=""
+          if [ -n "$PYTHON_OVERRIDES" ]; then
+            OVERRIDE_ARGS="--python-expr"
+          fi
+
           blender --background '{{Param.BlenderSceneFile}}' \
                   --render-output '{{Param.OutputDir}}/{{Param.OutputPattern}}' \
                   --render-format {{Param.Format}} \
                   --use-extension 1 \
+                  ${OVERRIDE_ARGS:+"$OVERRIDE_ARGS"} ${PYTHON_OVERRIDES:+"import bpy; $PYTHON_OVERRIDES"} \
                   --render-frame {{Task.Param.Frame}}


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Blender 5.1.1 was released on 2026-04-14 and there was no conda recipe in the samples repository for it. Customers using Deadline Cloud's service-managed fleet need an up-to-date recipe to render with Blender 5.1 on cloud workers. 

### What was the solution? (How)

1. Added a new `conda_recipes/blender-5.1/` recipe based on the existing blender-5.0 recipe, updated with Blender 5.1.1 source URLs and SHA256 hashes for both Linux and Windows platforms.
2. Added `ResolutionX`, `ResolutionY`, and `Samples` parameters to the `blender_render` job bundle template. All default to 0 (use scene defaults). When set to non-zero values, they override the scene's render resolution and sample count via `--python-expr`, enabling fast low-resolution test renders.

### What is the impact of this change?

- Customers can now build and use Blender 5.1.1 conda packages on Deadline Cloud service-managed fleets.
- The blender_render job bundle now supports resolution and sample overrides, useful for both local testing and production workflows where customers want to control quality/speed tradeoffs.
- The blender-builder skill provides a repeatable process for adding future Blender versions.

### How was this change tested?

- Built the blender-5.1 conda package using rattler-build inside an AL2023 Docker container (matching the SMF worker OS).
- Indexed the package into a local conda channel and verified it was discoverable via `conda search`.
- Created a conda environment with the package, verified `blender --version` returned 5.1.1 and all BLENDER_* environment variables were set correctly.
- Rendered a test frame (Blender 4.5 splash scene) at 640x480 with 8 Cycles samples directly inside the container — completed in ~6 seconds.
- Ran a full end-to-end test using `openjd run` with the `conda_queue_env_pyrattler.yaml` queue environment, the updated `blender_render` job bundle, and the new ResolutionX/ResolutionY/Samples parameters. The job completed successfully in ~43 seconds including environment setup, rendering at 640x480 with reduced samples.

### Was this change documented?

- `conda_recipes/blender-5.1/README.md` documents the recipe, build commands, and testing instructions.
- `conda_skills/blender-builder/SKILL.md` documents the full workflow for creating Blender recipes including Docker setup, headless X11/EGL dependencies, and common mistakes.

### Diff between 5.0 and 5.1 
```
> cat $PREFIX/etc/conda/deactivate.d/$PKG_NAME-$PKG_VERSION-vars.sh
diff -r '--exclude=.git' deadline-cloud-samples/conda_recipes/blender-5.0/recipe/recipe.yaml deadline-cloud-samples/conda_recipes/blender-5.1/recipe/recipe.yaml
5,6c5,6
<   version: "5.0.1"
<   major_minor_version: "5.0"
---
>   version: "5.1.1"
>   major_minor_version: "5.1"
16c16
<       sha256: 8019580ee1b7262e505f4196a00237ccf743c88d205b38d34201510676e60b09
---
>       sha256: 6f9fff89fef154ef7974d1a1c4b916ab4bc1f5618bcb48d5befee1bd0a7c7f2a
21c21
<       sha256: 921d77f6c505a35b2c2f6e67d4ad1c10b72418338ba0e0d3ea7f582a5e5fe46e
---
>       sha256: 307123caa3bad0c1d04ec373a2f22f622c403eecb34b9c646ede104906b04ced
(base) 
```
---
