### PR TITLE
fix: ayon-launcher build script + cross-shell tests, document build-host requirement

### DIFF
--- a/conda_recipes/ayon-launcher/README.md
+++ b/conda_recipes/ayon-launcher/README.md
@@ -26,6 +26,23 @@ The AYON Launcher conda package provides the **runtime environment**. The studio
 pixi global install rattler-build
 ```
 
+> **Build each platform on a matching-OS host.** The build scripts are bash
+> (`build.sh` / `build_win.sh`), and rattler-build runs the build script through the
+> **build host's native shell** — bash on Linux, `cmd.exe` on Windows — while the
+> `if: unix` / `if: win` selectors choose the branch by the **target** platform. As a
+> result:
+> - Build **linux-64 on a Linux host** (bash runs `build.sh` directly).
+> - Build **win-64 on a Windows host** (`cmd.exe` expands `%RECIPE_DIR%` and launches
+>   bash to run `build_win.sh`; bash ships with the Deadline Cloud sample Windows
+>   workers and Git for Windows).
+>
+> Cross-OS builds are **not supported** — e.g. building linux-64 from Windows fails
+> because `cmd.exe` does not expand `$RECIPE_DIR`, and building win-64 from Linux fails
+> because bash does not expand `%RECIPE_DIR%`. When submitting with
+> `submit-package-job`, the job runs rattler-build on a fleet worker, so ensure the
+> queue has a fleet whose OS matches each requested conda platform (see the repo's
+> top-level `conda_recipes/README.md`).
+
 ### Linux (linux-64)
 
 The Linux source is downloaded directly from GitHub releases:

--- a/conda_recipes/ayon-launcher/recipe/build.sh
+++ b/conda_recipes/ayon-launcher/recipe/build.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -xeuo pipefail
+
+# Repackage the pre-built cx_Freeze Linux launcher release into the conda prefix.
+mkdir -p $PREFIX/opt/ayon-launcher
+cp -r ayon app_launcher common dependencies lib share shim vendor version.py LICENSE $PREFIX/opt/ayon-launcher/
+
+# Expose the launcher on PATH.
+mkdir -p $PREFIX/bin
+ln -sf ../opt/ayon-launcher/ayon $PREFIX/bin/ayon
+
+# Activation script to set the runtime environment variables.
+mkdir -p $PREFIX/etc/conda/activate.d
+cat > $PREFIX/etc/conda/activate.d/ayon-launcher.sh << 'ACTIVATE'
+#!/bin/bash
+export AYON_LAUNCHER_DIR="$CONDA_PREFIX/opt/ayon-launcher"
+export AYON_HEADLESS_MODE=1
+ACTIVATE
+chmod +x $PREFIX/etc/conda/activate.d/ayon-launcher.sh

--- a/conda_recipes/ayon-launcher/recipe/build_win.sh
+++ b/conda_recipes/ayon-launcher/recipe/build_win.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+set -xeuo pipefail
+
+# Repackage the pre-built Windows launcher release into the conda prefix.
+mkdir -p $PREFIX/opt/ayon-launcher
+cp -r ayon.exe ayon_console.exe common dependencies lib share shim vendor version.py LICENSE $PREFIX/opt/ayon-launcher/
+cp *.dll $PREFIX/opt/ayon-launcher/ || true
+
+# bash wrapper so the launcher is callable from the bash-based activation used on Windows workers.
+mkdir -p $PREFIX/Scripts
+cat > $PREFIX/Scripts/ayon << 'WRAPPER'
+#!/bin/bash
+exec "$CONDA_PREFIX/opt/ayon-launcher/ayon_console.exe" "$@"
+WRAPPER
+chmod +x $PREFIX/Scripts/ayon
+
+# Activation scripts to set the runtime environment variables.
+# The Deadline Cloud sample queue environments use bash to activate environments
+# on Windows, so we produce both .sh and .bat files.
+mkdir -p $PREFIX/etc/conda/activate.d
+cat > $PREFIX/etc/conda/activate.d/ayon-launcher.sh << 'ACTIVATE'
+#!/bin/bash
+export AYON_LAUNCHER_DIR="$CONDA_PREFIX/opt/ayon-launcher"
+export AYON_HEADLESS_MODE=1
+ACTIVATE
+chmod +x $PREFIX/etc/conda/activate.d/ayon-launcher.sh
+printf '@echo off\r\nset "AYON_LAUNCHER_DIR=%%CONDA_PREFIX%%\\opt\\ayon-launcher"\r\nset "AYON_HEADLESS_MODE=1"\r\n' > $PREFIX/etc/conda/activate.d/ayon-launcher.bat

--- a/conda_recipes/ayon-launcher/recipe/recipe.yaml
+++ b/conda_recipes/ayon-launcher/recipe/recipe.yaml
@@ -30,42 +30,19 @@ build:
     binary_relocation: false
     missing_dso_allowlist:
       - "**"
+  # Run the packaging logic from separate bash scripts rather than inline commands.
+  # Inline build.script commands are run by the build machine's default interpreter
+  # (cmd.exe on Windows), which cannot parse these bash commands. A .sh file is always
+  # run with bash via extension detection, so this works when building a linux target
+  # from a Windows machine (cross-build). bash is available on the Deadline Cloud sample
+  # Windows workers, so the win branch drives bash too.
   script:
     - if: unix
       then:
-        - mkdir -p $PREFIX/opt/ayon-launcher
-        - cp -r ayon app_launcher common dependencies lib share shim vendor version.py LICENSE $PREFIX/opt/ayon-launcher/
-        - mkdir -p $PREFIX/bin
-        - ln -sf ../opt/ayon-launcher/ayon $PREFIX/bin/ayon
-        - mkdir -p $PREFIX/etc/conda/activate.d
-        - |
-          cat > $PREFIX/etc/conda/activate.d/ayon-launcher.sh << 'ACTIVATE'
-          #!/bin/bash
-          export AYON_LAUNCHER_DIR="$CONDA_PREFIX/opt/ayon-launcher"
-          export AYON_HEADLESS_MODE=1
-          ACTIVATE
-        - chmod +x $PREFIX/etc/conda/activate.d/ayon-launcher.sh
+        - bash $RECIPE_DIR/build.sh
     - if: win
       then:
-        - mkdir -p $PREFIX/opt/ayon-launcher
-        - cp -r ayon.exe ayon_console.exe common dependencies lib share shim vendor version.py LICENSE $PREFIX/opt/ayon-launcher/
-        - cp *.dll $PREFIX/opt/ayon-launcher/ || true
-        - mkdir -p $PREFIX/Scripts
-        - |
-          cat > $PREFIX/Scripts/ayon << 'WRAPPER'
-          #!/bin/bash
-          exec "$CONDA_PREFIX/opt/ayon-launcher/ayon_console.exe" "$@"
-          WRAPPER
-        - chmod +x $PREFIX/Scripts/ayon
-        - mkdir -p $PREFIX/etc/conda/activate.d
-        - |
-          cat > $PREFIX/etc/conda/activate.d/ayon-launcher.sh << 'ACTIVATE'
-          #!/bin/bash
-          export AYON_LAUNCHER_DIR="$CONDA_PREFIX/opt/ayon-launcher"
-          export AYON_HEADLESS_MODE=1
-          ACTIVATE
-        - chmod +x $PREFIX/etc/conda/activate.d/ayon-launcher.sh
-        - printf '@echo off\r\nset "AYON_LAUNCHER_DIR=%%CONDA_PREFIX%%\\opt\\ayon-launcher"\r\nset "AYON_HEADLESS_MODE=1"\r\n' > $PREFIX/etc/conda/activate.d/ayon-launcher.bat
+        - bash %RECIPE_DIR%\build_win.sh
 
 tests:
   - if: unix

--- a/conda_recipes/ayon-launcher/recipe/recipe.yaml
+++ b/conda_recipes/ayon-launcher/recipe/recipe.yaml
@@ -30,12 +30,20 @@ build:
     binary_relocation: false
     missing_dso_allowlist:
       - "**"
-  # Run the packaging logic from separate bash scripts rather than inline commands.
-  # Inline build.script commands are run by the build machine's default interpreter
-  # (cmd.exe on Windows), which cannot parse these bash commands. A .sh file is always
-  # run with bash via extension detection, so this works when building a linux target
-  # from a Windows machine (cross-build). bash is available on the Deadline Cloud sample
-  # Windows workers, so the win branch drives bash too.
+  # The packaging logic lives in separate bash scripts (build.sh / build_win.sh)
+  # rather than inline commands, because the inline bash (mkdir -p, cp -r, heredocs)
+  # cannot be parsed by cmd.exe when the win-64 target is built on a Windows worker.
+  #
+  # rattler-build runs the build script through the build HOST's native shell
+  # (bash on Linux, cmd.exe on Windows), while the if: unix / if: win selectors choose
+  # the branch by TARGET platform. Each conda platform is therefore built on a
+  # matching-OS fleet: linux-64 on a Linux worker (bash runs build.sh directly), and
+  # win-64 on a Windows worker (cmd.exe expands %RECIPE_DIR% and launches bash, which is
+  # available on the Deadline Cloud sample Windows workers, to run build_win.sh).
+  #
+  # Building a target on a non-matching host (e.g. a linux-64 target from Windows) is
+  # NOT supported: cmd.exe will not expand $RECIPE_DIR and bash will not expand
+  # %RECIPE_DIR%, so the script invocation fails. See the recipe README for details.
   script:
     - if: unix
       then:
@@ -44,22 +52,30 @@ build:
       then:
         - bash %RECIPE_DIR%\build_win.sh
 
+# Use package_contents checks rather than `script` tests. rattler-build evaluates
+# these globs directly against the built package without launching a shell, so they
+# work on every platform - unlike `test -f/-x/-d`, which is a posix builtin that
+# cmd.exe cannot run when the win-64 package is tested on a Windows worker.
+# Paths are forward-slash and relative to the install prefix.
 tests:
   - if: unix
     then:
-      script:
-        - test -x $PREFIX/bin/ayon
-        - test -f $PREFIX/opt/ayon-launcher/ayon
-        - test -d $PREFIX/opt/ayon-launcher/dependencies
-        - test -d $PREFIX/opt/ayon-launcher/lib
+      package_contents:
+        files:
+          - bin/ayon
+          - opt/ayon-launcher/ayon
+          - opt/ayon-launcher/dependencies/**
+          - opt/ayon-launcher/lib/**
+          - etc/conda/activate.d/ayon-launcher.sh
   - if: win
     then:
-      script:
-        - test -x $PREFIX/Scripts/ayon
-        - test -f $PREFIX/opt/ayon-launcher/ayon_console.exe
-        - test -d $PREFIX/opt/ayon-launcher/dependencies
-        - test -d $PREFIX/opt/ayon-launcher/lib
-        - test -f $PREFIX/etc/conda/activate.d/ayon-launcher.sh
+      package_contents:
+        files:
+          - Scripts/ayon
+          - opt/ayon-launcher/ayon_console.exe
+          - opt/ayon-launcher/dependencies/**
+          - opt/ayon-launcher/lib/**
+          - etc/conda/activate.d/ayon-launcher.sh
 
 about:
   summary: AYON Launcher for Deadline Cloud workers — provides the pipeline runtime for headless publishing.


### PR DESCRIPTION
## What

Two changes to the `ayon-launcher` recipe, plus a docs note:

1. Move the packaging logic out of the inline `build.script` lists into separate `build.sh` (linux) / `build_win.sh` (win), invoked with `bash`.
2. Replace the `tests` `script` blocks (`test -x/-f/-d`) with `package_contents` file globs.
3. Document in the recipe README and a build comment that each conda platform must be built on a matching-OS host/fleet.

## Why

A user reported the recipe **builds the linux target fine from Linux but fails when building from Windows**, erroring on "bad syntax" at the top of the unix build block.

I verified **all four host × target combinations** on EC2 (Linux + Windows workers, rattler-build 0.67):

| Build target | Build host | Before this PR | After this PR |
|---|---|---|---|
| linux-64 | Linux  | ✅ pass | ✅ pass |
| win-64   | Windows | ❌ build failed (inline bash under cmd.exe) | ✅ build passes; test now passes |
| linux-64 | Windows | ❌ fails | ❌ still unsupported (documented) |
| win-64   | Linux   | ❌ fails | ❌ still unsupported (documented) |

### Root cause

rattler-build runs the build script through the **build host's native shell** (`bash` on Linux, `cmd.exe` on Windows), while the `if: unix` / `if: win` selectors choose the branch by the **target** platform. These are independent axes:

- The original inline bash (`mkdir -p`, `cp -r`, heredocs) can't be parsed by `cmd.exe`, so building win-64 on a Windows worker failed. Moving the logic into `build.sh` / `build_win.sh` and invoking `bash` fixes that — **verified**: win-64 builds on Windows, linux-64 on Linux.
- **Cross-OS building cannot be fixed in-recipe**: on a Windows host `cmd.exe` won't expand `$RECIPE_DIR`; on a Linux host `bash` won't expand `%RECIPE_DIR%`. Each invocation fails with exit 127. This matches how `submit-package-job` already works — it runs rattler-build on a fleet worker whose OS matches the target platform. Documented in the README and the build comment rather than papered over.

### Test fix (found during verification)

The win-64 package **test** failed even on a Windows host: `test -x/-f/-d` is a posix builtin that `cmd.exe` can't run (exit 9009). Replaced with `package_contents` globs, which rattler-build evaluates directly against the built package **without launching a shell**, so they pass on both platforms.

## Testing

All combinations above were run on real EC2 instances via SSM. Recipe validated as well-formed YAML; `build.sh` / `build_win.sh` pass `bash -n`.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.