### PR TITLE
fix: handle submit-package-job when Deadline CLI is installed via submitter installer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,10 +66,22 @@ For other tools, point your assistant at the relevant `SKILL.md` directly
   `openjd check` and `openjd run --tasks <one>` to verify a single task end-
   to-end before submitting the full parameter range to a Deadline Cloud farm.
 
-## Before You Commit
+## Pre-PR checklist
 
-**Every commit title MUST use [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) syntax.**
-PRs without it will be blocked by CI. Use one of these types:
+Before opening a pull request, make sure every commit on the branch satisfies the following:
+
+- [ ] **Conventional commit title** — every commit title MUST use
+  [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) syntax
+  (see the type table below). PRs without it will be blocked by CI.
+- [ ] **Signed-off commits** — every commit MUST carry a `Signed-off-by` trailer
+  ([Developer Certificate of Origin](https://developercertificate.org/)). Create
+  commits with `git commit -s`, or add the trailer to an existing commit with
+  `git commit --amend -s`.
+- [ ] **Sample README updated** — if you changed a sample's behavior, prerequisites,
+  or parameters, update its `README.md`.
+- [ ] **Inclusive language** — no `master`/`slave`, `whitelist`/`blacklist`.
+
+### Conventional commit types
 
 | Type       | Use for                                                   |
 |------------|-----------------------------------------------------------|

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/conda_recipes/README.md
+++ b/conda_recipes/README.md
@@ -27,7 +27,10 @@ a configured package build queue as documented in the Deadline Cloud developer g
 
 To submit package build jobs, you will need the
 [Deadline Cloud CLI](https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/submit-jobs-how.html)
-installed on your workstation.
+installed on your workstation, along with a Python interpreter that has the `deadline`
+library available. Installing the CLI with `pip install deadline` satisfies both requirements.
+See [Python interpreter requirement](#python-interpreter-requirement) below if you installed
+the CLI using the standalone submitter installer.
 
 ## Submitting package build jobs
 
@@ -39,6 +42,36 @@ By default it will submit the job to a queue whose name starts with "Package", a
 use the job attachments bucket of that queue to form the conda channel `s3://<my-job-attachments-bucket>/Conda/Default`.
 
 Run the command `submit-package-job --help` to get a listing of available CLI arguments.
+
+### Python interpreter requirement
+
+The `submit-package-job` command is a thin wrapper that runs
+[submit-package-job-script.py](submit-package-job-script.py) with a Python interpreter that
+has the `deadline` library installed. How it finds that interpreter depends on how you
+installed the Deadline Cloud CLI:
+
+* **`pip install deadline`** (recommended for this workflow): the wrapper discovers the
+  interpreter automatically from the `deadline` entry point script, so no extra setup is
+  needed.
+* **Standalone submitter installer**: the installer ships a self-contained `deadline`
+  executable and does *not* bundle a reusable Python interpreter. In this case the wrapper
+  cannot find a Python to use on its own, and you must point it at one yourself by setting
+  the `DEADLINE_PYTHON` environment variable to a Python that has the `deadline` library
+  installed (`pip install deadline`):
+
+  ```
+  $ DEADLINE_PYTHON=python3 ./submit-package-job blender-4.2
+  ```
+
+  On Windows:
+
+  ```
+  > set DEADLINE_PYTHON=python
+  > submit-package-job blender-4.2
+  ```
+
+  If you run the command without a usable interpreter, it exits with an explanatory error
+  rather than a cryptic failure.
 
 ### Basic job submission
 

--- a/conda_recipes/submit-package-job
+++ b/conda_recipes/submit-package-job
@@ -2,11 +2,50 @@
 #
 # This script finds the Python that is used by the Deadline Cloud CLI,
 # and then runs submit-package-job-script.py with that Python.
+#
+# It requires a Python interpreter that has the 'deadline' library available.
+# When the Deadline Cloud CLI is installed with `pip install deadline`, this
+# script discovers that interpreter automatically from the 'deadline' entry
+# point script. The standalone submitter installer does not bundle a reusable
+# Python interpreter, so in that case you must point this script at a suitable
+# Python yourself by setting the DEADLINE_PYTHON environment variable, e.g.:
+#
+#     DEADLINE_PYTHON=python3 ./submit-package-job blender-4.2
+#
+# where that Python has the 'deadline' library installed (`pip install deadline`).
 
 set -euo pipefail
 
+usage_error() {
+    echo "ERROR: $1" >&2
+    echo >&2
+    echo "submit-package-job needs a Python interpreter that has the 'deadline' library" >&2
+    echo "installed. Set the DEADLINE_PYTHON environment variable to such an interpreter, e.g.:" >&2
+    echo >&2
+    echo "    DEADLINE_PYTHON=python3 $0 ${SCRIPT_ARGS}" >&2
+    echo >&2
+    echo "and ensure it has the library available (pip install deadline)." >&2
+    exit 1
+}
+
+# Remember the original arguments for use in error messages.
+SCRIPT_ARGS="$*"
+
+# Allow the user to specify their own Python interpreter. This is required when
+# the Deadline Cloud CLI was installed via the standalone submitter installer,
+# which does not ship a reusable Python interpreter.
+if [ -n "${DEADLINE_PYTHON:-}" ]; then
+    # Run the Python script submitter with the provided Python.
+    # Not quoting the command for cases like `DEADLINE_PYTHON="/usr/bin/env python"`.
+    $DEADLINE_PYTHON "$0-script.py" "$@"
+    exit $?
+fi
+
 # Find the path to the 'deadline' executable
-DEADLINE_PATH="$(which deadline)"
+DEADLINE_PATH="$(command -v deadline || true)"
+if [ -z "$DEADLINE_PATH" ]; then
+    usage_error "Could not find the 'deadline' command on your PATH."
+fi
 
 if [ "$(basename "$(dirname "$DEADLINE_PATH")")" = Scripts ]; then
     # Windows Python installation with Scripts directory
@@ -15,8 +54,20 @@ if [ "$(basename "$(dirname "$DEADLINE_PATH")")" = Scripts ]; then
     # Run the Python script submitter with the same Python
     "$DEADLINE_PYTHON" "$0-script.py" "$@"
 else
-    # Take the #! from the script
+    # The 'deadline' command is expected to be a pip-installed entry point
+    # script whose first line is a `#!` shebang pointing at the Python to use.
+    # The standalone submitter installer instead provides a compiled binary
+    # with no reusable interpreter, so guard against that case.
+    if [ "$(head -c 2 "$DEADLINE_PATH")" != "#!" ]; then
+        usage_error "The 'deadline' command at '$DEADLINE_PATH' is not a pip-installed Python script (it looks like the standalone submitter installer build, which does not bundle a reusable Python interpreter)."
+    fi
+
+    # Take the interpreter path from the #! shebang line.
     DEADLINE_PYTHON=$(head -1 "$DEADLINE_PATH" | cut -c 3-)
+
+    if [ -z "$DEADLINE_PYTHON" ]; then
+        usage_error "Could not determine the Python interpreter from '$DEADLINE_PATH'."
+    fi
 
     # Run the Python script submitter with the same Python.
     # Not quoting the command for cases like `#!/usr/bin/env python`

--- a/conda_recipes/submit-package-job.bat
+++ b/conda_recipes/submit-package-job.bat
@@ -4,22 +4,48 @@ REM This script finds the Python that is used by the Deadline Cloud CLI,
 REM and then runs submit-package-job-script.py with that Python.
 REM If the Deadline Cloud CLI doesn't have an associated Python.exe,
 REM it will fall back to the bare "python" command.
+REM
+REM You can override the Python interpreter to use by setting the
+REM DEADLINE_PYTHON environment variable. This is useful when the Deadline
+REM Cloud CLI was installed via the standalone submitter installer, which does
+REM not bundle a reusable Python interpreter. The interpreter you point at must
+REM have the 'deadline' library installed (pip install deadline).
+REM
+REM     set DEADLINE_PYTHON=python
+REM     submit-package-job blender-4.2
+
+set SCRIPT_PATH=%~d0%~p0%~n0-script.py
+
+REM Allow the user to specify their own Python interpreter.
+if defined DEADLINE_PYTHON (
+    set "PYTHON=%DEADLINE_PYTHON%"
+    goto runpython
+)
 
 for /f "delims=" %%F in ('where deadline') do set DEADLINE_DIR=%%~dF%%~pF
-set SCRIPT_PATH=%~d0%~p0%~n0-script.py
 for %%a in (%DEADLINE_DIR:~0,-1%) do set "DEADLINE_PARENT_DIR=%%~dpa"
 
 set "PYTHON=%DEADLINE_PARENT_DIR%Python.exe"
 where "%PYTHON%" > nul 2> nul
 if %ERRORLEVEL% NEQ 0 set PYTHON=python
 
+:runpython
 where "%PYTHON%" > nul 2> nul
 if %ERRORLEVEL% NEQ 0 goto nopython
 
 "%PYTHON%" "%SCRIPT_PATH%" %*
 
-exit /b 0
+exit /b %ERRORLEVEL%
 
 :nopython
-echo No Python interpreter was found to run submit-package-job-script.py.
+echo ERROR: No Python interpreter with the 'deadline' library was found to run
+echo submit-package-job-script.py.
+echo.
+echo If you installed the Deadline Cloud CLI via the standalone submitter
+echo installer, it does not bundle a reusable Python interpreter. Set the
+echo DEADLINE_PYTHON environment variable to a Python that has the 'deadline'
+echo library installed (pip install deadline), for example:
+echo.
+echo     set DEADLINE_PYTHON=python
+echo     %~n0 %*
 exit /b 1


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-samples/issues/123

### What was the problem/requirement? (What/Why)

The `conda_recipes/submit-package-job` wrapper script assumed the `deadline` command was always a `pip`-installed Python entry point script. On macOS/Linux it recovered the interpreter to use by reading the script's `#!` shebang line via `head -1 "$DEADLINE_PATH" | cut -c 3-`.

When the Deadline Cloud CLI is installed via the **standalone submitter installer**, `deadline` is instead a self-contained compiled binary (PyInstaller build) with no reusable Python interpreter. Feeding that binary to `head -1 | cut` hits a non-UTF-8 byte and fails with a cryptic error, leaving the user with no path forward:

```
$ sh submit-package-job aftereffects-25.1
cut: stdin: Illegal byte sequence
```

The only workaround was to uninstall the CLI and reinstall it via `pip`.

### What was the solution? (How)

- **`submit-package-job`** — Added a `DEADLINE_PYTHON` environment variable override so users can point the wrapper at any Python that has the `deadline` library installed. Guarded the shebang read by verifying the file actually begins with `#!`, and emit an actionable error (instead of a cryptic `cut` failure) for both the installer-binary case and the case where `deadline` is not found on `PATH`.
- **`submit-package-job.bat`** — Mirrored the `DEADLINE_PYTHON` override and replaced the terse `:nopython` message with one that explains the installer limitation and how to resolve it.
- **`conda_recipes/README.md`** — Documented the Python interpreter requirement, the difference between `pip install` and the standalone installer, and how to use `DEADLINE_PYTHON`.

### What is the impact of this change?

- Users who installed the CLI via the submitter installer can now submit package build jobs by setting `DEADLINE_PYTHON` to a Python that has the `deadline` library, without uninstalling/reinstalling.
- Users who hit an unsupported configuration get a clear, actionable error instead of `cut: stdin: Illegal byte sequence`.
- The existing `pip install deadline` auto-discovery path is unchanged and fully backward compatible.

### How was this change tested?

Tested on macOS with two `deadline` installs present: a standalone submitter-installer binary (`/Users/.../DeadlineClient/deadline`, a Mach-O executable) and a `pip`-installed one (a shebang script).

**Case 1 — installer binary first on `PATH` (previously failed with `Illegal byte sequence`):**
```
$ ./submit-package-job aftereffects-25.1
ERROR: The 'deadline' command at '/Users/.../DeadlineClient/deadline' is not a pip-installed Python script (it looks like the standalone submitter installer build, which does not bundle a reusable Python interpreter).

submit-package-job needs a Python interpreter that has the 'deadline' library
installed. Set the DEADLINE_PYTHON environment variable to such an interpreter, e.g.:

    DEADLINE_PYTHON=python3 ./submit-package-job aftereffects-25.1

and ensure it has the library available (pip install deadline).
```

**Case 2 — `DEADLINE_PYTHON` override (installer still first on `PATH`):**
```
$ DEADLINE_PYTHON=python3 ./submit-package-job --help
usage: submit-package-job [-h] [-q QUEUE] [--s3-channel S3_CHANNEL] ...
```

**Case 3 — `pip`-installed `deadline` first on `PATH` (auto-discovery, unchanged behavior):**
```
$ ./submit-package-job --help
usage: submit-package-job [-h] [-q QUEUE] [--s3-channel S3_CHANNEL] ...
```

**Case 4 — no `deadline` on `PATH` and no override:**
```
$ ./submit-package-job blender-4.2
ERROR: Could not find the 'deadline' command on your PATH.
...
```

`bash -n submit-package-job` passes the syntax check.

### Was this change documented?

Yes. Added a "Python interpreter requirement" section to `conda_recipes/README.md` covering the `pip` vs. standalone-installer cases and the `DEADLINE_PYTHON` override, plus a pointer to it from the prerequisites. Both wrapper scripts also gained explanatory header comments.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
