### PR TITLE
feat: add vLLM + lm-evaluation-harness leaderboard job bundle

### DIFF
--- a/job_bundles/README.md
+++ b/job_bundles/README.md
@@ -71,6 +71,13 @@ If you've created a similar job for your favorite DCC, see [CONTRIBUTING.md](../
 The [gsplat_pipeline](gsplat_pipeline/README.md) job bundle can take a video file as input and train a 3D Gaussian Splatting point cloud.
 This example shows Deadline Cloud running a 3D reconstruction workload that uses CUDA GPUs for acceleration.
 
+### LLM evaluation with vLLM and lm-evaluation-harness
+
+The [vllm_lm_eval_leaderboard](vllm_lm_eval_leaderboard/README.md) job bundle evaluates multiple LLMs on a set of benchmarks in a single Deadline Cloud job using
+[vLLM](https://github.com/vllm-project/vllm) for inference and [EleutherAI's lm-evaluation-harness](https://github.com/EleutherAI/lm-evaluation-harness) for scoring.
+Models are a STRING parameter sweep — each task starts vLLM for one model, runs every benchmark against it, then stops vLLM. A final aggregation step
+produces a ranked leaderboard (CSV + Markdown).
+
 ### Arnold standalone render
 
 The [arnold_standalone_render](arnold_standalone_render) job bundle renders Arnold `.ass` (Arnold Scene Source) files

--- a/job_bundles/vllm_lm_eval_leaderboard/.gitignore
+++ b/job_bundles/vllm_lm_eval_leaderboard/.gitignore
@@ -1,0 +1,1 @@
+leaderboard_results/

--- a/job_bundles/vllm_lm_eval_leaderboard/README.md
+++ b/job_bundles/vllm_lm_eval_leaderboard/README.md
@@ -1,0 +1,100 @@
+# vLLM LLM Leaderboard (Matrix Evaluation)
+
+Evaluate **multiple LLMs × multiple benchmarks** in a single Deadline Cloud job. Each model becomes one task in a parameter sweep; tasks run in parallel across workers. A final step aggregates the per-model results into a ranked leaderboard.
+
+## How it works
+
+```
+┌─────────────────────────────────────────────────────┐
+│  Deadline Cloud Job                                 │
+│                                                     │
+│  ┌───────────────────────────────────────────────┐  │
+│  │ Step: EvalModels                              │  │
+│  │ parameterSpace: ModelName                     │  │
+│  │                                               │  │
+│  │  Task 1: Qwen/Qwen2.5-0.5B                    │  │
+│  │  Task 2: Qwen/Qwen2.5-1.5B                    │  │
+│  │  Task 3: EleutherAI/pythia-1.4b               │  │
+│  └──────────────────────┬────────────────────────┘  │
+│                         ▼                           │
+│  ┌───────────────────────────────────────────────┐  │
+│  │ Step: Aggregate                               │  │
+│  │  → leaderboard.csv + leaderboard.md           │  │
+│  └───────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────┘
+```
+
+Each task in `EvalModels` runs one model end-to-end: starts a local [vLLM](https://github.com/vllm-project/vllm) server, runs every benchmark via [EleutherAI's lm-evaluation-harness](https://github.com/EleutherAI/lm-evaluation-harness) against the local endpoint, then stops vLLM. Models load directly from HuggingFace Hub — no job attachments needed.
+
+## Prerequisites
+
+- GPU fleet (CUDA 12.x)
+- Queue with a Conda queue environment configured — see the [queue environment samples](../../queue_environments) and the [create a queue environment](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/create-queue-environment.html) docs. The bundle passes `CondaPackages` and `CondaChannels` parameters to it.
+- HuggingFace token for gated models (optional)
+
+## Quick start
+
+```bash
+deadline bundle submit ./job_bundles/vllm_lm_eval_leaderboard/ \
+  --parameter MaxModelLen=2048
+```
+
+After completion:
+
+```bash
+deadline job download-output --job-id <job-id>
+cat leaderboard_results/leaderboard.md
+```
+
+Example output:
+
+```markdown
+# LLM Leaderboard
+
+Models: 3 | Benchmarks: arc_challenge, arc_easy, hellaswag, winogrande
+
+| Rank | Model                  | arc_challenge | arc_easy | hellaswag | winogrande | Mean   |
+|------|------------------------|---------------|----------|-----------|------------|--------|
+| 1    | Qwen/Qwen2.5-1.5B      | 0.4497        | 0.7176   | 0.6775    | 0.6322     | 0.6192 |
+| 2    | Qwen/Qwen2.5-0.5B      | 0.3200        | 0.5816   | 0.5223    | 0.5691     | 0.4982 |
+| 3    | EleutherAI/pythia-1.4b | 0.2833        | 0.5387   | 0.5201    | 0.5730     | 0.4788 |
+```
+
+## Changing the model list
+
+Models are a STRING parameter space on the `EvalModels` step in `template.yaml`:
+
+```yaml
+parameterSpace:
+  taskParameterDefinitions:
+  - name: ModelName
+    type: STRING
+    range:
+    - "Qwen/Qwen2.5-0.5B"
+    - "Qwen/Qwen2.5-1.5B"
+    - "EleutherAI/pythia-1.4b"
+```
+
+To add or remove models, edit the `range` list. Each entry becomes a task visible in the Monitor UI. Model IDs must be supported by vLLM (see the [vLLM supported models list](https://docs.vllm.ai/en/latest/models/supported_models.html)).
+
+## Choosing benchmarks
+
+The `Benchmarks` job parameter is a comma-separated list of lm-evaluation-harness task names. Default covers commonsense reasoning:
+
+```
+hellaswag,arc_easy,arc_challenge,winogrande
+```
+
+Override at submit time:
+
+```bash
+deadline bundle submit ./job_bundles/vllm_lm_eval_leaderboard/ \
+  --parameter Benchmarks="hellaswag,mmlu,gsm8k"
+```
+
+All benchmarks in the list run sequentially against each model's vLLM server. Keep `MaxModelLen` ≤ the smallest model's context window.
+
+## References
+
+- [lm-evaluation-harness](https://github.com/EleutherAI/lm-evaluation-harness)
+- [vLLM](https://github.com/vllm-project/vllm)

--- a/job_bundles/vllm_lm_eval_leaderboard/README.md
+++ b/job_bundles/vllm_lm_eval_leaderboard/README.md
@@ -26,11 +26,31 @@ Evaluate **multiple LLMs × multiple benchmarks** in a single Deadline Cloud job
 
 Each task in `EvalModels` runs one model end-to-end: starts a local [vLLM](https://github.com/vllm-project/vllm) server, runs every benchmark via [EleutherAI's lm-evaluation-harness](https://github.com/EleutherAI/lm-evaluation-harness) against the local endpoint, then stops vLLM. Models load directly from HuggingFace Hub — no job attachments needed.
 
-## Prerequisites
+## Set up your farm
 
-- GPU fleet (CUDA 12.x)
-- Queue with a Conda queue environment configured — see the [queue environment samples](../../queue_environments) and the [create a queue environment](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/create-queue-environment.html) docs. The bundle passes `CondaPackages` and `CondaChannels` parameters to it.
-- HuggingFace token for gated models (optional)
+The fastest way to get a compatible farm is to deploy the [`cuda_farm`](../../cloudformation/farm_templates/cuda_farm) CloudFormation template. It provisions an NVIDIA-GPU service-managed fleet (A10G/L4) plus a queue with the Conda queue environment this bundle relies on. Once the stack reaches `CREATE_COMPLETE`, point the CLI at it:
+
+```bash
+deadline config set defaults.farm_id <FarmId from stack outputs>
+deadline config set defaults.queue_id <CUDAQueueId from stack outputs>
+```
+
+This bundle has been verified end-to-end against the queue environment provisioned by `cuda_farm` with no modifications required.
+
+**Already have a farm?** You need:
+- An SMF fleet with NVIDIA GPUs, ≥32 GB RAM, ≥4 vCPU
+- A queue with a Conda queue environment attached that reads `CondaPackages` and `CondaChannels` job parameters (any of the templates in [`queue_environments/`](../../queue_environments) named `conda_queue_env_*.yaml`)
+
+A HuggingFace token is only needed for gated models (Llama, etc.).
+
+### Service quotas
+
+EC2 GPU instances are gated by per-region vCPU quotas, which often default to **0 in a fresh AWS region**. In the [Service Quotas console](https://console.aws.amazon.com/servicequotas/home/services/ec2/quotas), under **EC2**, request increases for:
+
+- **Running On-Demand G and VT instances** — vCPU count, not instance count. The default 3-model run on `g5.xlarge` (4 vCPU each) needs ≥12 vCPU running concurrently.
+- **All G and VT Spot Instance Requests** — only if your fleet uses spot.
+
+Quota increases for these can take anywhere from minutes to a couple of business days, so request them before you submit.
 
 ## Quick start
 

--- a/job_bundles/vllm_lm_eval_leaderboard/README.md
+++ b/job_bundles/vllm_lm_eval_leaderboard/README.md
@@ -45,7 +45,7 @@ A HuggingFace token is only needed for gated models (Llama, etc.).
 
 ### Service quotas
 
-EC2 GPU instances are gated by per-region vCPU quotas, which often default to **0 in a fresh AWS region**. In the [Service Quotas console](https://console.aws.amazon.com/servicequotas/home/services/ec2/quotas), under **EC2**, request increases for:
+If your fleet doesn't scale up workers, the most common cause is an EC2 vCPU quota. GPU instance limits are per-region and per-instance-family, and may be capped below what you need on accounts that haven't previously launched these instances. Open the [Service Quotas console](https://console.aws.amazon.com/servicequotas/home/services/ec2/quotas) under **EC2** and confirm you have headroom for:
 
 - **Running On-Demand G and VT instances** — vCPU count, not instance count. The default 3-model run on `g5.xlarge` (4 vCPU each) needs ≥12 vCPU running concurrently.
 - **All G and VT Spot Instance Requests** — only if your fleet uses spot.
@@ -95,11 +95,13 @@ parameterSpace:
     - "EleutherAI/pythia-1.4b"
 ```
 
+The default list is a small, ungated, fast-loading mix that fits comfortably on a single A10G/L4: two models from the same family at different sizes (Qwen2.5 0.5B vs 1.5B) so you can see scaling within a family, plus one from a different family (Pythia 1.4B) at a comparable size so you can see cross-family differences. It's just a starting point; swap in whatever models you actually want to compare.
+
 To add or remove models, edit the `range` list. Each entry becomes a task visible in the Monitor UI. Model IDs must be supported by vLLM (see the [vLLM supported models list](https://docs.vllm.ai/en/latest/models/supported_models.html)).
 
 ## Choosing benchmarks
 
-The `Benchmarks` job parameter is a comma-separated list of lm-evaluation-harness task names. Default covers commonsense reasoning:
+The `Benchmarks` job parameter is a comma-separated list of lm-evaluation-harness task names. The default set is a standard **commonsense reasoning** suite, a well-known benchmark category that tests whether a model can apply everyday world knowledge (picking the most plausible continuation of a scenario, resolving an ambiguous pronoun, answering grade-school science questions). It's cheap to run and a reasonable smoke test for general capability:
 
 ```
 hellaswag,arc_easy,arc_challenge,winogrande

--- a/job_bundles/vllm_lm_eval_leaderboard/scripts/aggregate_leaderboard.py
+++ b/job_bundles/vllm_lm_eval_leaderboard/scripts/aggregate_leaderboard.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Aggregate per-model lm-eval-harness JSON results into a leaderboard.
+
+Reads all `results_*.json` files under <results-dir>/**/, extracts each
+benchmark's best-available accuracy metric, and writes:
+  - leaderboard.csv — one row per model, one column per benchmark
+  - leaderboard.md — same data as a ranked Markdown table
+"""
+import argparse
+import csv
+import json
+import re
+import sys
+from pathlib import Path
+
+
+METRIC_PRIORITY = [
+    "acc_norm,none",
+    "acc,none",
+    "exact_match,strict-match",
+    "exact_match,flexible-extract",
+]
+
+
+def extract_metric(task_results: dict):
+    for metric in METRIC_PRIORITY:
+        if metric in task_results:
+            return metric.split(",")[0], float(task_results[metric])
+    for k, v in task_results.items():
+        if isinstance(v, (int, float)) and not k.endswith("_stderr,none"):
+            return k.split(",")[0], float(v)
+    return None
+
+
+def parse_results_file(path: Path):
+    data = json.loads(path.read_text())
+    model = data.get("model_name") or str(data.get("config", {}).get("model_args", "unknown"))
+    m = re.search(r"model=([^,]+)", model)
+    if m:
+        model = m.group(1)
+    scores = {}
+    for bench, results in data.get("results", {}).items():
+        extracted = extract_metric(results)
+        if extracted:
+            scores[bench] = extracted
+    return model, scores
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--results-dir", required=True, type=Path)
+    args = ap.parse_args()
+
+    results_dir: Path = args.results_dir
+    if not results_dir.exists():
+        print(f"ERROR: results dir {results_dir} does not exist", file=sys.stderr)
+        return 1
+
+    by_model: dict = {}
+    for json_path in sorted(results_dir.rglob("results_*.json")):
+        try:
+            model, scores = parse_results_file(json_path)
+        except (json.JSONDecodeError, ValueError, OSError) as e:
+            print(f"WARN: skipping malformed {json_path.relative_to(results_dir)}: {e}", file=sys.stderr)
+            continue
+        print(f"Parsed {json_path.relative_to(results_dir)}: {model} -> {list(scores.keys())}")
+        by_model.setdefault(model, {}).update(scores)
+
+    if not by_model:
+        print(f"ERROR: no results_*.json files found under {results_dir}", file=sys.stderr)
+        return 1
+
+    all_benchmarks = sorted({b for scores in by_model.values() for b in scores})
+
+    rows = []
+    for model, scores in by_model.items():
+        row = {"model": model}
+        vals = []
+        for bench in all_benchmarks:
+            if bench in scores:
+                _, v = scores[bench]
+                row[bench] = v
+                vals.append(v)
+            else:
+                row[bench] = None
+        row["mean"] = sum(vals) / len(vals) if vals else 0.0
+        rows.append(row)
+    rows.sort(key=lambda r: r["mean"], reverse=True)
+
+    csv_path = results_dir / "leaderboard.csv"
+    with csv_path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=["model"] + all_benchmarks + ["mean"])
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({
+                k: (f"{v:.4f}" if isinstance(v, float) else ("N/A" if v is None else v))
+                for k, v in row.items()
+            })
+    print(f"\nWrote {csv_path}")
+
+    md = ["# LLM Leaderboard", ""]
+    md.append(f"Models: {len(rows)} | Benchmarks: {', '.join(all_benchmarks)}")
+    md.append("")
+    md.append("| Rank | Model | " + " | ".join(all_benchmarks) + " | **Mean** |")
+    md.append("|------|-------|" + "|".join(["-----"] * (len(all_benchmarks) + 1)) + "|")
+    for i, row in enumerate(rows, 1):
+        cells = [f"{row[b]:.4f}" if row[b] is not None else "—" for b in all_benchmarks]
+        md.append(f"| {i} | `{row['model']}` | " + " | ".join(cells) + f" | **{row['mean']:.4f}** |")
+    md_path = results_dir / "leaderboard.md"
+    md_path.write_text("\n".join(md) + "\n")
+    print(f"Wrote {md_path}")
+    print("\n" + "\n".join(md))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/job_bundles/vllm_lm_eval_leaderboard/scripts/eval-model.sh
+++ b/job_bundles/vllm_lm_eval_leaderboard/scripts/eval-model.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# Evaluate one model against all benchmarks.
+#
+# Starts vLLM for the given model, runs every benchmark in the list against
+# the local vLLM endpoint via lm-evaluation-harness's local-completions model
+# type, then stops vLLM.
+#
+# Args:
+#   $1 - HuggingFace model ID (e.g. Qwen/Qwen2.5-0.5B)
+#   $2 - Comma-separated benchmark task names (e.g. "hellaswag,arc_easy")
+#   $3 - Results output directory
+#   $4 - Number of concurrent lm_eval requests
+#   $5 - GPU memory utilization fraction
+#   $6 - Max model length
+#   $7 - HuggingFace token (may be empty)
+#   $8 - Session working directory
+set -euo pipefail
+
+MODEL="$1"
+BENCHMARKS="$2"
+RESULTS_DIR="$3"
+NUM_CONCURRENT="$4"
+GPU_MEM_UTIL="$5"
+MAX_MODEL_LEN="$6"
+HF_TOKEN_ARG="$7"
+SESSION_DIR="$8"
+
+[ -n "$HF_TOKEN_ARG" ] && export HF_TOKEN="$HF_TOKEN_ARG"
+mkdir -p "$RESULTS_DIR"
+
+VLLM_LOG="$SESSION_DIR/vllm_server.log"
+
+# Make sure vLLM is killed even if a benchmark fails.
+cleanup() {
+  if [ -n "${VLLM_PID:-}" ] && kill -0 "$VLLM_PID" 2>/dev/null; then
+    echo "Stopping vLLM (PID $VLLM_PID)..."
+    kill "$VLLM_PID" 2>/dev/null || true
+    wait "$VLLM_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+echo "Starting vLLM server for $MODEL..."
+START_TS=$(date +%s)
+nohup python -m vllm.entrypoints.openai.api_server \
+  --model "$MODEL" --dtype auto --port 8000 \
+  --gpu-memory-utilization "$GPU_MEM_UTIL" \
+  --max-model-len "$MAX_MODEL_LEN" \
+  > "$VLLM_LOG" 2>&1 &
+VLLM_PID=$!
+
+# Poll /v1/models until the server is ready (max 15 minutes).
+# Stream new vLLM log lines to stdout every 30s so progress is visible in
+# the Deadline Cloud Monitor UI while the model loads and compiles.
+MAX_WAIT=900
+LAST_LOG_LINES=0
+READY=0
+for i in $(seq 1 $((MAX_WAIT / 5))); do
+  if ! kill -0 "$VLLM_PID" 2>/dev/null; then
+    echo "ERROR: vLLM server exited unexpectedly after $(( $(date +%s) - START_TS ))s"
+    tail -100 "$VLLM_LOG"
+    exit 1
+  fi
+  if curl -sf http://localhost:8000/v1/models > /dev/null; then
+    echo "vLLM ready after $(( $(date +%s) - START_TS ))s"
+    READY=1
+    break
+  fi
+  if [ $((i % 6)) -eq 0 ]; then
+    CURRENT_LINES=$(wc -l < "$VLLM_LOG" 2>/dev/null || echo 0)
+    if [ "$CURRENT_LINES" -gt "$LAST_LOG_LINES" ]; then
+      tail -n $((CURRENT_LINES - LAST_LOG_LINES)) "$VLLM_LOG" | tail -10
+      LAST_LOG_LINES=$CURRENT_LINES
+    fi
+  fi
+  sleep 5
+done
+if [ "$READY" -ne 1 ]; then
+  echo "ERROR: vLLM did not become ready within ${MAX_WAIT}s"
+  tail -100 "$VLLM_LOG"
+  exit 1
+fi
+
+# Run each benchmark against the running vLLM daemon.
+IFS=',' read -ra BENCH_ARR <<< "$BENCHMARKS"
+for BENCH in "${BENCH_ARR[@]}"; do
+  BENCH=$(echo "$BENCH" | xargs)
+  echo "== Running $BENCH on $MODEL =="
+  lm_eval --model local-completions \
+    --model_args "model=$MODEL,base_url=http://localhost:8000/v1/completions,num_concurrent=$NUM_CONCURRENT,max_retries=5,tokenized_requests=False" \
+    --tasks "$BENCH" \
+    --output_path "$RESULTS_DIR"
+done
+
+echo "All benchmarks complete for $MODEL"

--- a/job_bundles/vllm_lm_eval_leaderboard/template.yaml
+++ b/job_bundles/vllm_lm_eval_leaderboard/template.yaml
@@ -1,0 +1,165 @@
+specificationVersion: 'jobtemplate-2023-09'
+name: vLLM Leaderboard Matrix Evaluation
+description: |
+  Evaluates multiple LLMs on a set of benchmarks in a single Deadline Cloud job.
+
+  The `EvalModels` step has a parameter space over models — each task runs one
+  model. The task script starts vLLM for that model, runs every benchmark via
+  EleutherAI's lm-evaluation-harness against the local vLLM endpoint, then
+  stops vLLM. Tasks run in parallel across workers.
+
+  A final step aggregates per-model JSON results into a ranked leaderboard
+  (CSV + Markdown).
+
+  Dependencies (vLLM, PyTorch, transformers, lm_eval) are provided by the
+  queue's Conda queue environment via the `CondaPackages` parameter. Your
+  queue must have a Conda queue environment configured — see
+  https://docs.aws.amazon.com/deadline-cloud/latest/userguide/create-queue-environment.html
+
+  To change the model list, edit the `range` of the `ModelName` task parameter.
+  To change benchmarks, edit the `Benchmarks` job parameter at submit time.
+
+parameterDefinitions:
+- name: Benchmarks
+  type: STRING
+  default: "hellaswag,arc_easy,arc_challenge,winogrande"
+  description: "Comma-separated lm-evaluation-harness task names to run against every model."
+  userInterface:
+    control: LINE_EDIT
+    label: Benchmarks
+    groupLabel: Evaluation Settings
+
+- name: ResultsDir
+  type: PATH
+  objectType: DIRECTORY
+  dataFlow: OUT
+  default: leaderboard_results
+  description: "Output directory for per-model results and the final leaderboard."
+  userInterface:
+    control: CHOOSE_DIRECTORY
+    label: Results Directory
+    groupLabel: Output
+
+- name: NumConcurrent
+  type: INT
+  default: 4
+  minValue: 1
+  maxValue: 64
+  description: "Number of concurrent requests lm_eval sends to vLLM."
+  userInterface:
+    control: SPIN_BOX
+    label: Concurrent Requests
+    groupLabel: Evaluation Settings
+
+- name: MaxModelLen
+  type: INT
+  default: 2048
+  minValue: 512
+  maxValue: 32768
+  description: "Max sequence length for vLLM. Set to the smallest context window among your models."
+  userInterface:
+    control: SPIN_BOX
+    label: Max Model Length
+    groupLabel: Server Settings
+
+- name: GpuMemoryUtilization
+  type: STRING
+  default: "0.90"
+  description: "Fraction of GPU memory for vLLM KV cache (0.0-1.0)."
+  userInterface:
+    control: LINE_EDIT
+    label: GPU Memory Utilization
+    groupLabel: Server Settings
+
+- name: HfToken
+  type: STRING
+  default: ""
+  description: "HuggingFace token for gated models (Llama, etc.). Leave empty if not needed."
+  userInterface:
+    control: LINE_EDIT
+    label: HuggingFace Token
+    groupLabel: Model Settings
+
+- name: JobScriptDir
+  description: Directory containing bundled scripts.
+  type: PATH
+  objectType: DIRECTORY
+  dataFlow: IN
+  default: scripts
+  userInterface:
+    control: HIDDEN
+
+# Dependencies resolved by the queue's Conda queue environment. Three groups:
+#   1. vLLM stack: vLLM (cuda build) transitively pulls PyTorch, transformers,
+#      tokenizers. cuda-toolkit provides the headers and libcuda.so stub that
+#      Triton needs for JIT kernel compilation on the worker.
+#   2. lm_eval[api] extras: conda-forge lm_eval doesn't declare these (they're
+#      a pip-only extra upstream), but local-completions needs them.
+#   3. typepy[datetime] extras: pytablewriter -> dataproperty -> typepy lazily
+#      imports pytz/dateutil when rendering the final markdown results table.
+#      conda-forge typepy hides these behind the [datetime] extra.
+- name: CondaPackages
+  type: STRING
+  default: "python=3.11 vllm=0.19.1=cuda* cuda-toolkit=12.9 lm_eval=0.4.9 requests aiohttp tenacity tqdm tiktoken pytz python-dateutil"
+  userInterface:
+    control: HIDDEN
+
+- name: CondaChannels
+  type: STRING
+  default: "conda-forge"
+  userInterface:
+    control: HIDDEN
+
+jobEnvironments:
+- name: UnbufferedOutput
+  variables:
+    PYTHONUNBUFFERED: "True"
+
+steps:
+
+# Each task evaluates one model. The task script starts vLLM for the model,
+# runs all benchmarks against it sequentially, then stops vLLM.
+- name: EvalModels
+  parameterSpace:
+    taskParameterDefinitions:
+    - name: ModelName
+      type: STRING
+      range:
+      - "Qwen/Qwen2.5-0.5B"
+      - "Qwen/Qwen2.5-1.5B"
+      - "EleutherAI/pythia-1.4b"
+  script:
+    actions:
+      onRun:
+        command: bash
+        args:
+        - '{{Param.JobScriptDir}}/eval-model.sh'
+        - '{{Task.Param.ModelName}}'
+        - '{{Param.Benchmarks}}'
+        - '{{Param.ResultsDir}}'
+        - '{{Param.NumConcurrent}}'
+        - '{{Param.GpuMemoryUtilization}}'
+        - '{{Param.MaxModelLen}}'
+        - '{{Param.HfToken}}'
+        - '{{Session.WorkingDirectory}}'
+  hostRequirements:
+    attributes:
+    - {name: attr.worker.os.family, anyOf: [linux]}
+    amounts:
+    - {name: amount.worker.gpu, min: 1}
+    - {name: amount.worker.memory, min: 32768}
+
+- name: Aggregate
+  dependencies:
+  - dependsOn: EvalModels
+  script:
+    actions:
+      onRun:
+        command: python
+        args:
+        - '{{Param.JobScriptDir}}/aggregate_leaderboard.py'
+        - '--results-dir'
+        - '{{Param.ResultsDir}}'
+  hostRequirements:
+    attributes:
+    - {name: attr.worker.os.family, anyOf: [linux]}

--- a/job_bundles/vllm_lm_eval_leaderboard/template.yaml
+++ b/job_bundles/vllm_lm_eval_leaderboard/template.yaml
@@ -119,6 +119,12 @@ steps:
 
 # Each task evaluates one model. The task script starts vLLM for the model,
 # runs all benchmarks against it sequentially, then stops vLLM.
+#
+# Models live in the parameterSpace rather than as a job parameter because
+# OpenJD doesn't currently expose a multi-select dropdown control (LIST[STRING]
+# exists as a type but submitter UIs don't render it as a multi-select), so a
+# job parameter would only let users pick one model at a time. Editing this
+# range list is the supported way to change which models the job evaluates.
 - name: EvalModels
   parameterSpace:
     taskParameterDefinitions:

--- a/job_bundles/vllm_lm_eval_leaderboard/template.yaml
+++ b/job_bundles/vllm_lm_eval_leaderboard/template.yaml
@@ -119,12 +119,6 @@ steps:
 
 # Each task evaluates one model. The task script starts vLLM for the model,
 # runs all benchmarks against it sequentially, then stops vLLM.
-#
-# Models live in the parameterSpace rather than as a job parameter because
-# OpenJD doesn't currently expose a multi-select dropdown control (LIST[STRING]
-# exists as a type but submitter UIs don't render it as a multi-select), so a
-# job parameter would only let users pick one model at a time. Editing this
-# range list is the supported way to change which models the job evaluates.
 - name: EvalModels
   parameterSpace:
     taskParameterDefinitions:


### PR DESCRIPTION
Fixes: *<insert link to GitHub issue here>*

### What was the problem/requirement? (What/Why)
There was no Deadline Cloud sample for running LLM evaluations. Customers wanting to benchmark multiple language models: comparing fine-tunes, evaluating quantization tradeoffs, building a leaderboard across a model lineup.

A new job bundle (job_bundles/vllm_lm_eval_leaderboard/) that runs a matrix of N models × M benchmarks in a single submission and produces a ranked leaderboard:
                                                                                                                                         
-  Architecture: one step (EvalModels) with ModelName as a STRING parameter sweep. Each task starts a local vLLM                     (https://github.com/vllm-project/vllm) server for its model, runs every benchmark via EleutherAI's lm-evaluation-harness (https://github.com/EleutherAI/lm-evaluation-harness) against localhost:8000, then stops vLLM. A dependent Aggregate step produces leaderboard.csv and leaderboard.md.                             
-  Dependencies: resolved entirely by the queue's Conda queue environment from conda-forge. The CondaPackages parameter pins the vLLM stack (vllm + cuda-toolkit).                                         
-  Models: pulled directly from HuggingFace Hub by vLLM at task start.

### What is the impact of this change?

Adds a new self-contained sample. The only existing file touched is job_bundles/README.md (cross-link added to the index).             

### How was this change tested?

  End-to-end on Deadline Cloud against an SMF GPU fleet (on-demand g5.xlarge / A10G):                                                    
   

-   Submitted the bundle with the default 3 models (Qwen/Qwen2.5-0.5B, Qwen/Qwen2.5-1.5B, EleutherAI/pythia-1.4b) against hellaswag      
-   All 4 tasks SUCCEEDED, 0 retries                              
-   Per-task wall time ~12–15 min including model load, vLLM warmup, evaluation, and shutdown                                            
-   Output:                                                                                                                              
                                                                                                                                         
  | Rank | Model                  | hellaswag |                                                                                          
  |------|------------------------|-----------|                                                                                          
  | 1    | Qwen/Qwen2.5-1.5B      | 0.6781    |                                                                                          
  | 2    | Qwen/Qwen2.5-0.5B      | 0.5215    |                                                                                          
  | 3    | EleutherAI/pythia-1.4b | 0.5207    |                                                                                          
                                                                                                                                                                                                                                                                            

### Was this change documented?

Yes. The bundle ships with a README.md covering quick-start, how to swap models, how to choose benchmarks, prerequisites (GPU SMF fleet, queue with a Conda queue env), and a service-quotas note flagging the EC2 G/VT vCPU quotas that often default to 0 in fresh AWS regions. The new sample is also linked from job_bundles/README.md.   

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*