### PR TITLE
feat: Add plugin sync delivery activate/deactivate scripts for Maya

### DIFF
--- a/conda_recipes/maya-2026/recipe/build.sh
+++ b/conda_recipes/maya-2026/recipe/build.sh
@@ -103,3 +103,16 @@ cat > "$PREFIX/etc/conda/env_vars.d/$PKG_NAME-$PKG_VERSION.json" << EOF
   "MAYA_LEGACY_THINCLIENT": "1"
 }
 EOF
+
+# --- Plugin Sync ---
+# Copies the plugin delivery scripts into the conda activate.d/deactivate.d
+# directories. These run AFTER the main Maya env vars are set via env_vars.d.
+#
+# See zzz-maya-plugin-sync-activate.sh for the full implementation.
+mkdir -p "$PREFIX/etc/conda/activate.d"
+cp $RECIPE_DIR/zzz-maya-plugin-sync-activate.sh \
+    $PREFIX/etc/conda/activate.d/zzz-$PKG_NAME-plugin-sync.sh
+
+mkdir -p "$PREFIX/etc/conda/deactivate.d"
+cp $RECIPE_DIR/zzz-maya-plugin-sync-deactivate.sh \
+    $PREFIX/etc/conda/deactivate.d/zzz-$PKG_NAME-plugin-sync.sh

--- a/conda_recipes/maya-2026/recipe/zzz-maya-plugin-sync-activate.sh
+++ b/conda_recipes/maya-2026/recipe/zzz-maya-plugin-sync-activate.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Plugin Sync for Maya
+# Downloads plugin files from S3 and configures MAYA_MODULE_PATH.
+# Runs after all standard Maya env vars are set via env_vars.d.
+#
+# S3 convention: s3://<bucket>/<prefix>/plugins/<os>/maya/<version>/
+# Generic path:  s3://<bucket>/<prefix>/plugins/generic/
+#
+# Required environment variables (set by the worker agent):
+#   DEADLINE_JA_S3_BUCKET      - Job attachment S3 bucket name
+#   DEADLINE_JA_ROOT_PREFIX    - Job attachment root prefix in the bucket
+#   OPENJD_SESSION_WORKING_DIR - Session working directory path
+
+# Skip if the required env vars aren't available (e.g. local testing without
+# the worker agent, or the worker agent hasn't been updated yet).
+if [ -z "${DEADLINE_JA_S3_BUCKET:-}" ] || [ -z "${MAYA_VERSION:-}" ]; then
+    echo "Plugin Sync: Skipping — DEADLINE_JA_S3_BUCKET or MAYA_VERSION not set."
+    return 0 2>/dev/null || exit 0
+fi
+
+_SP_PREFIX="${DEADLINE_JA_ROOT_PREFIX:+${DEADLINE_JA_ROOT_PREFIX}/}"
+_SP_OS="linux"
+if [ "$(uname -s)" = "MINGW"* ] || [ "$(uname -s)" = "MSYS"* ] || [ -n "${OS:-}" ]; then
+    _SP_OS="windows"
+fi
+
+# Determine plugin download directory
+_SP_PLUGIN_DIR="${OPENJD_SESSION_WORKING_DIR:-${TMPDIR:-/tmp}}/.maya-plugins"
+mkdir -p "$_SP_PLUGIN_DIR"
+
+# Download generic plugins to the session working directory
+_SP_GENERIC_SRC="s3://${DEADLINE_JA_S3_BUCKET}/${_SP_PREFIX}plugins/generic/"
+if [ -n "${OPENJD_SESSION_WORKING_DIR:-}" ]; then
+    if aws s3 ls "$_SP_GENERIC_SRC" >/dev/null 2>&1; then
+        echo "Plugin Sync: Downloading plugins from $_SP_GENERIC_SRC"
+        aws s3 cp "$_SP_GENERIC_SRC" "$OPENJD_SESSION_WORKING_DIR/" --recursive --quiet 2>/dev/null || true
+    fi
+fi
+
+# Download Maya-specific plugins
+_SP_DCC_SRC="s3://${DEADLINE_JA_S3_BUCKET}/${_SP_PREFIX}plugins/${_SP_OS}/maya/${MAYA_VERSION}/"
+_SP_MAYA_DIR="$_SP_PLUGIN_DIR/maya"
+mkdir -p "$_SP_MAYA_DIR"
+
+if aws s3 ls "$_SP_DCC_SRC" >/dev/null 2>&1; then
+    echo "Plugin Sync: Downloading Maya plugins from $_SP_DCC_SRC"
+    aws s3 cp "$_SP_DCC_SRC" "$_SP_MAYA_DIR/" --recursive --quiet 2>/dev/null || true
+fi
+
+# Append to MAYA_MODULE_PATH if we downloaded any files
+if [ -d "$_SP_MAYA_DIR" ] && [ -n "$(ls -A "$_SP_MAYA_DIR" 2>/dev/null)" ]; then
+    export MAYA_MODULE_PATH="${_SP_MAYA_DIR}:${MAYA_MODULE_PATH:-}"
+    echo "Plugin Sync: MAYA_MODULE_PATH updated with $_SP_MAYA_DIR"
+else
+    echo "Plugin Sync: No Maya plugins found, skipping."
+fi
+
+# Export for deactivate script cleanup
+export _MAYA_PLUGIN_SYNC_DIR="$_SP_PLUGIN_DIR"
+
+# Clean up temp variables
+unset _SP_PREFIX _SP_OS _SP_PLUGIN_DIR _SP_GENERIC_SRC _SP_DCC_SRC _SP_MAYA_DIR

--- a/conda_recipes/maya-2026/recipe/zzz-maya-plugin-sync-deactivate.sh
+++ b/conda_recipes/maya-2026/recipe/zzz-maya-plugin-sync-deactivate.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Plugin Sync for Maya — deactivate script
+# Cleans up downloaded plugin files.
+
+if [ -n "${_MAYA_PLUGIN_SYNC_DIR:-}" ] && [ -d "$_MAYA_PLUGIN_SYNC_DIR" ]; then
+    rm -rf "$_MAYA_PLUGIN_SYNC_DIR"
+fi
+unset _MAYA_PLUGIN_SYNC_DIR


### PR DESCRIPTION
Fixes: *<insert link to GitHub issue here>*

### What was the problem/requirement? (What/Why)
Getting plugins onto Deadline Cloud render workers is the hardest part of customer onboarding. Customers want a simple "drag and drop files to S3" experience — like copying files to a shared folder on-prem — instead of learning Conda packaging. This implements the Maya portion of the plugin sync delivery feature.

### What was the solution? (How)
 Added `zzz-maya-plugin-sync-activate.sh` and `zzz-maya-plugin-sync-deactivate.sh` to the Maya 2026 conda recipe. On `conda activate`, the script:                                                                  
  1. Downloads plugin files from `s3://<bucket>/<prefix>/plugins/<os>/maya/<version>/`                                                                                                                                     
  2. Downloads generic plugins from `s3://<bucket>/<prefix>/plugins/generic/`                                                                                                                                              
  3. Prepends the download directory to `MAYA_MODULE_PATH`                                                                                                                                                                 
  4. On deactivate, cleans up downloaded files 

   Pattern follows Blender prototype (branch `5.1.simpleplugin`) — standalone script files, OS detection, `aws s3 ls` pre-check, echo logging.                                                                
                                                                                                                                                                                                                           
  Depends on worker agent env vars (`DEADLINE_JA_S3_BUCKET`, `DEADLINE_JA_ROOT_PREFIX`, `OPENJD_SESSION_WORKING_DIR`) that are not yet exposed natively. Silently skips when these are not set. 

### What is the impact of this change?

Customers can upload Maya plugin files (`.mod` modules, MEL scripts, Python plugins, Arnold OSL shaders) to their job attachment S3 bucket and have them automatically available on workers before Maya launches. No Conda packaging, scripting, or CLI tools required beyond `aws s3 cp`.    

### How was this change tested?
 1. **Unit tests (14/14 pass)** — aws CLI stub, tested: activate with plugins, deactivate cleanup, silent skip (no bucket), silent skip (no MAYA_VERSION), root prefix handling, empty S3 prefix.                         
                                                                                                                                                                                                                           
  2. **Docker smoke test (6/6 pass)** — AL2023 worker-equivalent container, real `conda activate` flow verifying env_vars.d + activate.d ordering.                                                                         
                                                                                                                                                                                                                           
  3. **End-to-end on real Deadline Cloud farm** (using temporary queue environment to inject missing worker agent env vars):        
                                                                                                                                                                                                                           
     - **Studio Library** (254 files, real third-party Maya tool) — uploaded as Maya module, all files downloaded, MAYA_MODULE_PATH updated, render succeeded.   
                                                                                                                                                                                                                           
     - **Arnold OSL shaders** (106 files from [iceprincefounder/oslShaders](https://github.com/iceprincefounder/oslShaders)) — uploaded `.osl` + `.mtd` files with a `.mod` file setting `ARNOLD_PLUGIN_PATH`. Arnold 7.4.0 compiled and loaded all 41 OSL shaders at render time. Worker logs confirm: `loaded 41 OSL shaders in 0:00.29`. Wrench scene rendered successfully with Arnold.   

  4. **End-to-end with native worker agent env vars (no workaround)**:                                                                                                                                                   
     - Used host config script to install worker agent from                                                                                                                                                              
       [aws-deadline/deadline-cloud-worker-agent@mainline](https://github.com/aws-deadline/deadline-cloud-worker-agent/pull/917)                                                                                         
       and openjd-sessions from                                                                                                                                                                                          
       [OpenJobDescription/openjd-sessions-for-python@mainline](https://github.com/OpenJobDescription/openjd-sessions-for-python)                                                                                        
       following the custom wheels on SMF guide                                                                                                                                
     - No queue environment workaround needed — `DEADLINE_JA_S3_BUCKET` and                                                                                                                                              
       `DEADLINE_JA_ROOT_PREFIX` provided natively by the worker agent                                                                                                                                                   
     - Arnold 7.4.0 compiled and loaded 3 OSL shaders (jiWindowBox, mandelbrot, lc_random)                                                                                                                               
       from the S3 plugin path                                                                                                                                                                                           
     - Worker logs confirm: `loaded 3 OSL shaders in 0:00.02`, render succeeded       

Submit with 
```
  deadline bundle submit maya_wrench_sample/ \                                                                                                                                                                             
    -p CondaPackages="maya=2026 maya-mtoa=2026" \                                                                                                                                                                          
    -p CondaChannels="s3://kenyrish-test-cmf-bucket/Conda/Default" \                                                                                                                                                       
    -p Frames="1"       
```

### Was this change documented?
The activate script contains inline documentation of the S3 convention, required env vars, and behavior.

- For instance, if applicable, has the sample's description been updated?

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*