### PR TITLE
fix: bump lm_eval to 0.4.11 for transformers 4.56+ compatibility

### DIFF
--- a/job_bundles/vllm_lm_eval_leaderboard/template.yaml
+++ b/job_bundles/vllm_lm_eval_leaderboard/template.yaml
@@ -100,7 +100,7 @@ parameterDefinitions:
 #      conda-forge typepy hides these behind the [datetime] extra.
 - name: CondaPackages
   type: STRING
-  default: "python=3.11 vllm=0.19.1=cuda* cuda-toolkit=12.9 lm_eval=0.4.9 requests aiohttp tenacity tqdm tiktoken pytz python-dateutil"
+  default: "python=3.11 vllm=0.19.1=cuda* cuda-toolkit=12.9 lm_eval=0.4.11 requests aiohttp tenacity tqdm tiktoken pytz python-dateutil"
   userInterface:
     control: HIDDEN
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The conda-forge `vllm=0.19.1` package was rebuilt with a dependency on `transformers>=4.56.0`. In transformers 4.56+, `AutoModelForVision2Seq` was removed/renamed. `lm_eval=0.4.9` still references this attribute at import time, causing an immediate crash before any evaluation runs.

### What was the solution? (How)

Bumped `lm_eval` from `0.4.9` to `0.4.11` in the `CondaPackages` parameter default in `template.yaml`. Version 0.4.11 is compatible with `transformers>=4.56.0`.

### What is the impact of this change?
Without this fix, the job bundle fails during benchmark evaluation due to the import error. With this fix, the bundle works as intended again.

### How was this change tested?

Ran the job bundle -- all 3 default models (Qwen/Qwen2.5-0.5B, Qwen/Qwen2.5-1.5B, EleutherAI/pythia-1.4b) evaluated successfully across all 4 default benchmarks (hellaswag, arc_easy, arc_challenge, winogrande). The Aggregate step produced the expected leaderboard.csv and leaderboard.md with results matching the README examples.

### Was this change documented?

No documentation changes needed, the README does not reference the specific lm_eval version.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*