### PR TITLE
feat: Add FFmpeg encode video job bundle sample

### DIFF
--- a/job_bundles/ffmpeg_encode_video/README.md
+++ b/job_bundles/ffmpeg_encode_video/README.md
@@ -1,0 +1,91 @@
+# FFmpeg Encode Video job bundle
+
+## Introduction
+
+This job takes a directory of sequentially numbered image files and encodes them into an MP4 video using FFmpeg. It is useful as a standalone utility for converting render output to video, or as a reference for adding a video encoding step to a multi-step render pipeline.
+
+## Features
+
+* Encodes numbered image sequences (PNG, EXR, JPEG, etc.) into H.264 MP4 video
+* Supports customizable frame rate, quality (CRF), and encoding speed presets
+* Uses `####` hash-mark patterns for input file naming, automatically converted to FFmpeg's printf-style `%04d` format
+* Works with job attachments or shared file systems
+* Produces broadcast-safe output with BT.709 color space and `faststart` for web streaming
+
+## Prerequisites
+
+The job needs FFmpeg to run. On Deadline Cloud service-managed fleets, use `conda-forge` as the `CondaChannels` parameter for a [conda queue environment](https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/provide-applications.html). FFmpeg is available from the [conda-forge](https://anaconda.org/conda-forge/ffmpeg) community channel.
+
+> **Note:** FFmpeg is **not** available from the `deadline-cloud` conda channel. You must use `conda-forge`.
+
+## Example submission
+
+### GUI submission
+
+```
+deadline bundle gui-submit ffmpeg_encode_video/
+```
+
+### CLI submission
+
+```
+deadline bundle submit ffmpeg_encode_video/ \
+  -p InputDir=/path/to/frames \
+  -p InputFilePattern="render.####.png" \
+  -p StartFrame=1 \
+  -p EndFrame=250 \
+  -p OutputDir=/path/to/output \
+  -p OutputFileName="my_video.mp4"
+```
+
+### Using output from another job
+
+A common workflow is to render an image sequence with one job, then encode it to video with this job. If both jobs use job attachments, you can download the render output and include it as input to this job:
+
+```bash
+# Download rendered frames from a completed render job
+deadline job download-output \
+  --farm-id farm-XXXX --queue-id queue-XXXX --job-id job-XXXX
+
+# Submit the encode job pointing to the downloaded frames
+deadline bundle submit ffmpeg_encode_video/ \
+  -p InputDir=/path/to/downloaded/frames \
+  -p InputFilePattern="render.####.png" \
+  -p StartFrame=1 \
+  -p EndFrame=250
+```
+
+## Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| InputDir | *(required)* | Directory containing the numbered image sequence |
+| InputFilePattern | `output_####.png` | Filename pattern using `####` for frame numbers |
+| StartFrame | `1` | First frame number in the sequence |
+| EndFrame | `100` | Last frame number in the sequence |
+| OutputDir | `output` | Directory for the output video |
+| OutputFileName | `output.mp4` | Name of the output video file |
+| FrameRate | `24` | Playback frame rate in fps |
+| EncodingPreset | `slower` | FFmpeg x264 preset (ultrafast to veryslow) |
+| ConstantRateFactor | `18` | Quality setting: 0 = lossless, 51 = worst, 17-18 ≈ visually lossless |
+
+## Adding video encoding to a multi-step job
+
+This job bundle can serve as a reference for adding a video encoding step to an existing render job. The key elements to copy into your own job template are:
+
+1. The `CondaChannels` parameter set to `conda-forge` (or add `conda-forge` alongside your existing channels)
+2. The `EncodeVideo` step with its embedded bash script
+3. A `dependencies` entry so the encode step waits for rendering to complete:
+
+```yaml
+steps:
+  - name: Render
+    # ... your render step ...
+
+  - name: EncodeVideo
+    dependencies:
+      - dependsOn: Render
+    # ... encode step from this template ...
+```
+
+See the [turntable_with_maya_arnold](../turntable_with_maya_arnold) sample for a complete example of a multi-step pipeline that includes video encoding.

--- a/job_bundles/ffmpeg_encode_video/template.yaml
+++ b/job_bundles/ffmpeg_encode_video/template.yaml
@@ -1,0 +1,186 @@
+specificationVersion: jobtemplate-2023-09
+name: FFmpeg Encode Video
+description: |
+  Encodes a numbered image sequence into a video file using FFmpeg.
+
+  This job is useful as a standalone utility or as a post-render step
+  in a pipeline. It takes a directory of sequentially numbered image
+  files (e.g. render.0001.png, render.0002.png, ...) and produces an
+  MP4 video using the H.264 codec.
+
+  The job needs FFmpeg to run. On Deadline Cloud service-managed fleets,
+  you can use "conda-forge" as the CondaChannels parameter for a conda
+  queue environment.
+
+parameterDefinitions:
+  # Input
+  - name: InputDir
+    description: >
+      Choose the directory containing the input image sequence.
+      The images must be sequentially numbered (e.g. render.0001.png).
+    type: PATH
+    objectType: DIRECTORY
+    dataFlow: IN
+    userInterface:
+      control: CHOOSE_DIRECTORY
+      label: Input Image Directory
+      groupLabel: Input
+
+  - name: InputFilePattern
+    description: >
+      The FFmpeg input pattern matching the image filenames.
+      Use printf-style numbering, e.g. "render.%04d.png" for
+      render.0001.png, render.0002.png, etc.
+    type: STRING
+    default: "output_####.png"
+    userInterface:
+      control: LINE_EDIT
+      label: Input File Pattern
+      groupLabel: Input
+
+  - name: StartFrame
+    description: The first frame number in the image sequence.
+    type: INT
+    default: 1
+    userInterface:
+      control: SPIN_BOX
+      label: Start Frame
+      groupLabel: Input
+
+  - name: EndFrame
+    description: The last frame number in the image sequence.
+    type: INT
+    default: 100
+    userInterface:
+      control: SPIN_BOX
+      label: End Frame
+      groupLabel: Input
+
+  # Output
+  - name: OutputDir
+    description: Choose the directory for the output video file.
+    type: PATH
+    objectType: DIRECTORY
+    dataFlow: OUT
+    default: output
+    userInterface:
+      control: CHOOSE_DIRECTORY
+      label: Output Directory
+      groupLabel: Output
+
+  - name: OutputFileName
+    description: The name of the output video file.
+    type: STRING
+    default: "output.mp4"
+    userInterface:
+      control: LINE_EDIT
+      label: Output File Name
+      groupLabel: Output
+
+  # Encoding Settings
+  - name: FrameRate
+    description: The playback frame rate of the output video.
+    type: INT
+    default: 24
+    userInterface:
+      control: SPIN_BOX
+      label: Frame Rate (fps)
+      groupLabel: Encoding Settings
+
+  - name: EncodingPreset
+    description: >
+      Controls the encoding speed to compression ratio.
+      Slower presets produce smaller files at the cost of encoding time.
+    type: STRING
+    default: slower
+    userInterface:
+      control: DROPDOWN_LIST
+      label: Encoding Preset
+      groupLabel: Encoding Settings
+    allowedValues:
+      [ultrafast, superfast, veryfast, faster, fast, medium, slow, slower, veryslow]
+
+  - name: ConstantRateFactor
+    description: >
+      Controls output quality. Ranges from 0 (lossless) to 51 (worst).
+      Values of 17-18 are nearly visually lossless.
+    type: INT
+    default: 18
+    userInterface:
+      control: SPIN_BOX
+      label: Constant Rate Factor (CRF)
+      groupLabel: Encoding Settings
+    minValue: 0
+    maxValue: 51
+
+  # Software Environment
+  - name: CondaPackages
+    type: STRING
+    description: >
+      If you have a Queue Environment that creates a Conda environment
+      from a parameter called CondaPackages, this will set the default
+      packages to use for the job.
+    default: ffmpeg
+    userInterface:
+      control: HIDDEN
+
+  - name: CondaChannels
+    type: STRING
+    description: >
+      If you have a Queue Environment that creates a Conda environment
+      from a parameter called CondaChannels, this will set the channels
+      to use. FFmpeg is available from the conda-forge community channel.
+    default: conda-forge
+    userInterface:
+      control: HIDDEN
+
+steps:
+  - name: EncodeVideo
+    script:
+      actions:
+        onRun:
+          command: bash
+          args:
+            - "{{Task.File.Encode}}"
+      embeddedFiles:
+        - name: Encode
+          type: TEXT
+          runnable: true
+          data: |
+            #!/bin/env bash
+            set -xeuo pipefail
+
+            # Convert #### pattern to printf-style %04d pattern for FFmpeg
+            INPUT_PATTERN='{{Param.InputFilePattern}}'
+            FFMPEG_PATTERN=$(echo "$INPUT_PATTERN" | sed 's/####/%04d/g; s/###/%03d/g; s/##/%02d/g')
+            echo "Input pattern: $INPUT_PATTERN -> FFmpeg pattern: $FFMPEG_PATTERN"
+
+            echo "Input directory contents (first 10 files):"
+            ls '{{Param.InputDir}}/' | head -10
+            TOTAL_FILES=$(ls '{{Param.InputDir}}/' | wc -l)
+            echo "Total files in input directory: $TOTAL_FILES"
+
+            mkdir -p '{{Param.OutputDir}}'
+
+            FRAMES=$(({{Param.EndFrame}} - {{Param.StartFrame}} + 1))
+            echo "Encoding $FRAMES frames at {{Param.FrameRate}} fps..."
+
+            ffmpeg -y \
+              -r {{Param.FrameRate}} \
+              -start_number {{Param.StartFrame}} \
+              -i "{{Param.InputDir}}/$FFMPEG_PATTERN" \
+              -frames:v $FRAMES \
+              -pix_fmt yuv420p \
+              -vf "scale=in_color_matrix=bt709:out_color_matrix=bt709" \
+              -c:v libx264 \
+              -preset {{Param.EncodingPreset}} \
+              -crf {{Param.ConstantRateFactor}} \
+              -color_range tv \
+              -colorspace bt709 \
+              -color_primaries bt709 \
+              -color_trc iec61966-2-1 \
+              -movflags faststart \
+              '{{Param.OutputDir}}/{{Param.OutputFileName}}'
+
+            echo "Video encoding complete!"
+            ls -lh '{{Param.OutputDir}}/{{Param.OutputFileName}}'


### PR DESCRIPTION
## Summary

Adds a standalone job bundle that encodes a numbered image sequence into an MP4 video using FFmpeg. This is useful as a post-render utility or as a reference for adding video encoding to multi-step pipelines.

## What's included

- `template.yaml` — Job template with configurable frame rate, quality (CRF), and encoding presets
- `README.md` — Documentation with GUI/CLI submission examples and integration guidance

## Features

- Supports hash-mark patterns (`####`) auto-converted to FFmpeg's printf-style format
- BT.709 color space output with `faststart` for web streaming
- Uses `conda-forge` channel for FFmpeg (not available in the `deadline-cloud` channel)
- Works with job attachments or shared file systems

## Tested

- Submitted and verified on a Deadline Cloud farm with 251 4K PNG frames (1.1 GB) → 15 MB MP4 video
- Conda environment setup and FFmpeg 8.0.1 encoding both succeed on Linux SMF workers with spot instances