### PR TITLE
feat: Add support for 3dsmax 2027 host configuration script

### DIFF
--- a/host_configuration_scripts/3dsmax/3dsmax-2027/3dsmax-2027.ps1
+++ b/host_configuration_scripts/3dsmax/3dsmax-2027/3dsmax-2027.ps1
@@ -1,0 +1,34 @@
+<#
+This is an example host configuration script that downloads and installs 3ds Max 2027.
+You can configure a Windows Service-Managed Fleet to use this host configuration to render your 3ds Max 2027 jobs.
+This script was tested with the 3ds Max 2027 installer.
+
+Requirements:
+- S3 bucket to host the 3ds Max 2027 installer
+- Your fleet role must have permissions to s3:GetObject the installer file from your S3 bucket.
+#>
+
+# TODO: Replace the below value with your S3 URI from your bucket
+# Guide on how to create the 3ds Max installer zip file: https://github.com/aws-deadline/deadline-cloud-samples/blob/mainline/host_configuration_scripts/3dsmax/README.md
+$3DS_MAX_INSTALLER_ZIP_S3_URI="s3://your-bucket-name/path/to/3ds-max-2027.zip"
+
+Write-Host ' --- Installing 3ds Max 2027 --- '
+
+mkdir C:\3dsmax_setup -Force
+aws s3 cp --no-progress "$3DS_MAX_INSTALLER_ZIP_S3_URI" C:\3dsmax_setup\3dsmax.zip
+Expand-Archive C:\3dsmax_setup\3dsmax.zip C:\3dsmax_setup\
+Start-Process "C:\3dsmax_setup\Setup.exe" -ArgumentList '-q' -Wait
+
+Write-Host ' --- Configuring environment for 3ds Max 2027 --- '
+
+[Environment]::SetEnvironmentVariable('Path', 'C:\Program Files\Autodesk\3ds Max 2027;' + [Environment]::GetEnvironmentVariable('Path', 'Machine'), 'Machine')
+[Environment]::SetEnvironmentVariable('3DSMAX_EXECUTABLE', 'C:\Program Files\Autodesk\3ds Max 2027\3dsmaxbatch.exe', 'Machine')
+[Environment]::SetEnvironmentVariable('PYTHONPATH', 'C:\Program Files\Autodesk\3ds Max 2027\Python;C:\Program Files\Autodesk\3ds Max 2027\Python\Scripts', 'Machine')
+[Environment]::SetEnvironmentVariable('Path', 'C:\Program Files\Autodesk\3ds Max 2027\Python;C:\Program Files\Autodesk\3ds Max 2027\Python\Scripts;' + [Environment]::GetEnvironmentVariable('Path', 'Machine'), 'Machine')
+
+Write-Host ' --- Installing Deadline Cloud for 3ds Max --- '
+
+& "C:\Program Files\Autodesk\3ds Max 2027\Python\python.exe" -m ensurepip
+& "C:\Program Files\Autodesk\3ds Max 2027\Python\python.exe" -m pip install deadline-cloud-for-3ds-max
+
+Exit 0

--- a/host_configuration_scripts/3dsmax/3dsmax-2027/README.md
+++ b/host_configuration_scripts/3dsmax/3dsmax-2027/README.md
@@ -1,0 +1,15 @@
+# Sample Host Configuration script to install 3ds Max 2027 to Service Managed Fleets for AWS Deadline Cloud
+
+This sample host configuration script configures your Service Managed Fleet with 3ds Max 2027 to render your 3ds Max 2027 jobs.
+
+## Installation guide
+1. Create an S3 bucket in the same region as your Deadline Cloud farm.
+2. Download the 3ds Max 2027 installer from Autodesk, zip up the installer folder, and upload it to your S3 bucket.
+3. Configure the Windows Service Managed Fleet's host configuration using [3dsmax-2027.ps1](./3dsmax-2027.ps1).
+    - Note that there are placeholder variables at the start of the script marked with `TODO`. Replace the values with ones matching your configuration.
+4. Save the fleet configuration.
+5. Configure your Fleet's IAM role to have `s3:GetObject` access to your S3 bucket.
+6. Recommendation: Set the fleet's min worker count to 1. Review a worker's CloudWatch log to ensure the script executes successfully prior to production use.
+    - Log group: `/aws/deadline/farm-<farm-id>/fleet-<fleet-id>`
+
+> **Note:** Host configuration changes only affect Workers launched after the update is applied. Existing workers will not be updated.

--- a/host_configuration_scripts/3dsmax/README.md
+++ b/host_configuration_scripts/3dsmax/README.md
@@ -6,7 +6,7 @@ Please see the README.md in each sample script for more steps on how to set it u
 ## 3ds Max
 3ds Max is a popular Digital Content Creation tool provided by Autodesk. 3ds Max runs on Windows, and requires administrative access to install onto a host. Because of the administrative requirement, Deadline Cloud recommends installing 3ds Max on to the worker host using Host Configuration Scripts.
 
-- Note: While the example installs 3ds Max 2024 and 2025, Deadline Cloud's submitter supports 3ds Max 2026 as well. The installation script should work equivalently for 3ds Max 2026.
+- Note: While the example installs 3ds Max 2024 and 2025, Deadline Cloud's submitter supports 3ds Max 2026 and 2027 as well. The installation script should work equivalently for 3ds Max 2026 and 2027.
 
 ## Generating a script for your version using Kiro
 

--- a/skills/3dsmax-host-config/README.md
+++ b/skills/3dsmax-host-config/README.md
@@ -21,6 +21,6 @@ AWS Deadline Cloud Service Managed Fleet workers.
    - `"Create a host configuration script for 3ds Max 2026 and V-Ray 8"`
    - `"Add a host config script for 3ds Max 2027 with Forest Pack 10 and RailClone 7"`
 3. Kiro will generate the `.ps1` script and a `README.md` for your version combination
-4. Fill in the `TODO` variables at the top of the script (your S3 bucket name and installer file names)
+4. Fill in the `TODO` variables at the top of the script — each installer has its own full S3 URI variable (e.g. `$3DS_MAX_INSTALLER_ZIP_S3_URI="s3://your-bucket/path/to/installer.zip"`)
 5. Upload your installers to your S3 bucket
 6. Configure your Service Managed Fleet to use the generated script

--- a/skills/3dsmax-host-config/SKILL.md
+++ b/skills/3dsmax-host-config/SKILL.md
@@ -41,6 +41,9 @@ use the `host-config-from-installer` skill instead.
 - Scripts are PowerShell (`.ps1`) targeting Windows Service Managed Fleets
 - Each script downloads installers from a customer-owned S3 bucket using the AWS CLI (`aws s3 cp`)
 - All version-specific values are exposed as `$VARIABLES` at the top of the script, marked with `# TODO`
+- Each installer/plugin gets its own full S3 URI variable (e.g. `$3DS_MAX_INSTALLER_ZIP_S3_URI`) — do NOT use a shared `$BUCKET_NAME` + filename pattern
+- The 3ds Max installer variable MUST include a comment linking to the zip creation guide:
+  `# Guide on how to create the 3ds Max installer zip file: https://github.com/aws-deadline/deadline-cloud-samples/blob/mainline/host_configuration_scripts/3dsmax/README.md`
 - After installing 3ds Max, every script MUST set these environment variables at Machine scope:
   - `Path` — add `C:\Program Files\Autodesk\3ds Max <VERSION>`
   - `3DSMAX_EXECUTABLE` — path to `3dsmaxbatch.exe`
@@ -83,7 +86,7 @@ When in doubt, look at existing folder names in `host_configuration_scripts/3dsm
 
 Structure:
 1. Header comment block — what it installs, tested with, S3 requirements
-2. TODO variables — bucket name, folder names, zip names, installer file names, install roots
+2. TODO variables — one full S3 URI variable per installer/plugin file, each marked with `# TODO` and the zip guide comment for the 3ds Max installer
 3. Install 3ds Max — `mkdir C:\3dsmax_setup -Force`, `aws s3 cp`, `Expand-Archive`, `Start-Process Setup.exe -q -Wait`
 4. For each plugin — find its add-on in `skills/3dsmax-host-config/add-ons/`, download from S3 into `C:\3dsmax_setup\`, then run its silent installer
 5. Configure environment for 3ds Max
@@ -93,11 +96,15 @@ Structure:
 
 Key patterns:
 ```powershell
-# Download from S3
-aws s3 cp --no-progress "s3://$BUCKET_NAME/$ZIP_FILE" C:\3dsmax_setup\3dsmax.zip
+# TODO variables — one full S3 URI per installer/plugin
+# Guide on how to create the 3ds Max installer zip file: https://github.com/aws-deadline/deadline-cloud-samples/blob/mainline/host_configuration_scripts/3dsmax/README.md
+$3DS_MAX_INSTALLER_ZIP_S3_URI="s3://your-bucket-name/path/to/3ds-max-<YEAR>.zip"
 
-# Install 3ds Max silently
-Start-Process "C:\3dsmax_setup\$FOLDER_NAME\Setup.exe" -ArgumentList '-q' -Wait
+# Download from S3 using the URI variable directly
+aws s3 cp --no-progress "$3DS_MAX_INSTALLER_ZIP_S3_URI" C:\3dsmax_setup\3dsmax.zip
+
+# Install 3ds Max silently — Setup.exe is at the root after extracting
+Start-Process "C:\3dsmax_setup\Setup.exe" -ArgumentList '-q' -Wait
 
 # Set env vars
 [Environment]::SetEnvironmentVariable('3DSMAX_EXECUTABLE', "C:\Program Files\Autodesk\3ds Max $VERSION\3dsmaxbatch.exe", 'Machine')
@@ -140,7 +147,8 @@ version or plugin not already listed.
 
 ## Common Mistakes
 
-- Forgetting `mkdir C:\3dsmax_setup -Force` before the first `aws s3 cp`
+- Using a shared `$BUCKET_NAME` variable — each installer must have its own full S3 URI variable instead
+- Using `$FOLDER_NAME\Setup.exe` — after `Expand-Archive`, `Setup.exe` is at the root of `C:\3dsmax_setup\`
 - Missing `Exit 0` at the end
 - Setting env vars before installing — always install first, then configure
 - Using `&&` as a command separator — PowerShell uses `;` or separate lines

--- a/skills/host-config-from-installer/SKILL.md
+++ b/skills/host-config-from-installer/SKILL.md
@@ -20,8 +20,6 @@ host configuration script for AWS Deadline Cloud Windows Service Managed Fleets.
 The generated `.ps1` is based on commands that were actually tested and confirmed working — not
 guesswork or templates.
 
-> **Note:** This skill currently covers Windows only. Linux support (`.sh` / `.rpm` / `.deb` installers) will be added in a follow-up.
-
 ## Usage
 
 Use this skill when:
@@ -182,7 +180,7 @@ Include:
 - Note about TODO variables to replace
 - Note that config changes only affect Workers launched after the update is applied
 - Recommendation to set min Worker count to 1 and check CloudWatch logs
-  (log group: `/aws/deadline/farm-<farm-id>/fleet-<fleet-id>`)
+  (log group: `/aws/deadline/<farm-id>/<fleet-id>`)
 
 ## Common Mistakes
 


### PR DESCRIPTION
Fixes: N/A

### What was the problem/requirement? (What/Why)
There was no host configuration script for 3ds Max 2027, leaving customers without a ready-to-use example to install 3ds Max 2027 on Deadline Cloud Windows Service Managed Fleet workers.

### What was the solution? (How)
Added `host_configuration_scripts/3dsmax/3dsmax-2027/3dsmax-2027.ps1` — a PowerShell host config script that downloads the 3ds Max 2027 installer from S3, installs it silently, configures the required environment variables, and installs `deadline-cloud-for-3ds-max` via the bundled Python pip.

Also updated:
- `skills/3dsmax-host-config/SKILL.md` — updated key patterns to use per-installer full S3 URI variables (following the pattern introduced in #216) instead of a shared `$BUCKET_NAME` variable
- `skills/3dsmax-host-config/README.md` — updated TODO variable description to reflect the new S3 URI pattern
- `host_configuration_scripts/3dsmax/README.md` — added 3ds Max 2027 to the supported versions note

### What is the impact of this change?
Customers can now configure a Windows Service Managed Fleet to install and run 3ds Max 2027 jobs using the provided script. The skill update ensures Kiro generates correctly structured scripts for any future version requests.

### How was this change tested?
- Reviewed the generated script against the existing 2025 script and the changes introduced in PR #216
- Verified all environment variables, install paths, and S3 URI patterns are consistent with the established conventions

### Was this change documented?
Yes — `host_configuration_scripts/3dsmax/3dsmax-2027/README.md` includes prerequisites, installation steps, IAM role requirements, and CloudWatch log guidance.

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
