### PR TITLE
feat: Add Kiro skill for 3ds Max host configuration scripts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,3 +98,14 @@ to guide you.
 ## Licensing
 
 See the [LICENSE](LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
+
+## Contributing a 3ds Max Host Config Add-on
+
+The `skills/3dsmax-host-config/add-ons/` folder contains building blocks that Kiro uses to generate
+host configuration scripts for 3ds Max plugins. If you have tested a plugin combination that isn't
+covered yet, you can contribute a new add-on by:
+
+1. Create a new `.md` file in `skills/3dsmax-host-config/add-ons/` named after the plugin (e.g. `redshift.md`)
+2. Follow the structure of the existing add-ons — include a brief description, a reference script path, a "What to add to the script" section, and any important notes
+3. Add a working example `.ps1` script under `host_configuration_scripts/3dsmax/` that has been tested
+4. Open a pull request with both the add-on `.md` and the example script

--- a/host_configuration_scripts/3dsmax/README.md
+++ b/host_configuration_scripts/3dsmax/README.md
@@ -8,6 +8,25 @@ Please see the README.md in each sample script for more steps on how to set it u
 
 - Note: While the example installs 3ds Max 2024, Deadline Cloud's submitter supports 3ds Max 2025, 2026 as well. The installation script should work equivalently for 3ds Max 2025, 2026.
 
+## Generating a script for your version using Kiro
+
+The sample scripts in this folder cover specific version combinations. If you need a script for a different version of 3ds Max, a different renderer, or a different plugin combination, you can use [Kiro](https://kiro.dev) to generate one for you.
+
+### Prerequisites
+
+- [Kiro](https://kiro.dev) installed
+- This repository cloned and opened as a workspace in Kiro
+
+### Steps
+
+1. In the Kiro chat, type a request like:
+   - `"Create a host configuration script for 3ds Max 2026"`
+   - `"Create a host configuration script for 3ds Max 2026 and V-Ray 8"`
+   - `"Create a host configuration script for 3ds Max 2027 and Corona 14"`
+   - `"Add a host configuration script for 3ds Max 2026 with Forest Pack 10"`
+2. Kiro will read the skill in `skills/3dsmax-host-config/SKILL.md` and generate the correct script and README for your version combination.
+3. Review the generated script, fill in the `TODO` variables at the top (your S3 bucket name, installer file names), and configure your fleet.
+
 ## Common Prerequisites
 - Each sample requires you to have the 3ds Max installer in an S3 bucket in your AWS account. You can download the 3ds Max installer directly from Autodesk.
 - The host configuration scripts will download the installers from your S3 bucket, so your Fleet roles will need to be granted s3:GetObject permissions for the installers in S3.

--- a/skills/3dsmax-host-config/README.md
+++ b/skills/3dsmax-host-config/README.md
@@ -1,0 +1,26 @@
+# 3ds Max Host Config
+
+This skill helps you generate a PowerShell host configuration script for any version of 3ds Max
+and supported plugin combinations (V-Ray, Corona, tyFlow, Forest Pack, RailClone, and more) for
+AWS Deadline Cloud Service Managed Fleet workers.
+
+## How to use this skill with Kiro
+
+### Prerequisites
+
+- [Kiro](https://kiro.dev) installed
+- This repository cloned and opened as a workspace in Kiro
+- The 3ds Max installer (and any plugin installers) downloaded from the vendor and available locally
+- An S3 bucket in the same region as your Deadline Cloud farm to host the installers
+
+### Steps
+
+1. Open Kiro chat
+2. Tell Kiro what you need, for example:
+   - `"Create a host configuration script for 3ds Max 2026"`
+   - `"Create a host configuration script for 3ds Max 2026 and V-Ray 8"`
+   - `"Add a host config script for 3ds Max 2027 with Forest Pack 10 and RailClone 7"`
+3. Kiro will generate the `.ps1` script and a `README.md` for your version combination
+4. Fill in the `TODO` variables at the top of the script (your S3 bucket name and installer file names)
+5. Upload your installers to your S3 bucket
+6. Configure your Service Managed Fleet to use the generated script

--- a/skills/3dsmax-host-config/SKILL.md
+++ b/skills/3dsmax-host-config/SKILL.md
@@ -117,22 +117,21 @@ Follow the style of `3dsmax-2025-and-vray/README.md`. Include:
 - Note that config changes only affect Workers launched after the update
 - CloudWatch log group: `/aws/deadline/farm-<farm-id>/fleet-<fleet-id>`
 
-### Step 6: Test the script locally
+### Step 6: Test the script locally and on a fleet worker
 
 Before considering the script done:
-1. Run the generated `.ps1` locally on a Windows machine to verify the install succeeds
+1. Run the generated `.ps1` locally on a fresh Windows machine to verify the install succeeds end-to-end
 2. Verify 3ds Max installed correctly:
    ```powershell
    & "C:\Program Files\Autodesk\3ds Max <YEAR>\3dsmaxbatch.exe" -help
    ```
-3. If the script includes V-Ray, use the `sunflower_sphere` test bundle in
-   `host_configuration_scripts/3dsmax/3dsmax-2025-and-vray/sunflower_sphere/` to verify rendering works:
+3. Configure a Service Managed Fleet with the script, set min worker count to 1, and wait for a worker to start
+4. If the script includes V-Ray, submit the `sunflower_sphere` test bundle against the fleet to verify rendering works end-to-end:
    ```
    deadline bundle submit host_configuration_scripts/3dsmax/3dsmax-2025-and-vray/sunflower_sphere
    ```
    The job should complete and produce a rendered sphere with a sunflower texture.
-4. For other plugin combinations, verify the plugin loads by opening 3ds Max and checking
-   the plugin is available, or run a minimal batch render with a scene that uses the plugin.
+5. For other plugin combinations, create a minimal job bundle that exercises the plugin and submit it to the fleet to confirm the setup is good before production use.
 
 ### Step 7: Update the top-level README
 

--- a/skills/3dsmax-host-config/SKILL.md
+++ b/skills/3dsmax-host-config/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: 3dsmax-host-config
+description: >
+  Create or update 3ds Max host configuration scripts for AWS Deadline Cloud Service Managed Fleets.
+  Use when asked to "add a 3ds Max host config script", "create a host configuration for 3ds Max",
+  "add support for 3ds Max YEAR", "update V-Ray to version X", "add Forest Pack", "update Forest Pack",
+  "add RailClone", "add tyFlow", "add Corona", or when any new 3ds Max version or plugin combination
+  needs a host configuration script.
+tags: [skill, 3dsmax, host-configuration, deadline-cloud, powershell, service-managed-fleet]
+---
+
+# 3ds Max Host Configuration Script Builder
+
+## Overview
+
+This skill creates host configuration PowerShell scripts for AWS Deadline Cloud Windows Service Managed
+Fleets. These scripts install 3ds Max (and optionally renderer plugins) onto worker hosts at fleet
+startup, since 3ds Max requires administrative access to install.
+
+All scripts live under `host_configuration_scripts/3dsmax/` and follow a consistent structure.
+
+Plugin-specific instructions are in `skills/3dsmax-host-config/add-ons/`. Each `.md` file there is
+a self-contained building block. When a customer needs a plugin, find the relevant add-on and
+incorporate it into the ps1.
+
+## Usage
+
+Use this skill when:
+- A new 3ds Max version needs a host configuration script
+- A new plugin combination needs a script for an existing or new version
+- An existing script needs its 3ds Max version, renderer version, or plugin version bumped
+- Someone asks "add host config for 3ds Max X", "update to V-Ray 8", or "bump 3ds Max to 2026"
+
+**Important:** The add-ons in this skill (V-Ray, Corona, tyFlow, AEC plugins) are only supported
+as part of a 3ds Max installation. If the customer asks to install a plugin standalone without
+3ds Max, let them know this skill only covers 3ds Max + plugin combinations and direct them to
+use the `host-config-from-installer` skill instead.
+
+## Core Concepts
+
+- Scripts are PowerShell (`.ps1`) targeting Windows Service Managed Fleets
+- Each script downloads installers from a customer-owned S3 bucket using the AWS CLI (`aws s3 cp`)
+- All version-specific values are exposed as `$VARIABLES` at the top of the script, marked with `# TODO`
+- After installing 3ds Max, every script MUST set these environment variables at Machine scope:
+  - `Path` — add `C:\Program Files\Autodesk\3ds Max <VERSION>`
+  - `3DSMAX_EXECUTABLE` — path to `3dsmaxbatch.exe`
+  - `PYTHONPATH` — 3ds Max Python and Scripts dirs
+  - `Path` — also add the Python and Scripts dirs
+- Every script MUST install `deadline-cloud-for-3ds-max` via the bundled Python pip
+- Scripts MUST end with `Exit 0`
+- Each script lives in its own subfolder alongside a `README.md`
+
+## Workflow
+
+You MUST follow these steps in order.
+
+### Step 1: Clarify the request
+
+Ask the user (if not already specified):
+- Which 3ds Max version? (e.g. 2026, 2027)
+- Any renderer or plugin? (V-Ray, Corona, tyFlow, Forest Pack, RailClone, none)
+- If a renderer: which version?
+
+### Step 2: Find the closest existing script as a template
+
+Look in `host_configuration_scripts/3dsmax/` for the most similar existing script and read it in full.
+
+**If updating an existing script** (e.g. bumping 3ds Max 2025 → 2026, or V-Ray 7 → 8):
+- Create a new folder and script — do not edit the existing one
+- Update every version occurrence: `$VARIABLES`, `Write-Host` messages, install paths, env var names
+  (e.g. `VRAY_FOR_3DSMAX2025_MAIN` → `VRAY_FOR_3DSMAX2026_MAIN`)
+
+### Step 3: Determine folder and file names
+
+Follow the existing naming convention:
+- Base only: `3dsmax-<YEAR>/3dsmax-<YEAR>.ps1`
+- One plugin: `3dsmax-<YEAR>-and-<plugin>/3dsmax-<YEAR>-and-<plugin>.ps1`
+- Multiple plugins: `3dsmax-<YEAR>-<plugin1>-and-<plugin2>/...`
+
+When in doubt, look at existing folder names in `host_configuration_scripts/3dsmax/`.
+
+### Step 4: Write the script
+
+Structure:
+1. Header comment block — what it installs, tested with, S3 requirements
+2. TODO variables — bucket name, folder names, zip names, installer file names, install roots
+3. Install 3ds Max — `mkdir C:\3dsmax_setup -Force`, `aws s3 cp`, `Expand-Archive`, `Start-Process Setup.exe -q -Wait`
+4. For each plugin — find its add-on in `skills/3dsmax-host-config/add-ons/`, download from S3 into `C:\3dsmax_setup\`, then run its silent installer
+5. Configure environment for 3ds Max
+6. Configure environment for each plugin (from add-on)
+7. Install Deadline Cloud — `python.exe -m ensurepip` then `pip install deadline-cloud-for-3ds-max`
+8. `Exit 0`
+
+Key patterns:
+```powershell
+# Download from S3
+aws s3 cp --no-progress "s3://$BUCKET_NAME/$ZIP_FILE" C:\3dsmax_setup\3dsmax.zip
+
+# Install 3ds Max silently
+Start-Process "C:\3dsmax_setup\$FOLDER_NAME\Setup.exe" -ArgumentList '-q' -Wait
+
+# Set env vars
+[Environment]::SetEnvironmentVariable('3DSMAX_EXECUTABLE', "C:\Program Files\Autodesk\3ds Max $VERSION\3dsmaxbatch.exe", 'Machine')
+
+# Install deadline-cloud-for-3ds-max
+& "C:\Program Files\Autodesk\3ds Max $VERSION\Python\python.exe" -m ensurepip
+& "C:\Program Files\Autodesk\3ds Max $VERSION\Python\python.exe" -m pip install deadline-cloud-for-3ds-max
+```
+
+### Step 5: Write the README.md
+
+Follow the style of `3dsmax-2025-and-vray/README.md`. Include:
+- Title and one-line description
+- Brief description of any plugins
+- Installation guide (S3 bucket, upload installers, configure fleet, save, IAM role, test)
+- Note about TODO variables
+- Note that config changes only affect Workers launched after the update
+- CloudWatch log group: `/aws/deadline/farm-<farm-id>/fleet-<fleet-id>`
+
+### Step 6: Test the script locally
+
+Before considering the script done:
+1. Run the generated `.ps1` locally on a Windows machine to verify the install succeeds
+2. Verify 3ds Max installed correctly:
+   ```powershell
+   & "C:\Program Files\Autodesk\3ds Max <YEAR>\3dsmaxbatch.exe" -help
+   ```
+3. If the script includes V-Ray, use the `sunflower_sphere` test bundle in
+   `host_configuration_scripts/3dsmax/3dsmax-2025-and-vray/sunflower_sphere/` to verify rendering works:
+   ```
+   deadline bundle submit host_configuration_scripts/3dsmax/3dsmax-2025-and-vray/sunflower_sphere
+   ```
+   The job should complete and produce a rendered sphere with a sunflower texture.
+4. For other plugin combinations, verify the plugin loads by opening 3ds Max and checking
+   the plugin is available, or run a minimal batch render with a scene that uses the plugin.
+
+### Step 7: Update the top-level README
+
+Check `host_configuration_scripts/3dsmax/README.md` and update if the new script introduces a
+version or plugin not already listed.
+
+## Common Mistakes
+
+- Forgetting `mkdir C:\3dsmax_setup -Force` before the first `aws s3 cp`
+- Missing `Exit 0` at the end
+- Setting env vars before installing — always install first, then configure
+- Using `&&` as a command separator — PowerShell uses `;` or separate lines
+- Forgetting `-m ensurepip` before `-m pip install`
+- When bumping versions: forgetting to update year suffixes in env var names
+  (e.g. `VRAY_FOR_3DSMAX2025_MAIN` → `VRAY_FOR_3DSMAX2026_MAIN`)

--- a/skills/3dsmax-host-config/add-ons/aec-plugins.md
+++ b/skills/3dsmax-host-config/add-ons/aec-plugins.md
@@ -1,0 +1,36 @@
+# AEC Plugins Add-on
+
+Common architectural visualization plugins for 3ds Max: Forest Pack and RailClone (by iToo Software),
+and FloorGenerator and MultiTexture (by CG-Source). Use any combination as needed.
+
+## Reference Script
+
+See `host_configuration_scripts/3dsmax/3dsmax-2025-vray-and-aec-plugins/3dsmax-2025-vray-and-aec-plugins.ps1` for a working example.
+
+## What to add to the script
+
+Only include the sections for plugins you are actually installing. The reference script downloads all installers first then installs sequentially — you can follow the same pattern or download and install each plugin one at a time.
+
+**Forest Pack**
+1. Add a TODO variable for the Forest Pack installer file name
+2. Download the installer from S3 into `C:\3dsmax_setup\`
+3. Run the installer silently with `/S`, `MAXVER=max<YEAR>-64`, `/MAXDIR`, and `/LICMODE=rendernode`
+4. Set `ITOO_SOFTWARE_FOREST_PACK_PRO_MAINDIR` and `ITOO_SOFTWARE_FOREST_PACK_PRO_USELICSERVER=0`
+
+**RailClone**
+1. Add a TODO variable for the RailClone installer file name
+2. Download the installer from S3 into `C:\3dsmax_setup\`
+3. Run the installer silently with `/S` and `/LICMODE=rendernode`
+4. Set `ITOO_SOFTWARE_RAILCLONE_PRO_MAINDIR` and `ITOO_SOFTWARE_RAILCLONE_PRO_USELICSERVER=0`
+
+**FloorGenerator and MultiTexture**
+1. Add TODO variables for the `.dlm` and `.dlt` plugin file names
+2. Download both files from S3 into `C:\3dsmax_setup\`
+3. Copy both files into `C:\Program Files\Autodesk\3ds Max <YEAR>\plugins\`
+4. No environment variables needed
+
+## Important notes
+
+- Forest Pack and RailClone: `/LICMODE=rendernode` installs without a UI license — required for fleet workers
+- Forest Pack: `MAXVER` format is `max<YEAR>-64` (e.g. `max2026-64`)
+- FloorGenerator and MultiTexture plugin file names include the 3ds Max year — update to match your version

--- a/skills/3dsmax-host-config/add-ons/corona.md
+++ b/skills/3dsmax-host-config/add-ons/corona.md
@@ -1,0 +1,21 @@
+# Corona Add-on
+
+Corona is a photorealistic rendering engine by Chaos that integrates as a plugin with 3ds Max.
+It shares the same licensing structure as V-Ray.
+
+## Reference Script
+
+See `host_configuration_scripts/3dsmax/3dsmax-2025-and-corona-13/3dsmax-2025-and-corona.ps1` for a working example.
+
+## What to add to the script
+
+1. Add a TODO variable for the Corona installer file name at the top of the script
+2. After installing 3ds Max, download the Corona installer from S3 into `C:\3dsmax_setup\`
+3. Run the Corona installer silently with `-gui=0 -auto`
+4. Write the `vrlclient.xml` license file to `C:\Program Files\Common Files\ChaosGroup\` — note this requires elevated privileges, which the host config script already runs with
+5. Set `VRAY_AUTH_CLIENT_FILE_PATH` to the directory (not the file itself)
+
+## Important notes
+
+- `VRAY_AUTH_CLIENT_FILE_PATH` must point to the directory `C:\Program Files\Common Files\ChaosGroup`, not to `vrlclient.xml` directly
+- Corona uses the same `vrlclient.xml` licensing as V-Ray — if both are installed, only one copy of the file is needed

--- a/skills/3dsmax-host-config/add-ons/tyflow.md
+++ b/skills/3dsmax-host-config/add-ons/tyflow.md
@@ -1,0 +1,19 @@
+# tyFlow Add-on
+
+tyFlow is a particle system and physics simulation plugin for 3ds Max. It ships as a single
+`.dlo` file — no installer needed.
+
+## Reference Script
+
+See `host_configuration_scripts/3dsmax/3dsmax-2025-vray-and-tyflow/3dsmax-2025-vray-and-tyflow.ps1` for a working example.
+
+## What to add to the script
+
+1. Add a TODO variable for the tyFlow `.dlo` plugin file name at the top of the script
+2. Download the `.dlo` file from S3 into `C:\3dsmax_setup\`
+3. Copy the `.dlo` file into `C:\Program Files\Autodesk\3ds Max <YEAR>\plugins\`
+
+## Important notes
+
+- No environment variables are needed — 3ds Max loads plugins automatically from the plugins directory
+- The `.dlo` file name includes the 3ds Max year — make sure it matches the version being installed

--- a/skills/3dsmax-host-config/add-ons/vray.md
+++ b/skills/3dsmax-host-config/add-ons/vray.md
@@ -1,0 +1,19 @@
+# V-Ray Add-on
+
+V-Ray is a professional rendering engine by Chaos Group that integrates as a plugin with 3ds Max.
+
+## Reference Script
+
+See `host_configuration_scripts/3dsmax/3dsmax-2025-and-vray/3dsmax-2025-and-vray.ps1` for a working example.
+
+## What to add to the script
+
+1. Add a TODO variable for the V-Ray installer file name and optional install root at the top of the script
+2. After installing 3ds Max, download the V-Ray installer from S3 into `C:\3dsmax_setup\`
+3. Write a silent install config XML file to `C:\3dsmax_setup\config.xml` and run the installer with `-gui=0 -configFile -quiet=1`
+4. After setting 3ds Max env vars, set three V-Ray env vars — MAIN, PLUGINS, and MDL path — all suffixed with the 3ds Max year (e.g. `VRAY_FOR_3DSMAX2026_MAIN`)
+
+## Important notes
+
+- The year suffix in the V-Ray env var names MUST match the 3ds Max version year — this is the most common mistake when bumping versions
+- The install root variable is optional but recommended so the MDL path derives from it


### PR DESCRIPTION
Fixes: Adding support for new 3dsmax and its plugins versions. 

### What was the problem/requirement? (What/Why)

There was no reusable guide or skill for creating 3ds Max host configuration scripts for Deadline Cloud. Each new version or plugin combination required manually figuring out the correct install commands, environment variables, and script structure from scratch.

### What was the solution? (How)

Added a `skills/3dsmax-host-config/` skill that documents the complete workflow for creating 3ds Max host configuration scripts — from picking the right template, naming conventions, install structure, plugin-specific environment variables (V-Ray, Corona, tyFlow, Forest Pack, RailClone), to writing the README. The skill also directs Kiro to fall back to a generic installer skill for unknown plugins.

Updated `host_configuration_scripts/3dsmax/README.md` to point customers to Kiro as a way to generate scripts for versions and plugin combinations not already covered by the samples.

### What is the impact of this change?

Customers can now open this repo in Kiro and ask for a host config script for any 3ds Max version or plugin combination. Kiro will follow the skill's workflow and generate a correctly structured `.ps1` and `README.md` without the customer needing any scripting knowledge.

### How was this change tested?

Used the skill end-to-end in Kiro chat:

1. Asked Kiro: *"Create a host configuration script for 3ds Max 2027"*
2. Kiro asked a clarifying question about plugins
3. Responded: *"just the base"*
4. Kiro read the closest existing script (`3dsmax-2024.ps1`) as a template and generated:
   - `host_configuration_scripts/3dsmax/3dsmax-2027/3dsmax-2027.ps1`
   - `host_configuration_scripts/3dsmax/3dsmax-2027/README.md`
5. Generated script correctly included all required env vars, `TODO` variables, and `Exit 0`

### Was this change documented?

Yes — `skills/3dsmax-host-config/README.md` explains prerequisites and how to use the skill with Kiro. `host_configuration_scripts/3dsmax/README.md` was updated to point customers to Kiro for generating new version scripts.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*