### PR TITLE
feat: Add generic (Windows) host config from installer Kiro skill

### DIFF
--- a/skills/host-config-from-installer/README.md
+++ b/skills/host-config-from-installer/README.md
@@ -1,0 +1,28 @@
+# Host Config from Installer
+
+This skill helps you create a PowerShell host configuration script for any Windows `.exe` software
+you want to run on AWS Deadline Cloud Service Managed Fleet workers.
+
+Instead of writing the script manually, Kiro will walk you through installing the software on your
+local machine, verify it works, upload the installer to S3, and generate the script from the steps
+that were actually confirmed working.
+
+## How to use this skill with Kiro
+
+### Prerequisites
+
+- [Kiro](https://kiro.dev) installed
+- This repository cloned and opened as a workspace in Kiro
+- The `.exe` installer file available on your local Windows machine
+- AWS CLI installed and configured with credentials that have S3 access
+
+### Steps
+
+1. Open Kiro chat
+2. Tell Kiro what you want to install, for example:
+   - `"I have a RealFlow 10 installer and I want to run it on my Deadline Cloud fleet"`
+   - `"Help me create a host config script for Marvelous Designer 12"`
+   - `"I want to install this .exe on my Service Managed Fleet workers"`
+3. Kiro will guide you step by step — running the installer, testing it, uploading to S3, and
+   generating the `.ps1` script
+4. At the end, review the generated script, fill in any `TODO` variables, and configure your fleet

--- a/skills/host-config-from-installer/SKILL.md
+++ b/skills/host-config-from-installer/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: host-config-from-installer
+description: >
+  Interactively install any Windows .exe software with the customer, test it, upload the installer
+  to S3, and convert the working steps into a PowerShell host configuration script for AWS Deadline
+  Cloud Service Managed Fleets. Use when a customer says "I have an installer", "I want to install X
+  on my fleet", "convert my install steps to a host config", or "help me set up X on Deadline Cloud
+  workers". Works for any software that ships as a Windows .exe installer.
+tags: [skill, host-configuration, deadline-cloud, powershell, installer, service-managed-fleet, windows]
+---
+
+# Host Config from Installer
+
+## Overview
+
+This skill walks a customer through installing any Windows `.exe` software on their local machine,
+verifies it works, uploads the installer to S3, and converts the verified steps into a PowerShell
+host configuration script for AWS Deadline Cloud Windows Service Managed Fleets.
+
+The generated `.ps1` is based on commands that were actually tested and confirmed working — not
+guesswork or templates.
+
+> **Note:** This skill currently covers Windows only. Linux support (`.sh` / `.rpm` / `.deb` installers) will be added in a follow-up.
+
+## Usage
+
+Use this skill when:
+- A customer has a `.exe` installer and wants it running on their Deadline Cloud fleet workers
+- A customer wants to convert a manual install process into a host config script
+- The software isn't covered by an existing specific skill (e.g. `3dsmax-host-config`)
+
+## Prerequisites
+
+Before starting, confirm the customer has:
+- The `.exe` installer file available locally on a Windows machine
+- AWS CLI installed and configured with credentials that have `s3:PutObject` access
+- An S3 bucket in the same region as their Deadline Cloud farm (or willingness to create one)
+- PowerShell available on their local machine
+
+## Workflow
+
+You MUST follow these steps in order. At each step, execute the command, check the output, and
+do not proceed until the step succeeds.
+
+### Step 1: Gather information
+
+Ask the customer:
+- What software are they installing? (name and version)
+- Where is the installer file located locally? (full path)
+- Do they have an S3 bucket already, or do they need one created?
+- What is their AWS region?
+
+### Step 2: Try the silent install
+
+Run the installer with common silent flags. Try them in this order until one works:
+
+```powershell
+# Attempt 1 - NSIS style
+Start-Process "<installer-path>" -ArgumentList '/S' -Wait -PassThru
+
+# Attempt 2 - Inno Setup style
+Start-Process "<installer-path>" -ArgumentList '/VERYSILENT', '/SUPPRESSMSGBOXES', '/NORESTART' -Wait -PassThru
+
+# Attempt 3 - MSI wrapped in exe
+Start-Process "<installer-path>" -ArgumentList '/quiet', '/norestart' -Wait -PassThru
+
+# Attempt 4 - InstallShield style
+Start-Process "<installer-path>" -ArgumentList '-s' -Wait -PassThru
+```
+
+After each attempt, check whether the software was installed by looking for it in
+`C:\Program Files\` or `C:\Program Files (x86)\`. Ask the customer to confirm.
+
+If none of the above work, ask the customer to check the installer's documentation or
+run `<installer-path> /?` or `<installer-path> /help` to discover the correct flags.
+
+### Step 3: Verify the install
+
+Once installed, verify the software runs correctly. Ask the customer to run the most basic
+verification command for the software — for example:
+
+```powershell
+# Check the install directory exists
+Get-ChildItem "C:\Program Files\<SoftwareName>"
+
+# Try running the executable
+& "C:\Program Files\<SoftwareName>\<executable>.exe" --version
+```
+
+Confirm with the customer that the output looks correct before proceeding.
+
+### Step 4: Capture environment changes
+
+Ask the customer to check what environment variables or PATH entries the installer added:
+
+```powershell
+# Check machine-level env vars
+[System.Environment]::GetEnvironmentVariables('Machine') | Format-List
+```
+
+Note down any new variables or PATH entries — these will need to be set explicitly in the host
+config script since the installer won't run interactively on fleet workers.
+
+### Step 5: Ensure the S3 bucket exists
+
+If the customer doesn't have a bucket yet, create one:
+
+```powershell
+aws s3 mb s3://<bucket-name> --region <region>
+```
+
+> **Important:** Make sure the fleet's IAM role has `s3:GetObject` permission on this bucket.
+> Without it, workers won't be able to download the installer at runtime.
+
+If they already have one, verify access:
+
+```powershell
+aws s3 ls s3://<bucket-name>
+```
+
+### Step 6: Upload the installer to S3
+
+```powershell
+aws s3 cp "<local-installer-path>" s3://<bucket-name>/<installer-filename>
+```
+
+Confirm the upload succeeded:
+
+```powershell
+aws s3 ls s3://<bucket-name>/<installer-filename>
+```
+
+### Step 7: Generate the host config script
+
+Using the working install command from Step 2 and the env vars from Step 4, generate a `.ps1`
+host configuration script. Place it in a new folder under `host_configuration_scripts/`:
+
+```
+host_configuration_scripts/<software-name>/<software-name>.ps1
+host_configuration_scripts/<software-name>/README.md
+```
+
+The script MUST follow this structure:
+
+```powershell
+<#
+Description of what this script installs.
+Tested with: <software name and version>.
+Requirements:
+- S3 bucket containing the installer
+- Fleet role with s3:GetObject permission
+#>
+
+# TODO: Replace with your bucket name
+$BUCKET_NAME="your-bucket-name"
+
+# TODO: Replace with your installer file name
+$INSTALLER_FILE="<installer-filename>"
+
+Write-Host ' --- Downloading installer --- '
+
+mkdir C:\software_setup -Force
+aws s3 cp --no-progress "s3://$BUCKET_NAME/$INSTALLER_FILE" C:\software_setup\
+
+Write-Host ' --- Installing <software> --- '
+
+Start-Process "C:\software_setup\$INSTALLER_FILE" -ArgumentList '<verified-silent-flags>' -Wait
+
+Write-Host ' --- Configuring environment --- '
+
+# Set any env vars captured in Step 4
+[Environment]::SetEnvironmentVariable('<VAR_NAME>', '<value>', 'Machine')
+
+Exit 0
+```
+
+### Step 8: Write the README.md
+
+Include:
+- What the script installs
+- Installation guide (S3 bucket, upload installer, configure fleet, IAM role, test)
+- Note about TODO variables to replace
+- Note that config changes only affect Workers launched after the update is applied
+- Recommendation to set min Worker count to 1 and check CloudWatch logs
+  (log group: `/aws/deadline/farm-<farm-id>/fleet-<fleet-id>`)
+
+## Common Mistakes
+
+- Not using `-Wait` in `Start-Process` — the script will proceed before the install finishes
+- Forgetting `mkdir C:\software_setup -Force` before the first download
+- Missing `Exit 0` at the end
+- Env vars set during interactive install won't apply on fleet workers — they MUST be set
+  explicitly with `[Environment]::SetEnvironmentVariable(..., 'Machine')`
+- Fleet IAM role must have `s3:GetObject` on the bucket — easy to forget


### PR DESCRIPTION
Fixes: *N/A*

### What was the problem/requirement? (What/Why)

There was no guided workflow for customers who have a Windows `.exe` installer and want to run that software on Deadline Cloud Service Managed Fleet workers. Each new software required manually figuring out silent install flags, environment variables, and S3 upload steps from scratch.

### What was the solution? (How)

Added a `skills/host-config-from-installer/` Kiro skill that walks the customer through the entire process interactively — trying silent install flags, verifying the install, capturing environment variables, uploading the installer to S3, and generating a ready-to-use `.ps1` host configuration script from the steps that were actually confirmed working.

### What is the impact of this change?

Customers can now open this repo in Kiro and say "I have an installer for X, I want it on my fleet" — Kiro will guide them step by step and produce a verified host config script without any scripting knowledge required. Works for any Windows `.exe` software.

### How was this change tested?

Used the skill end-to-end with the Deadline Cloud Submitter installer:

1. Provided the installer path `C:\Users\Administrator\Downloads\DeadlineCloudSubmitter-windows-x64-installer.exe`
2. Kiro tried `/S` — installer ran but used wrong component flag
3. Ran `--help` on the installer to discover `--mode unattended` as the correct silent flag
4. Kiro identified `deadline_client` is not a valid `--enable-components` value and fixed the script to only pass the flag when components are explicitly set
5. Generated `host_configuration_scripts/deadline-cloud-submitter/deadline-cloud-submitter.ps1` with correct flags and env vars

### Was this change documented?

Yes — `skills/host-config-from-installer/README.md` explains prerequisites and how to use the skill with Kiro.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
