### PR TITLE
feat: add persistent volumes variant for After Effects host config

### DIFF
--- a/host_configuration_scripts/aftereffects/aftereffects_redgiant/README.md
+++ b/host_configuration_scripts/aftereffects/aftereffects_redgiant/README.md
@@ -1,8 +1,12 @@
-# Host Configuration for After Effects, Red Giant, and Universe
+# Host Configuration for After Effects and Plugins
 
-This guide covers setting up the required software installers for the After Effects (AE) 2025, Red Giant and Universe (RGU) host config script package build. You'll be fetching the necessary standalone installers from After Effects and Maxon, storing them in S3, and then putting the provided ps1 script to the host configuration script so that it pulls the installer and runs it in silent mode on each Deadline worker launch. This solution has been tested and verified to work on Windows GPU SMF fleets only, but can also be applied to a CMF as well assuming your instance is a GPU Windows instance with the necessary driver installed to support GPU usage (not fully tested but theoretically should work).
+This guide covers setting up host configuration scripts for installing Adobe After Effects and optional plugins on AWS Deadline Cloud workers. You'll be fetching standalone installers, storing them in S3, and using the provided PowerShell script as a host configuration script that pulls and installs the software in silent mode on each worker launch.
 
-> **⚠️ Performance Impact**: This script can add about **15-20 minutes** to worker launch time due to software installation. This number goes down as you vertically scale your instance size up. For example, a g6.xlarge with 4 vCPUs + 16 GiB of memory adds 20 minutes while a g6.4xlarge with 16 vCPUs and 64 GiB memory adds 15 minutes. Plan accordingly for your fleet scaling and job scheduling. One strategy is to keep a warm worker alive during peak usage hours. Additionally, if you have AE jobs that doesn't require Red Giant, you can have one fleet for just AE renders via Conda and another fleet for AE + RGU using this host configuration.
+This solution has been tested and verified to work on Windows GPU SMF fleets, but can also be applied to a CMF assuming your instance is a GPU Windows instance with the necessary driver installed to support GPU usage (not fully tested but theoretically should work).
+
+> **Performance Note**: Software installation adds time to worker launch (varies with instance size — larger instances with more vCPUs and memory tend to complete faster). Plan accordingly for your fleet scaling and job scheduling. One strategy is to keep a warm worker alive during peak usage hours. Additionally, if you have AE jobs that don't require Red Giant, you can have one fleet for just AE renders via Conda and another fleet for AE + plugins using this host configuration.
+
+> **Looking for faster subsequent boot times?** See the [`aftereffects_redgiant_persistent`](../aftereffects_redgiant_persistent/) variant which uses persistent volumes to install software once and restore on subsequent boots without reinstalling.
 
 ## Prerequisites
 
@@ -14,24 +18,25 @@ This guide covers setting up the required software installers for the After Effe
 
 ## Required Installers
 
-*🔔 Note: the installer names can differ depending on the software versions, please keep note of differences so that the following script setup goes smoothly*
+*Note: Installer names can differ depending on software versions. Keep note of differences so that the script configuration goes smoothly.*
 
 ### 1. Adobe After Effects
 
-Download from Adobe Admin Console (make sure you're using an enterprise account and you have Administrator permissions):
 1. Log into [Adobe Admin Console](https://adminconsole.adobe.com/)
 2. Navigate to **Packages** > **Create a Package**
 3. Choose **Create Managed Package**
-4. For OS, select Windows 64-bt.
+4. For OS, select Windows 64-bit
 5. Under available applications, select **After Effects 2025** (or latest version). Continue with remaining default settings and don't include any add-ons since that is out-of-scope of this script.
 6. Name the package `After Effects`
 7. Download the resulting package zip file, which should be named something like `After Effects_en_US_WIN_64.zip`.
 
 See the [Adobe pre-generated packages documentation](https://helpx.adobe.com/enterprise/using/pre-generated-packages.html) for more information.
 
-Make sure to update the `$AE_INSTALLER` variable with the name of the package zip file  in the script configuration section.
+Make sure to update the `$AE_INSTALLER` variable with the name of the package zip file in the script configuration section.
 
 ### 2. Red Giant (Optional)
+
+Red Giant now [includes Universe by default as of version 2026.2.0](https://support.maxon.net/hc/en-us/articles/24114684657692-Red-Giant-2026-2-0-December-3-2025), so a separate Universe installer is no longer needed.
 
 Download from Red Giant:
 1. Log into your Maxon account
@@ -42,30 +47,16 @@ To enable Red Giant installation, set `$INSTALL_RED_GIANT = $true` in the script
 
 Make sure to update the `$RED_GIANT_INSTALLER` variable with the name of the Red Giant installer.
 
-### 3. Universe (Optional)
-
-Note that Universe is [now included in Red Giant 2026.2.0 and above by default](https://support.maxon.net/hc/en-us/articles/24114684657692-Red-Giant-2026-2-0-December-3-2025). For older versions of Red Giant, you can download Universe separately following the instructions below.
-
-Download from Red Giant:
-1. Log into your Maxon account
-2. Navigate to the [Maxon Downloads](https://www.maxon.net/en/downloads) section
-3. Download `Universe-2025.3.3_Win.exe` (or latest version) for Windows under the section Red Giant
-
-To enable standalone Universe installation, set `$INSTALL_UNIVERSE = $true` in the script configuration section.
-
-Make sure to update the `$UNIVERSE_INSTALLER` variable with the name of the Universe installer.
-
-### 4. Maxon App (required for Red Giant)
+### 3. Maxon App (required for Red Giant)
 
 This is needed to support Red Giant + Universe licensing since it serves as a proxy between your licensing server and the plugins being run.
 Download from Maxon:
-1. Log into your Maxon account
 2. Navigate to the [Maxon App](https://www.maxon.net/en/downloads) section after you scroll down a bit
 2. Download `Maxon_App_2025.4.2_Win.exe` (or latest version) for Windows under the section Maxon App
 
 Make sure to update the `$MAXON_APP_INSTALLER` variable with the name of the Maxon App installer.
 
-### 5. Microsoft Edge WebView2 Runtime (required for Red Giant)
+### 4. Microsoft Edge WebView2 Runtime (required for Red Giant)
 
 This is needed for the Maxon App installation to go smoothly. Download from Microsoft:
 1. Visit the [Microsoft Edge WebView2 download page](https://developer.microsoft.com/en-us/microsoft-edge/webview2?form=MA13LH#download)
@@ -73,7 +64,7 @@ This is needed for the Maxon App installation to go smoothly. Download from Micr
 
 Make sure to update the `$WEBVIEW2_INSTALLER` variable with the name of the WebView2 installer.
 
-### 6. Boris FX Sapphire (optional)
+### 5. Boris FX Sapphire (Optional)
 
 Download from Boris FX:
 1. Log into your Boris FX account
@@ -86,7 +77,7 @@ To enable Boris FX Sapphire installation, set `$INSTALL_BORIS_SAPPHIRE = $true` 
 
 Make sure to update the `$BORIS_SAPPHIRE_INSTALLER` variable with the name of the Boris FX Sapphire installer.
 
-### 7. Frischluft Lenscare (optional)
+### 6. Frischluft Lenscare (Optional)
 
 Download from Frischluft:
 1. Go to https://www.frischluft.com/lenscare/
@@ -99,7 +90,7 @@ To enable Lenscare installation, set `$INSTALL_LENSCARE = $true` in the script c
 
 Make sure to update the `$LENSCARE_INSTALLER` variable with the name of the Lenscare installer.
 
-### 8. RE:Vision Effects ReelSmart Motion Blur
+### 7. RE:Vision Effects ReelSmart Motion Blur (Optional)
 
 Download from RE:Vision Effects:
 1. Go to https://revisionfx.com/products/rsmb/after-effects/
@@ -113,7 +104,6 @@ To enable ReelSmart Motion Blur installation, set `$INSTALL_RSMB = $true` in the
 
 Make sure to update the `$RSMB_INSTALLER` variable with the name of the ReelSmart Motion Blur installer.
 
-
 ## S3 Bucket Setup
 
 ### 1. Create S3 Bucket Structure
@@ -123,7 +113,6 @@ If you have a job attachments bucket, you can just go ahead and use that. If you
 export INSTALLER_S3_BUCKET=your-installer-bucket
 aws s3api put-object --bucket $INSTALLER_S3_BUCKET --key Installers/
 ```
-
 
 ### 2. Upload Installers
 
@@ -138,9 +127,6 @@ aws s3 cp "After Effects_en_US_WIN_64.zip" s3://$INSTALLER_S3_BUCKET/Installers/
 aws s3 cp "RedGiant-2026.3.0-Win.exe" s3://$INSTALLER_S3_BUCKET/Installers/
 aws s3 cp "Maxon_App_2026.0.1_Win.exe" s3://$INSTALLER_S3_BUCKET/Installers/
 aws s3 cp "MicrosoftEdgeWebView2RuntimeInstallerX64.exe" s3://$INSTALLER_S3_BUCKET/Installers/
-
-# Optional, Maxon Universe is now included in Red Giant 2026.2.0 and above
-aws s3 cp "Universe-2026.0.1_Win.exe" s3://$INSTALLER_S3_BUCKET/Installers/
 
 # Optional, use if installing Boris FX Sapphire
 aws s3 cp "sapphire-ae-install-2026.exe" s3://$INSTALLER_S3_BUCKET/Installers/
@@ -183,69 +169,73 @@ This allows the host config script to pull down the installers from your S3 buck
 
 ## Usage
 
-### 1. Configure Host Config Installation Script
+### 1. Configure the Script
 
-Before running the installation script, you need to update the configuration variables at the top of the script. All configurable settings are located in the "Script Configuration Variables" section:
+Before deploying, update the configuration variables at the top of the script. All configurable settings are in the "Script Configuration Variables" section:
 
 **Basic Configuration (Required for all deployments):**
-Update with your chosen bucket's name and also change the After Effects version variable if you're not using 2025. For example:
 ```powershell
 $INSTALLER_S3_BUCKET = "your-installer-bucket"
 $AE_VERSION = "2025"
 ```
 
 **Installer File Names (Update if using different versions):**
-Take a look at the names of all of your zip files and executables that you uploaded to S3. Cross-reference them with the variable definitions in the script and update them to match what you have in S3. For example:
+
+Cross-reference the variable definitions in the script with the filenames you uploaded to S3 and update them to match:
 ```powershell
 $AE_INSTALLER = "After Effects_en_US_WIN_64.zip"
-$REDGIANT_INSTALLER = "RedGiant-2025.6.0-Win.exe"
-$UNIVERSE_INSTALLER = "Universe-2025.3.3_Win.exe"
-$MAXON_APP_INSTALLER = "Maxon_App_2025.4.2_Win.exe"
+$RED_GIANT_INSTALLER = "RedGiant-2026.3.0-Win.exe"
+$MAXON_APP_INSTALLER = "Maxon_App_2026.1.0_Win.exe"
 $WEBVIEW2_INSTALLER = "MicrosoftEdgeWebView2RuntimeInstallerX64.exe"
 ```
 
-**Customer Managed Fleet (CMF) Configuration (Optional - SMF users can skip this):**
+**Plugin Toggles:**
 
-For SMF deployments, the script works out-of-the-box with the default settings. For CMF, you can create a license endpoint and use it with CMF, see here for information on that: https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/cmf-ubl.html.
-
-Once you have that setup, get the VPC endpoint ID provided on the license endpoints console page and set the following variables as shown:
-
+Enable or disable plugins by setting the corresponding flags:
 ```powershell
-$is_cmf = $true  # Set to $true for Customer Managed Fleets
-$vpc_endpoint = "vpce-000000000000000-abcdefg.vpce-svc-000000000000000.us-west-2.vpce.amazonaws.com"  # Your VPC endpoint provided by license endpoints console page
+$INSTALL_RED_GIANT = $true       # Red Giant + Maxon App + WebView2
+$INSTALL_BORIS_SAPPHIRE = $false # Boris FX Sapphire
+$INSTALL_LENSCARE = $false       # Frischluft Lenscare
+$INSTALL_RSMB = $false           # RE:Vision Effects RSMB
 ```
 
-This will set the `redshift_LICENSE` environment variable to `7055@$vpc_endpoint` for Red Giant licensing. If you're not using UBL, you'll need to override the `redshift_LICENSE` environment variable with whatever port number or value you need to connect your CMF instance to your license server.
+**Dev testing without licenses:**
 
-You will also need to install your own Nvidia GPU driver to your CMF instance to support GPU rendering with Red Giant. Otherwise, you will most likely experience hanging or failing jobs.
+Both Lenscare and RSMB support installation without license files for dev testing. The plugins will produce watermarked output but are otherwise fully functional:
+```powershell
+$LENSCARE_HAS_LICENSE = $false  # Installs Lenscare without license — renders will be watermarked
+$RSMB_HAS_LICENSE = $false      # Installs RSMB without license — renders will be watermarked
+```
 
+> Boris FX Sapphire and Red Giant always require licensing (via license server environment variables).
+
+**Customer Managed Fleet (CMF) Configuration (Optional — SMF users can skip this):**
+
+For CMF, set up a license endpoint and configure the VPC endpoint. See the [CMF UBL guide](https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/cmf-ubl.html) for details.
+
+```powershell
+$is_cmf = $true
+$vpc_endpoint = "vpce-000000000000000-abcdefg.vpce-svc-000000000000000.us-west-2.vpce.amazonaws.com"
+```
+
+You will also need to install your own Nvidia GPU driver on your CMF instance to support GPU rendering with Red Giant.
 
 ### 2. Add Host Config Script to Windows GPU Fleet
 
-The contents of the script `.\install-software.ps1` should go in your Configuration Scripts for your fleet, which you can add to your fleet when you go to Fleets, select your fleet, go under Configurations, and add your script under Worker configuration script. Once pasted, scroll down and set the script timeout to **3600 seconds**. For more information, see the [AWS Deadline Cloud SMF administration guide](https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/smf-admin.html).
-
+Copy the script contents into your fleet's **Worker configuration script** and set timeout to **3600 seconds**. See the [SMF administration guide](https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/smf-admin.html) for details on configuring host configuration scripts.
 
 ## Local Dev Testing
-To test the script locally, run Powershell with Admin privileges on a Windows machine, add the credentials to your AWS account in the Powershell windows, and then run the following:
+
+To test the script locally, run PowerShell with Admin privileges on a Windows machine, add the credentials to your AWS account in the PowerShell window, and then run:
 
 ```powershell
-# Run the automated installer
 .\install-software.ps1
 ```
 
-You might see failures on the WebView installation though since your machine probably already has it, but you can splice that out and test the rest.
-
-The script will:
-1. Download all installers from S3
-2. Set environment variables for rendering (including Red Giant license server for CMF)
-3. Install Microsoft Edge WebView2 Runtime
-4. Install After Effects
-5. Install Maxon App
-6. Install Red Giant Suite
-7. Install Universe
+You might see failures on the WebView2 installation since your machine probably already has it, but you can splice that out and test the rest.
 
 ## Troubleshooting
 
 - Ensure all installer files are present in S3 before running
-- Verify enterprise Adobe account has package creation rights if you can't make the standalone After Effects installer package.
-- If your resulting renders are coming out corrupted on CMF, it's possible that you need to do Nvidia driver installation on your CMF to ensure that Red Giant is utilizing your GPU correctly.
+- Verify enterprise Adobe account has package creation rights if you can't make the standalone After Effects installer package
+- If your resulting renders are coming out corrupted on CMF, it's possible that you need to do Nvidia driver installation on your CMF to ensure that Red Giant is utilizing your GPU correctly

--- a/host_configuration_scripts/aftereffects/aftereffects_redgiant_persistent/README.md
+++ b/host_configuration_scripts/aftereffects/aftereffects_redgiant_persistent/README.md
@@ -1,0 +1,67 @@
+# Host Configuration for After Effects and Plugins (Persistent Volumes)
+
+A variant of [`aftereffects_redgiant`](../aftereffects_redgiant/) that supports **persistent volumes**. Software is installed once to a persistent EBS volume; subsequent worker boots restore via NTFS directory junctions in seconds instead of reinstalling.
+
+Use this when your fleet scales up and down frequently. If you don't need persistence, use the simpler [`aftereffects_redgiant`](../aftereffects_redgiant/) script.
+
+## How It Works
+
+1. **First boot**: Creates junctions redirecting install paths (e.g., `C:\Program Files\Adobe`) to the persistent volume, installs software, exports Windows service state, writes `.install-complete` marker.
+2. **Subsequent boots**: Detects marker, re-creates junctions, re-registers services. Takes seconds.
+3. **No volume configured**: Falls back to normal install (same as base script).
+
+## Setting Up Persistent Volumes
+
+Configure `persistentVolumeConfiguration` on your SMF fleet. See the [Deadline Cloud persistent storage developer guide](https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/smf-persistent-storage-dev.html) and [user guide](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/volumes.html) for full details.
+
+Example:
+```bash
+aws deadline create-fleet \
+    --farm-id farm-xxxxxxxxxxxxxxxxxxxxxxxxxxxx \
+    --display-name "AE Persistent Fleet" \
+    --role-arn arn:aws:iam::<account-id>:role/<fleet-role> \
+    --max-worker-count 10 \
+    --configuration '{
+        "serviceManagedEc2": {
+            "instanceCapabilities": {
+                "vCpuCount": { "min": 4 },
+                "memoryMiB": { "min": 16384 },
+                "osFamily": "WINDOWS",
+                "cpuArchitectureType": "x86_64",
+                "acceleratorCapabilities": {
+                    "selections": [{ "name": "l4" }],
+                    "count": { "min": 1 }
+                }
+            },
+            "instanceMarketOptions": { "type": "on-demand" },
+            "persistentVolumeConfiguration": {
+                "mountPath": "D:\\",
+                "sizeGiB": 100,
+                "iops": 3000,
+                "throughputMiB": 125,
+                "lastUsedTtlHours": 72
+            }
+        }
+    }'
+```
+
+> **Sizing Tip**: After Effects + Red Giant + Maxon App total ~10-15 GiB. 100 GiB is more than sufficient. The console default is 200 GiB.
+
+## Prerequisites
+
+Same as [`aftereffects_redgiant`](../aftereffects_redgiant/README.md#prerequisites), plus:
+- A fleet configured with `persistentVolumeConfiguration`
+
+## Usage
+
+1. Follow the [installer download and S3 upload instructions](../aftereffects_redgiant/README.md#required-installers) from the base variant.
+2. Configure the script variables at the top of `install-software-with-persistent-volumes.ps1`.
+3. Paste the script into your fleet's **Worker configuration script** and set timeout to **3600 seconds**.
+
+For full configuration details (plugin toggles, CMF setup, licensing), see the [base variant README](../aftereffects_redgiant/README.md#usage).
+
+## Troubleshooting
+
+- If restore fails, delete the persistent volume to force a fresh install on next boot. You can manage volumes from the **Storage Capabilities** tab on your fleet in the Deadline Cloud console, or via CLI: `aws deadline list-volumes --farm-id <farm-id> --fleet-id <fleet-id>` then `aws deadline delete-volume --farm-id <farm-id> --fleet-id <fleet-id> --volume-id <volume-id>`. See [DeleteVolume API](https://docs.aws.amazon.com/deadline-cloud/latest/APIReference/API_DeleteVolume.html).
+- If `DEADLINE_PERSISTENT_MOUNT` is not set, the script logs a warning and installs without persistence
+- For general issues, see the [base variant troubleshooting](../aftereffects_redgiant/README.md#troubleshooting)

--- a/host_configuration_scripts/aftereffects/aftereffects_redgiant_persistent/install-software-with-persistent-volumes.ps1
+++ b/host_configuration_scripts/aftereffects/aftereffects_redgiant_persistent/install-software-with-persistent-volumes.ps1
@@ -1,6 +1,3 @@
-# Sequential Software Installation Script
-# Downloads installers from S3 and installs Adobe After Effects, Red Giant, Boris Sapphire (optional),
-# Lenscare (optional), and RSMB (optional) in order
 Set-PSDebug -Trace 2
 $ErrorActionPreference = "Stop"
 
@@ -56,6 +53,113 @@ $AE_PLUGIN_LOCATION = "C:\Program Files\Adobe\Common\Plug-ins\7.0\MediaCore"
 $DOWNLOADS_PATH = "C:\Temp"
 $AE_LOCATION = "C:\Program Files\Adobe\Adobe After Effects $AE_VERSION\Support Files"
 
+# EBS Persistence - reads mount path set by EBS persistence script
+$MOUNT_PATH = [Environment]::GetEnvironmentVariable("DEADLINE_PERSISTENT_MOUNT", "Machine")
+if (-not $MOUNT_PATH) {
+    Write-Host "WARNING: DEADLINE_PERSISTENT_MOUNT not set - no persistence"
+    $PERSISTENCE_ENABLED = $false
+} else {
+    Write-Host "Persistent volume detected at: $MOUNT_PATH"
+    $PERSISTENCE_ENABLED = $true
+    $SW_PATH = "$MOUNT_PATH\Software"
+    $DATA_PATH = "$MOUNT_PATH\SoftwareData"
+    $SVC_BACKUP = "$MOUNT_PATH\SoftwareServices"
+    $INSTALL_MARKER = "$SW_PATH\.install-complete"
+}
+
+$junctions = @()
+if ($PERSISTENCE_ENABLED) {
+    $junctions = @(
+        @{ Link = "C:\Program Files\Adobe"; Target = "$SW_PATH\Adobe" }
+        @{ Link = "C:\ProgramData\Adobe"; Target = "$DATA_PATH\Adobe" }
+    )
+    if ($INSTALL_RED_GIANT) {
+        $junctions += @(
+            @{ Link = "C:\Program Files\Maxon"; Target = "$SW_PATH\Maxon" }
+            @{ Link = "C:\Program Files\Red Giant"; Target = "$SW_PATH\Red Giant" }
+            @{ Link = "C:\Program Files (x86)\Microsoft\EdgeWebView"; Target = "$SW_PATH\EdgeWebView" }
+            @{ Link = "C:\ProgramData\Maxon"; Target = "$DATA_PATH\Maxon" }
+            @{ Link = "C:\ProgramData\Red Giant"; Target = "$DATA_PATH\Red Giant" }
+        )
+    }
+    if ($INSTALL_BORIS_SAPPHIRE) {
+        $junctions += @(
+            @{ Link = "C:\Program Files\BorisFX"; Target = "$SW_PATH\BorisFX" }
+            @{ Link = "C:\ProgramData\BorisFX"; Target = "$DATA_PATH\BorisFX" }
+            @{ Link = "C:\ProgramData\GenArts"; Target = "$DATA_PATH\GenArts" }
+        )
+    }
+    if ($INSTALL_RSMB) {
+        $junctions += @(
+            @{ Link = "C:\Program Files\REVisionEffects"; Target = "$SW_PATH\REVisionEffects" }
+        )
+    }
+}
+
+function Setup-Junctions {
+    param([bool]$CreateTargets)
+    foreach ($j in $junctions) {
+        if (Test-Path $j.Link) {
+            $item = Get-Item $j.Link -Force
+            if ($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) {
+                Write-Host "Junction already exists: $($j.Link)"; continue
+            }
+            Remove-Item $j.Link -Recurse -Force
+        }
+        $parent = Split-Path $j.Link -Parent
+        if (-not (Test-Path $parent)) { New-Item -ItemType Directory -Path $parent -Force | Out-Null }
+        if ($CreateTargets) { New-Item -ItemType Directory -Path $j.Target -Force | Out-Null }
+        New-Item -ItemType Junction -Path $j.Link -Target $j.Target
+        Write-Host "Junction: $($j.Link) -> $($j.Target)"
+    }
+}
+
+# Snapshots Red Giant Windows service registrations to JSON on the persistent volume.
+# Installers register services that are lost when a new worker boots with a fresh OS
+# but reuses the same EBS volume. We save each service's binary path, start mode, and
+# display name so Import-InstallerState can re-register them in seconds.
+function Export-InstallerState {
+    New-Item -ItemType Directory -Path $SVC_BACKUP -Force | Out-Null
+    $services = Get-WmiObject Win32_Service | Where-Object {
+        $_.PathName -like "*Red Giant*" -or $_.Name -like "*RedGiant*"
+    }
+    foreach ($svc in $services) {
+        @{ Name = $svc.Name; DisplayName = $svc.DisplayName; PathName = $svc.PathName
+           StartMode = $svc.StartMode; Description = $svc.Description
+        } | ConvertTo-Json | Out-File "$SVC_BACKUP\$($svc.Name).json"
+        Write-Host "Exported service: $($svc.Name)"
+    }
+}
+
+# Re-registers Windows services from the JSON snapshots saved by Export-InstallerState.
+# On subsequent boots the persistent volume already has the binaries, but the fresh OS
+# has no knowledge of the services. This reads each backup, creates the service via sc.exe,
+# and starts it if it was originally set to Auto start.
+function Import-InstallerState {
+    if (Test-Path $SVC_BACKUP) {
+        foreach ($file in Get-ChildItem "$SVC_BACKUP\*.json") {
+            try {
+                $svcInfo = Get-Content $file.FullName | ConvertFrom-Json
+                if ($svcInfo.Name -notlike "*Red Giant*") { Write-Host "Skipping service: $($svcInfo.Name)"; continue }
+                $existing = Get-Service -Name $svcInfo.Name -ErrorAction SilentlyContinue
+                if ($existing) { Write-Host "Service already registered: $($svcInfo.Name)" }
+                else {
+                    $startType = switch ($svcInfo.StartMode) { "Auto" { "auto" } "Manual" { "demand" } "Disabled" { "disabled" } default { "auto" } }
+                    sc.exe create $svcInfo.Name binPath= "$($svcInfo.PathName)" start= $startType DisplayName= "$($svcInfo.DisplayName)"
+                    if ($svcInfo.Description) { sc.exe description $svcInfo.Name "$($svcInfo.Description)" }
+                    Write-Host "Re-registered service: $($svcInfo.Name)"
+                }
+                if ($svcInfo.StartMode -eq "Auto") {
+                    Start-Service -Name $svcInfo.Name -ErrorAction SilentlyContinue
+                    Write-Host "Started service: $($svcInfo.Name)"
+                }
+            } catch {
+                Write-Host "WARNING: Failed to restore service $($file.Name): $_"
+            }
+        }
+    }
+}
+
 # MAIN LOGIC
 $scriptStartTime = Get-Date
 
@@ -64,6 +168,22 @@ Write-Host "Setting environment variables for rendering..."
 [System.Environment]::SetEnvironmentVariable("MAXON_RENDERONLY", "true", [System.EnvironmentVariableTarget]::Machine)
 if ($INSTALL_RED_GIANT -and $is_cmf) {
     [System.Environment]::SetEnvironmentVariable("redshift_LICENSE", "7055@$vpc_endpoint", [System.EnvironmentVariableTarget]::Machine)
+}
+
+if ($PERSISTENCE_ENABLED -and (Test-Path $INSTALL_MARKER)) {
+    Write-Host "=== SOFTWARE FOUND ON PERSISTENT VOLUME - SKIPPING INSTALL ==="
+    $restoreStart = Get-Date
+    Setup-Junctions -CreateTargets $false
+    Import-InstallerState
+    $restoreDuration = (Get-Date) - $restoreStart
+    Write-Host "=== Restore completed in $($restoreDuration.ToString('hh\:mm\:ss')) ==="
+    Write-Host "Total Time: $(((Get-Date) - $scriptStartTime).ToString('hh\:mm\:ss'))"
+    exit 0
+}
+
+if ($PERSISTENCE_ENABLED) {
+    Write-Host "=== FIRST BOOT - INSTALLING TO PERSISTENT VOLUME ==="
+    Setup-Junctions -CreateTargets $true
 }
 
 $downloadStartTime = Get-Date
@@ -162,6 +282,12 @@ if ($INSTALL_RSMB) {
         [System.Environment]::SetEnvironmentVariable("RVL_SERVER", $RSMB_LICENSE_SERVER, [System.EnvironmentVariableTarget]::Machine)
     }
     $rsmbDuration = (Get-Date) - $rsmbStartTime
+}
+
+if ($PERSISTENCE_ENABLED) {
+    Export-InstallerState
+    Get-Date -Format "yyyy-MM-dd HH:mm:ss" | Out-File $INSTALL_MARKER
+    Write-Host "Install marker written - subsequent boots will skip installation"
 }
 
 $totalDuration = (Get-Date) - $scriptStartTime


### PR DESCRIPTION
## Summary

- Adds a new `aftereffects_redgiant_persistent` folder with a host configuration script that supports EBS persistent volumes — installs software once to a persistent EBS volume, then restores via NTFS directory junctions on subsequent boots (seconds instead of reinstalling)
- Updates the existing `aftereffects_redgiant` script to add version variables, optional licensing flags (`$LENSCARE_HAS_LICENSE`, `$RSMB_HAS_LICENSE`) for dev testing without licenses, and removes the deprecated standalone Universe installer (now bundled with Red Giant 2026.2.0+)
- Updates the existing README to reference the persistent variant for users who want faster subsequent boot times, and documents the new plugin toggle / licensing configuration

## Changes

### New: `aftereffects_redgiant_persistent/`
- `install-software-with-persistent-volumes.ps1` — Same plugin support as the base script but adds:
  - Reads `DEADLINE_PERSISTENT_MOUNT` env var to detect persistent volume availability
  - Creates NTFS directory junctions redirecting install paths to the persistent volume
  - Exports/imports Windows service registrations (Red Giant services) across reboots
  - Writes `.install-complete` marker; subsequent boots skip installation entirely
  - Falls back to normal install if no persistent volume is configured
- `README.md` — Documents persistent volume setup, fleet configuration, and how the persistence mechanism works

### Updated: `aftereffects_redgiant/`
- `install-software.ps1` — Refactored with version variables, optional license flags, removed Universe standalone installer
- `README.md` — Modernized documentation, added persistent variant cross-reference, documented dev testing without licenses

## Test plan

- [x] Verify `install-software.ps1` runs successfully on a Windows GPU SMF worker with After Effects only
- [x] Verify `install-software.ps1` runs with `$INSTALL_RED_GIANT = $true` on a Windows GPU SMF worker
- [x] Verify `install-software-with-persistent-volumes.ps1` first boot installs to persistent volume and writes marker
- [x] Verify subsequent boot detects marker and restores via junctions without reinstalling
- [x] Verify persistent script falls back to normal install when `DEADLINE_PERSISTENT_MOUNT` is not set