### PR TITLE
feat: Add satellite imagery classification job bundle

### DIFF
--- a/job_bundles/satellite_classification/README.md
+++ b/job_bundles/satellite_classification/README.md
@@ -1,0 +1,103 @@
+# Satellite Imagery Classification
+
+Classifies satellite image tiles into land-cover categories (water, vegetation, bare soil, rock, cloud) and stitches the results into a single map. The job runs each tile in parallel across a fleet, then merges them — a common pattern for any workload where input files are independent.
+
+Five sample tiles simulating the Grand Canyon area are automatically downloaded from the Deadline Cloud samples CDN when the job runs — no external data or accounts needed.
+
+## How It Works
+
+```
+Step 1: ClassifyTiles  (5 tasks, parallel)
+  ┌─────────┐ ┌─────────┐ ┌─────────┐ ┌─────────┐ ┌─────────┐
+  │North Rim│ │South Rim│ │ Inner   │ │ Desert  │ │  River  │
+  │         │ │         │ │ Canyon  │ │  East   │ │  West   │
+  └────┬────┘ └────┬────┘ └────┬────┘ └────┬────┘ └────┬────┘
+       │           │           │           │           │
+       ▼           ▼           ▼           ▼           ▼
+  Download tile → classify pixels → write result + color PNG
+
+Step 2: MosaicResults  (1 task, runs after Step 1 finishes)
+  Merge all tiles into one map + overview image
+```
+
+Each tile is a 4-band satellite image. The classifier looks at the color ratios between bands to decide what's on the ground — water absorbs infrared light, vegetation reflects it, etc.
+
+## Prerequisites
+
+1. **Deadline Cloud farm** with a Conda queue environment. The quickest setup is the
+   [starter farm CloudFormation template](https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/cloudformation/farm_templates/starter_farm).
+
+2. **Deadline CLI**:
+   ```bash
+   pip install deadline
+   ```
+
+3. **conda-forge channel** enabled on your queue (needed for the `rasterio` package).
+   If you used the starter farm template, set the **ProdCondaChannels** parameter to
+   `deadline-cloud conda-forge`. Otherwise, add `conda-forge` to your queue environment's
+   channel list in the [Deadline Cloud console](https://console.aws.amazon.com/deadlinecloud/home).
+
+## Usage
+
+> **Note:** When submitting with the default sample tiles (i.e. without specifying `-p TilesDir`),
+> you'll see a warning that `sample_tiles` does not exist locally — this is expected. The sample
+> tiles are downloaded on the worker at runtime. This warning does not appear when you provide
+> your own tiles directory.
+
+```bash
+# Submit with the sample tiles (downloaded automatically)
+deadline bundle submit job_bundles/satellite_classification/
+
+# Or open the GUI first to review parameters
+deadline bundle gui-submit job_bundles/satellite_classification/
+
+# Use your own tiles (skips download)
+deadline bundle submit job_bundles/satellite_classification/ \
+  -p TilesDir=/path/to/my/tiles
+```
+
+## Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| TilesDir | sample_tiles | Input directory of satellite image tiles |
+| OutputDir | output | Where results are written |
+| SampleTilesUrl | (CDN URL) | Base URL for downloading sample tiles |
+| CondaPackages | python numpy rasterio matplotlib | Software installed on workers |
+| CondaChannels | conda-forge | Package channel |
+
+## Output
+
+After the job completes:
+
+```bash
+deadline job download-output --job-id <job-id>
+```
+
+You'll get:
+- A classified `.tif` and color `.png` per input tile
+- `grand_canyon_mosaic.tif` — all tiles merged into one map
+- `grand_canyon_mosaic.png` — overview image with legend and class percentages
+
+## Running Locally
+
+```bash
+pip install numpy rasterio matplotlib
+
+# Download sample tiles
+for tile in T12S_GC_North_Rim T12S_GC_South_Rim T12S_GC_Inner_Canyon T12S_GC_Desert_East T12S_GC_River_West; do
+  python scripts/download_tile.py "$tile" \
+    https://downloads.deadlinecloud.amazonaws.com/samples/satellite-classification-tiles \
+    sample_tiles/
+done
+
+# Classify all tiles
+for tile in sample_tiles/*.tif; do
+  python scripts/classify_tile.py "$tile" output/
+done
+
+# Merge into a mosaic
+python scripts/mosaic.py output/
+```
+
+To regenerate the sample tiles from scratch instead of downloading: `python scripts/generate_sample_tiles.py`

--- a/job_bundles/satellite_classification/scripts/classify_tile.py
+++ b/job_bundles/satellite_classification/scripts/classify_tile.py
@@ -1,0 +1,154 @@
+"""
+Classify a single Sentinel-2 tile into land-cover classes using spectral indices.
+
+Input:  4-band GeoTIFF (Red, Green, Blue, NIR)
+Output: Classified GeoTIFF (single-band, class values 1-5) + PNG visualization
+
+Classes:
+  1 = Water (blue)
+  2 = Vegetation (green)
+  3 = Bare Soil (tan)
+  4 = Rock (brown)
+  5 = Cloud/Snow (white)
+
+Method: Threshold-based decision tree on NDVI, NDWI, and BSI indices.
+"""
+
+import sys
+import os
+import numpy as np
+import rasterio
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from matplotlib.colors import ListedColormap
+from matplotlib.patches import Patch
+
+
+CLASS_NAMES = {1: "Water", 2: "Vegetation", 3: "Bare Soil", 4: "Rock", 5: "Cloud/Snow"}
+CLASS_COLORS = {
+    1: [0.18, 0.55, 0.78],
+    2: [0.30, 0.69, 0.29],
+    3: [0.85, 0.75, 0.55],
+    4: [0.55, 0.35, 0.20],
+    5: [0.95, 0.95, 0.95],
+}
+
+
+def compute_indices(red, green, blue, nir):
+    """Compute spectral indices from surface reflectance bands."""
+    eps = 1e-10
+    ndvi = (nir - red) / (nir + red + eps)
+    ndwi = (green - nir) / (green + nir + eps)
+    bsi = ((red + blue) - (nir + green)) / ((red + blue) + (nir + green) + eps)
+    brightness = (red + green + blue + nir) / 4.0
+    return ndvi, ndwi, bsi, brightness
+
+
+def classify(ndvi, ndwi, bsi, brightness):
+    """Apply threshold-based decision tree for classification.
+
+    Thresholds calibrated to Sentinel-2 L2A surface reflectance (0-10000 scale):
+      cloud:      brightness > 6000 (all bands saturated)
+      water:      NDVI < -0.1 and NDWI > 0.2 (high green, very low NIR)
+      vegetation: NDVI > 0.4 (high NIR relative to Red)
+      soil:       brightness > 2200 and NDVI < 0.4 (bright, non-vegetated)
+      rock:       everything else (moderate brightness, low NDVI)
+    """
+    result = np.full(ndvi.shape, 4, dtype=np.uint8)
+
+    cloud_mask = brightness > 6000
+    result[cloud_mask] = 5
+
+    water_mask = (ndvi < -0.1) & (ndwi > 0.2) & ~cloud_mask
+    result[water_mask] = 1
+
+    veg_mask = (ndvi > 0.4) & ~cloud_mask & ~water_mask
+    result[veg_mask] = 2
+
+    soil_mask = (brightness > 2200) & (ndvi < 0.4) & ~cloud_mask & ~water_mask
+    result[soil_mask] = 3
+
+    return result
+
+
+def render_png(classified, output_path, tile_name):
+    """Render classified map as a color PNG with legend."""
+    cmap_colors = [CLASS_COLORS[i] for i in range(1, 6)]
+    cmap = ListedColormap(cmap_colors)
+
+    fig, ax = plt.subplots(1, 1, figsize=(10, 10))
+    ax.imshow(classified, cmap=cmap, vmin=1, vmax=5, interpolation="nearest")
+    ax.set_title(f"Land Cover Classification\n{tile_name}", fontsize=14)
+    ax.axis("off")
+
+    legend_patches = [
+        Patch(facecolor=CLASS_COLORS[i], edgecolor="black", label=CLASS_NAMES[i])
+        for i in range(1, 6)
+    ]
+    ax.legend(handles=legend_patches, loc="lower right", fontsize=11, framealpha=0.9)
+
+    total = classified.size
+    stats = []
+    for cls_id, cls_name in CLASS_NAMES.items():
+        pct = (classified == cls_id).sum() / total * 100
+        if pct > 0.1:
+            stats.append(f"{cls_name}: {pct:.1f}%")
+    ax.text(0.5, -0.02, " | ".join(stats), transform=ax.transAxes,
+            ha="center", fontsize=9, color="gray")
+
+    plt.tight_layout()
+    plt.savefig(output_path, dpi=150, bbox_inches="tight")
+    plt.close()
+
+
+def main():
+    if len(sys.argv) < 3:
+        print("Usage: python classify_tile.py <input_tile.tif> <output_dir>")
+        sys.exit(1)
+
+    input_path = sys.argv[1]
+    output_dir = sys.argv[2]
+    os.makedirs(output_dir, exist_ok=True)
+
+    tile_name = os.path.splitext(os.path.basename(input_path))[0]
+    print(f"Classifying: {tile_name}")
+
+    with rasterio.open(input_path) as src:
+        red = src.read(1).astype(np.float32)
+        green = src.read(2).astype(np.float32)
+        blue = src.read(3).astype(np.float32)
+        nir = src.read(4).astype(np.float32)
+        profile = src.profile.copy()
+
+    print("  Computing spectral indices (NDVI, NDWI, BSI)...")
+    ndvi, ndwi, bsi, brightness = compute_indices(red, green, blue, nir)
+
+    print("  Applying classification decision tree...")
+    classified = classify(ndvi, ndwi, bsi, brightness)
+
+    classified_path = os.path.join(output_dir, f"{tile_name}_classified.tif")
+    out_profile = profile.copy()
+    out_profile.update(count=1, dtype="uint8", compress="deflate")
+    with rasterio.open(classified_path, "w", **out_profile) as dst:
+        dst.write(classified, 1)
+        dst.set_band_description(1, "Land Cover Class")
+    print(f"  -> {classified_path}")
+
+    png_path = os.path.join(output_dir, f"{tile_name}_classified.png")
+    print("  Rendering visualization...")
+    render_png(classified, png_path, tile_name)
+    print(f"  -> {png_path}")
+
+    total = classified.size
+    print(f"\n  Classification results for {tile_name}:")
+    for cls_id, cls_name in CLASS_NAMES.items():
+        count = (classified == cls_id).sum()
+        pct = count / total * 100
+        print(f"    {cls_name:12s}: {pct:5.1f}% ({count:,} pixels)")
+    print("\n  Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/job_bundles/satellite_classification/scripts/download_tile.py
+++ b/job_bundles/satellite_classification/scripts/download_tile.py
@@ -1,0 +1,38 @@
+"""
+Download a single sample tile from the Deadline Cloud samples CDN.
+
+Usage: python download_tile.py <tile_name> <base_url> <output_dir>
+"""
+
+import os
+import sys
+import urllib.request
+
+
+def main():
+    if len(sys.argv) < 4:
+        print("Usage: python download_tile.py <tile_name> <base_url> <output_dir>")
+        sys.exit(1)
+
+    tile_name = sys.argv[1]
+    base_url = sys.argv[2].rstrip("/")
+    output_dir = sys.argv[3]
+
+    os.makedirs(output_dir, exist_ok=True)
+
+    filename = f"{tile_name}.tif"
+    url = f"{base_url}/{filename}"
+    dest = os.path.join(output_dir, filename)
+
+    if os.path.exists(dest):
+        print(f"  Tile already exists: {dest}")
+        return
+
+    print(f"  Downloading {url}")
+    urllib.request.urlretrieve(url, dest)
+    size_mb = os.path.getsize(dest) / (1024 * 1024)
+    print(f"  -> {dest} ({size_mb:.1f} MB)")
+
+
+if __name__ == "__main__":
+    main()

--- a/job_bundles/satellite_classification/scripts/generate_sample_tiles.py
+++ b/job_bundles/satellite_classification/scripts/generate_sample_tiles.py
@@ -1,0 +1,175 @@
+"""
+Generate synthetic Sentinel-2 L2A tiles simulating Grand Canyon area.
+
+Creates 5 GeoTIFF files with 4 bands (Red, Green, Blue, NIR) that mimic
+real spectral signatures for: canyon rock, Colorado River, rim vegetation,
+desert floor, and mixed terrain.
+
+Prerequisites: pip install numpy rasterio
+"""
+
+import numpy as np
+import os
+import rasterio
+from rasterio.transform import from_bounds
+from rasterio.crs import CRS
+
+
+TILE_SIZE = 512
+TILES_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "sample_tiles")
+
+TILE_CONFIGS = [
+    {
+        "name": "T12S_GC_North_Rim",
+        "bounds": (-112.2, 36.2, -112.0, 36.3),
+        "description": "North Rim - dense vegetation + exposed rock",
+        "mix": {"vegetation": 0.45, "rock": 0.40, "soil": 0.10, "water": 0.0, "cloud": 0.05},
+    },
+    {
+        "name": "T12S_GC_South_Rim",
+        "bounds": (-112.2, 36.0, -112.0, 36.1),
+        "description": "South Rim - sparse vegetation + desert + rock",
+        "mix": {"vegetation": 0.20, "rock": 0.35, "soil": 0.35, "water": 0.0, "cloud": 0.10},
+    },
+    {
+        "name": "T12S_GC_Inner_Canyon",
+        "bounds": (-112.2, 36.1, -112.0, 36.2),
+        "description": "Inner Canyon - river corridor + steep rock walls",
+        "mix": {"vegetation": 0.05, "rock": 0.65, "soil": 0.10, "water": 0.15, "cloud": 0.05},
+    },
+    {
+        "name": "T12S_GC_Desert_East",
+        "bounds": (-112.0, 36.0, -111.8, 36.1),
+        "description": "Eastern desert - painted desert, minimal vegetation",
+        "mix": {"vegetation": 0.05, "rock": 0.20, "soil": 0.65, "water": 0.0, "cloud": 0.10},
+    },
+    {
+        "name": "T12S_GC_River_West",
+        "bounds": (-112.4, 36.1, -112.2, 36.2),
+        "description": "Western river section - wider river + riparian vegetation",
+        "mix": {"vegetation": 0.15, "rock": 0.40, "soil": 0.15, "water": 0.25, "cloud": 0.05},
+    },
+]
+
+# Typical Sentinel-2 surface reflectance values (scaled 0-10000)
+# Format: [Red (B04), Green (B03), Blue (B02), NIR (B08)]
+SPECTRAL_SIGNATURES = {
+    "vegetation": {"mean": [600, 900, 500, 4500], "std": [150, 200, 100, 800]},
+    "water":      {"mean": [400, 500, 600, 200], "std": [80, 100, 120, 50]},
+    "rock":       {"mean": [2200, 1800, 1500, 2500], "std": [400, 350, 300, 500]},
+    "soil":       {"mean": [2800, 2200, 1800, 3000], "std": [500, 400, 350, 600]},
+    "cloud":      {"mean": [8000, 8500, 9000, 7500], "std": [500, 500, 500, 600]},
+}
+
+
+def generate_class_mask(size, mix, seed=42):
+    """Generate a spatially coherent land-cover mask using Voronoi-like regions."""
+    rng = np.random.default_rng(seed)
+    classes = list(mix.keys())
+    fractions = np.array([mix[c] for c in classes])
+
+    n_seeds = 30
+    seed_y = rng.integers(0, size, n_seeds)
+    seed_x = rng.integers(0, size, n_seeds)
+
+    counts_target = (fractions * n_seeds).astype(int)
+    for i, f in enumerate(fractions):
+        if f > 0 and counts_target[i] == 0:
+            counts_target[i] = 1
+    remainder = n_seeds - counts_target.sum()
+    if remainder > 0:
+        top_idx = np.argsort(-fractions)
+        for j in range(remainder):
+            counts_target[top_idx[j % len(top_idx)]] += 1
+    elif remainder < 0:
+        top_idx = np.argsort(-counts_target)
+        for j in range(-remainder):
+            counts_target[top_idx[j % len(top_idx)]] -= 1
+
+    seed_classes = []
+    for i, count in enumerate(counts_target):
+        seed_classes.extend([i] * count)
+    rng.shuffle(seed_classes)
+    seed_classes = np.array(seed_classes[:n_seeds])
+
+    yy, xx = np.mgrid[0:size, 0:size]
+    mask = np.zeros((size, size), dtype=np.uint8)
+    min_dist = np.full((size, size), np.inf)
+
+    for idx in range(n_seeds):
+        dist = (yy - seed_y[idx])**2 + (xx - seed_x[idx])**2
+        jitter = rng.normal(0, size * 5, (size, size))
+        dist = dist.astype(np.float64) + jitter
+        closer = dist < min_dist
+        min_dist[closer] = dist[closer]
+        mask[closer] = seed_classes[idx]
+
+    return mask, classes
+
+
+def generate_tile_data(mask, classes):
+    """Generate 4-band reflectance data from a class mask."""
+    rng = np.random.default_rng(123)
+    h, w = mask.shape
+    bands = np.zeros((4, h, w), dtype=np.float32)
+
+    for class_idx, class_name in enumerate(classes):
+        pixels = mask == class_idx
+        n_pixels = pixels.sum()
+        if n_pixels == 0:
+            continue
+        sig = SPECTRAL_SIGNATURES[class_name]
+        for band_idx in range(4):
+            values = rng.normal(sig["mean"][band_idx], sig["std"][band_idx] * 0.3, n_pixels)
+            bands[band_idx][pixels] = values
+
+    bands = np.clip(bands, 0, 10000).astype(np.uint16)
+    return bands
+
+
+def write_geotiff(filepath, bands, bounds):
+    """Write a 4-band GeoTIFF with geographic metadata."""
+    h, w = bands.shape[1], bands.shape[2]
+    transform = from_bounds(bounds[0], bounds[1], bounds[2], bounds[3], w, h)
+
+    with rasterio.open(
+        filepath,
+        "w",
+        driver="GTiff",
+        height=h,
+        width=w,
+        count=4,
+        dtype="uint16",
+        crs=CRS.from_epsg(4326),
+        transform=transform,
+        compress="deflate",
+    ) as dst:
+        dst.write(bands)
+        dst.set_band_description(1, "Red (B04)")
+        dst.set_band_description(2, "Green (B03)")
+        dst.set_band_description(3, "Blue (B02)")
+        dst.set_band_description(4, "NIR (B08)")
+
+
+def main():
+    os.makedirs(TILES_DIR, exist_ok=True)
+
+    print(f"Generating {len(TILE_CONFIGS)} synthetic Sentinel-2 tiles...")
+    print(f"Output directory: {TILES_DIR}\n")
+
+    for tile_idx, config in enumerate(TILE_CONFIGS):
+        print(f"  Generating: {config['name']}")
+        print(f"    {config['description']}")
+
+        mask, classes = generate_class_mask(TILE_SIZE, config["mix"], seed=42 + tile_idx)
+        bands = generate_tile_data(mask, classes)
+
+        filepath = os.path.join(TILES_DIR, f"{config['name']}.tif")
+        write_geotiff(filepath, bands, config["bounds"])
+        print(f"    -> {filepath} ({bands.nbytes / 1024:.0f} KB)\n")
+
+    print("Done! Tiles ready for classification.")
+
+
+if __name__ == "__main__":
+    main()

--- a/job_bundles/satellite_classification/scripts/mosaic.py
+++ b/job_bundles/satellite_classification/scripts/mosaic.py
@@ -1,0 +1,109 @@
+"""
+Mosaic all classified tiles into a single combined map.
+
+Reads all *_classified.tif files from the output directory,
+merges them into one image, and produces a final overview PNG.
+"""
+
+import sys
+import os
+import glob
+import numpy as np
+import rasterio
+from rasterio.merge import merge
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from matplotlib.colors import ListedColormap
+from matplotlib.patches import Patch
+
+
+CLASS_NAMES = {1: "Water", 2: "Vegetation", 3: "Bare Soil", 4: "Rock", 5: "Cloud/Snow"}
+CLASS_COLORS = {
+    1: [0.18, 0.55, 0.78],
+    2: [0.30, 0.69, 0.29],
+    3: [0.85, 0.75, 0.55],
+    4: [0.55, 0.35, 0.20],
+    5: [0.95, 0.95, 0.95],
+}
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python mosaic.py <output_dir>")
+        sys.exit(1)
+
+    output_dir = sys.argv[1]
+    classified_files = sorted(glob.glob(os.path.join(output_dir, "*_classified.tif")))
+
+    if not classified_files:
+        print("No classified tiles found. Run classify_tile.py first.")
+        sys.exit(1)
+
+    print(f"Merging {len(classified_files)} classified tiles...")
+    datasets = [rasterio.open(f) for f in classified_files]
+    mosaic_data, mosaic_transform = merge(datasets, method="first")
+    mosaic_data = mosaic_data[0]
+
+    merged_path = os.path.join(output_dir, "grand_canyon_mosaic.tif")
+    out_profile = datasets[0].profile.copy()
+    out_profile.update(
+        height=mosaic_data.shape[0],
+        width=mosaic_data.shape[1],
+        transform=mosaic_transform,
+        count=1,
+        dtype="uint8",
+        compress="deflate",
+    )
+    with rasterio.open(merged_path, "w", **out_profile) as dst:
+        dst.write(mosaic_data, 1)
+    print(f"  -> {merged_path}")
+
+    for ds in datasets:
+        ds.close()
+
+    cmap_colors = [CLASS_COLORS[i] for i in range(1, 6)]
+    cmap = ListedColormap(cmap_colors)
+    cmap.set_under(color="lightgray")
+    masked_data = np.ma.masked_where(mosaic_data == 0, mosaic_data)
+
+    fig, ax = plt.subplots(1, 1, figsize=(16, 12))
+    ax.set_facecolor("lightgray")
+    ax.imshow(masked_data, cmap=cmap, vmin=1, vmax=5, interpolation="nearest")
+    ax.set_title("Grand Canyon Land Cover Classification\n"
+                 "Sentinel-2 Spectral Index Analysis", fontsize=16)
+    ax.axis("off")
+
+    legend_patches = [
+        Patch(facecolor=CLASS_COLORS[i], edgecolor="black", label=CLASS_NAMES[i])
+        for i in range(1, 6)
+    ]
+    ax.legend(handles=legend_patches, loc="lower right", fontsize=12, framealpha=0.9)
+
+    valid_mask = mosaic_data > 0
+    total = valid_mask.sum() if valid_mask.any() else mosaic_data.size
+    stats = []
+    for cls_id, cls_name in CLASS_NAMES.items():
+        pct = (mosaic_data == cls_id).sum() / total * 100
+        if pct > 0.1:
+            stats.append(f"{cls_name}: {pct:.1f}%")
+    ax.text(0.5, -0.02, " | ".join(stats), transform=ax.transAxes,
+            ha="center", fontsize=10, color="gray")
+
+    mosaic_png = os.path.join(output_dir, "grand_canyon_mosaic.png")
+    plt.tight_layout()
+    plt.savefig(mosaic_png, dpi=150, bbox_inches="tight")
+    plt.close()
+    print(f"  -> {mosaic_png}")
+
+    print("\nFinal mosaic statistics:")
+    for cls_id, cls_name in CLASS_NAMES.items():
+        count = (mosaic_data == cls_id).sum()
+        pct = count / total * 100
+        print(f"  {cls_name:12s}: {pct:5.1f}% ({count:,} pixels)")
+    print("\nMosaic complete!")
+
+
+if __name__ == "__main__":
+    main()

--- a/job_bundles/satellite_classification/scripts/run_classify_tile.py
+++ b/job_bundles/satellite_classification/scripts/run_classify_tile.py
@@ -1,0 +1,29 @@
+"""
+Wrapper that downloads a sample tile (if needed) then classifies it.
+
+Usage: python run_classify_tile.py <tile_name> <sample_tiles_url> <tiles_dir> <output_dir>
+"""
+
+import subprocess
+import sys
+
+tile_name = sys.argv[1]
+sample_tiles_url = sys.argv[2]
+tiles_dir = sys.argv[3]
+output_dir = sys.argv[4]
+scripts_dir = sys.argv[5]
+
+subprocess.check_call([
+    sys.executable,
+    f"{scripts_dir}/download_tile.py",
+    tile_name,
+    sample_tiles_url,
+    tiles_dir,
+])
+
+subprocess.check_call([
+    sys.executable,
+    f"{scripts_dir}/classify_tile.py",
+    f"{tiles_dir}/{tile_name}.tif",
+    output_dir,
+])

--- a/job_bundles/satellite_classification/template.yaml
+++ b/job_bundles/satellite_classification/template.yaml
@@ -1,0 +1,117 @@
+specificationVersion: 'jobtemplate-2023-09'
+name: Satellite Imagery Classification - Grand Canyon
+description: |
+  Classifies Sentinel-2 satellite tiles into 5 land-cover classes
+  (Water, Vegetation, Bare Soil, Rock, Cloud/Snow) using spectral
+  index thresholds (NDVI, NDWI, BSI). Each tile is processed as an
+  independent parallel task, followed by a mosaic assembly step.
+
+parameterDefinitions:
+- name: TilesDir
+  type: PATH
+  objectType: DIRECTORY
+  dataFlow: IN
+  default: sample_tiles
+  description: "Directory containing input Sentinel-2 GeoTIFF tiles (4-band: Red, Green, Blue, NIR)."
+  userInterface:
+    control: CHOOSE_DIRECTORY
+    label: Input Tiles Directory
+    groupLabel: Input / Output
+
+- name: OutputDir
+  type: PATH
+  objectType: DIRECTORY
+  dataFlow: OUT
+  default: output
+  description: "Directory where classified GeoTIFFs, PNGs, and final mosaic will be written."
+  userInterface:
+    control: CHOOSE_DIRECTORY
+    label: Output Directory
+    groupLabel: Input / Output
+
+- name: ScriptsDir
+  type: PATH
+  objectType: DIRECTORY
+  dataFlow: IN
+  default: scripts
+  description: "Directory containing the bundled Python scripts."
+  userInterface:
+    control: HIDDEN
+
+- name: SampleTilesUrl
+  type: STRING
+  default: "https://downloads.deadlinecloud.amazonaws.com/samples/satellite-classification-tiles"
+  description: "Base URL for downloading sample tiles. Only used when TilesDir is the default."
+  userInterface:
+    control: HIDDEN
+
+- name: CondaPackages
+  type: STRING
+  default: "python numpy rasterio matplotlib"
+  description: "Packages to install via the queue's Conda environment."
+  userInterface:
+    control: LINE_EDIT
+    label: Conda Packages
+    groupLabel: Software Environment
+
+- name: CondaChannels
+  type: STRING
+  default: "conda-forge"
+  description: "Conda channels to resolve packages from."
+  userInterface:
+    control: LINE_EDIT
+    label: Conda Channels
+    groupLabel: Software Environment
+
+steps:
+- name: ClassifyTiles
+  hostRequirements:
+    amounts:
+    - name: amount.worker.vcpu
+      min: 2
+    - name: amount.worker.memory
+      min: 4096
+    attributes:
+    - name: attr.worker.os.family
+      anyOf: ["linux"]
+  parameterSpace:
+    taskParameterDefinitions:
+    - name: TileFile
+      type: STRING
+      range:
+      - T12S_GC_North_Rim
+      - T12S_GC_South_Rim
+      - T12S_GC_Inner_Canyon
+      - T12S_GC_Desert_East
+      - T12S_GC_River_West
+  script:
+    actions:
+      onRun:
+        command: python
+        args:
+        - "{{Param.ScriptsDir}}/run_classify_tile.py"
+        - "{{Task.Param.TileFile}}"
+        - "{{Param.SampleTilesUrl}}"
+        - "{{Param.TilesDir}}"
+        - "{{Param.OutputDir}}"
+        - "{{Param.ScriptsDir}}"
+
+- name: MosaicResults
+  dependencies:
+  - dependsOn: ClassifyTiles
+  hostRequirements:
+    amounts:
+    - name: amount.worker.vcpu
+      min: 2
+    - name: amount.worker.memory
+      min: 4096
+    attributes:
+    - name: attr.worker.os.family
+      anyOf: ["linux"]
+  script:
+    actions:
+      onRun:
+        command: python
+        args:
+        - "{{Param.ScriptsDir}}/mosaic.py"
+        - "{{Param.OutputDir}}"


### PR DESCRIPTION
## Summary

- Adds a new job bundle that classifies satellite image tiles into land-cover categories (water, vegetation, bare soil, rock, cloud) and merges results into a mosaic
- Each tile is processed independently across the fleet, then a final step stitches them together
- Includes 5 bundled synthetic tiles — no external data or accounts required to test

## Test plan

- [x] `openjd check` passes on the template
- [x] Submitted to a Deadline Cloud farm with conda-forge queue environment — job completed successfully
- [x] Ran `deadline bundle submit job_bundles/satellite_classification/` on a farm and verified output