### PR TITLE
Fix: Update 3ds Max + V-Ray host configs to handle Cloud Licensing and stop renaming the V-Ray installer

### DIFF
--- a/host_configuration_scripts/3dsmax/3dsmax-2025-and-vray/3dsmax-2025-and-vray.ps1
+++ b/host_configuration_scripts/3dsmax/3dsmax-2025-and-vray/3dsmax-2025-and-vray.ps1
@@ -25,8 +25,8 @@ Expand-Archive C:\3dsmax_setup\3dsmax.zip C:\3dsmax_setup\
 Start-Process "C:\3dsmax_setup\Setup.exe" -ArgumentList '-q' -Wait
 
 Write-Host ' --- Installing V-Ray for 3dsMax 2025 --- '
-
-aws s3 cp --no-progress "$VRAY_FOR_3DSMAX2025_INSTALLER_EXE_S3_URI" C:\3dsmax_setup\vray.exe
+$VRAY_INSTALLER = Split-Path "$VRAY_FOR_3DSMAX2025_INSTALLER_EXE_S3_URI" -Leaf
+aws s3 cp --no-progress "$VRAY_FOR_3DSMAX2025_INSTALLER_EXE_S3_URI" "C:\3dsmax_setup\$VRAY_INSTALLER"
 @"
 <DefValues>
 <Value Name="INSTALL_TYPE" DataType="value">1</Value>
@@ -40,7 +40,7 @@ aws s3 cp --no-progress "$VRAY_FOR_3DSMAX2025_INSTALLER_EXE_S3_URI" C:\3dsmax_se
 <Value Name="VISIT_SPOT3D" DataType="value">0</Value>
 </DefValues>
 "@ | Out-File -FilePath "C:\3dsmax_setup\config.xml" -Encoding UTF8
-Start-Process "C:\3dsmax_setup\vray.exe" -ArgumentList '-gui=0','-configFile=C:\3dsmax_setup\config.xml','-quiet=1' -Wait
+Start-Process "C:\3dsmax_setup\$VRAY_INSTALLER" -ArgumentList '-gui=0','-configFile=C:\3dsmax_setup\config.xml','-quiet=1' -Wait
 
 Write-Host ' --- Configuring environment for 3dsMax 2025 --- '
 
@@ -54,6 +54,9 @@ Write-Host ' --- Configuring environment for V-Ray for 3dsMax 2025 --- '
 [System.Environment]::SetEnvironmentVariable('VRAY_FOR_3DSMAX2025_MAIN', 'C:\ProgramData\Autodesk\ApplicationPlugins\VRay3dsMax2025\bin\', 'Machine')
 [System.Environment]::SetEnvironmentVariable('VRAY_FOR_3DSMAX2025_PLUGINS', 'C:\ProgramData\Autodesk\ApplicationPlugins\VRay3dsMax2025\bin\plugins\', 'Machine')
 [System.Environment]::SetEnvironmentVariable('VRAY_MDL_PATH_3DSMAX2025', "$VRAY_FOR_3DSMAX2025_INSTALL_ROOT\mdl", 'Machine')
+
+# V-Ray introduced Cloud Licensing in 7.30.02 which must be disabled for UBL to work
+Start-Process "C:\ProgramData\Autodesk\ApplicationPlugins\VRay3dsMax2025\utils\setvrlservice.exe" -ArgumentList '-cloud-server=0' -Wait -ErrorAction SilentlyContinue
 
 Write-Host ' --- Installing Deadline Cloud for 3dsMax --- '
 

--- a/host_configuration_scripts/3dsmax/3dsmax-2025-and-vray/README.md
+++ b/host_configuration_scripts/3dsmax/3dsmax-2025-and-vray/README.md
@@ -9,6 +9,7 @@ V-Ray is a professional rendering engine developed by Chaos Group for 3D compute
 1. Create an S3 bucket in your AWS account.
 2. Download the 3ds Max installer from Autodesk, zip up the installer according to [these steps](/host_configuration_scripts/3dsmax/README.md#creating-a-3ds-max-installer-archive-in-zip-format), and upload it to your S3 bucket.
 3. Download the V-Ray for 3ds Max 2025 installer from Chaos and upload it to your S3 bucket
+    - WARNING: Do not rename the V-Ray installer executable. The installer may silently fail if you give it a new name after downloading it from the Chaos Group website
 4. Configure the Windows Service Managed fleet's host configuration using [3dsmax-2025-and-vray.ps1](./3dsmax-2025-and-vray.ps1).
     - Note that there are placeholder variables at the start of the script marked with `TODO`. Please replace the values with ones matching your configuration.
 5. Save the fleet configuration.

--- a/host_configuration_scripts/3dsmax/3dsmax-2025-vray-and-aec-plugins/3dsmax-2025-vray-and-aec-plugins.ps1
+++ b/host_configuration_scripts/3dsmax/3dsmax-2025-vray-and-aec-plugins/3dsmax-2025-vray-and-aec-plugins.ps1
@@ -42,8 +42,10 @@ New-Item -ItemType Directory -Path $pluginsDir -Force
 Write-Host ' --- Downloading all installers and plugins --- '
 
 # Download all files sequentially for PowerShell 5.1 compatibility
+
+$VRAY_INSTALLER = Split-Path "$VRAY_FOR_3DSMAX2025_INSTALLER_EXE_S3_URI" -Leaf
 Write-Host 'Downloading V-Ray installer...'
-aws s3 cp --no-progress "$VRAY_FOR_3DSMAX2025_INSTALLER_EXE_S3_URI" C:\3dsmax_setup\vray.exe
+aws s3 cp --no-progress "$VRAY_FOR_3DSMAX2025_INSTALLER_EXE_S3_URI" "C:\3dsmax_setup\$VRAY_INSTALLER"
 Write-Host 'Downloading Forest Pack installer...'
 aws s3 cp --no-progress "$FOREST_PACK_INSTALLER_EXE_S3_URI" C:\3dsmax_setup\forestpack.exe
 Write-Host 'Downloading RailClone installer...'
@@ -73,7 +75,7 @@ Write-Host ' --- Installing V-Ray for 3ds Max 2025 --- '
 "@ | Out-File -FilePath "C:\3dsmax_setup\config.xml" -Encoding UTF8
 
 # Install V-Ray with render server configuration
-Start-Process "C:\3dsmax_setup\vray.exe" -ArgumentList '-gui=0','-configFile=C:\3dsmax_setup\config.xml','-quiet=1' -Wait
+Start-Process "C:\3dsmax_setup\$VRAY_INSTALLER" -ArgumentList '-gui=0','-configFile=C:\3dsmax_setup\config.xml','-quiet=1' -Wait
 
 Write-Host ' --- Installing Forest Pack --- '
 
@@ -97,6 +99,9 @@ Write-Host ' --- Configuring environment for V-Ray for 3ds Max 2025 --- '
 [System.Environment]::SetEnvironmentVariable('VRAY_FOR_3DSMAX2025_MAIN', 'C:\ProgramData\Autodesk\ApplicationPlugins\VRay3dsMax2025\bin\', 'Machine')
 [System.Environment]::SetEnvironmentVariable('VRAY_FOR_3DSMAX2025_PLUGINS', 'C:\ProgramData\Autodesk\ApplicationPlugins\VRay3dsMax2025\bin\plugins\', 'Machine')
 [System.Environment]::SetEnvironmentVariable('VRAY_MDL_PATH_3DSMAX2025', "$VRAY_FOR_3DSMAX2025_INSTALL_ROOT\mdl", 'Machine')
+
+# V-Ray introduced Cloud Licensing in 7.30.02 which must be disabled for UBL to work
+Start-Process "C:\ProgramData\Autodesk\ApplicationPlugins\VRay3dsMax2025\utils\setvrlservice.exe" -ArgumentList '-cloud-server=0' -Wait -ErrorAction SilentlyContinue
 
 Write-Host ' --- Configuring environment for Forest Pack --- '
 

--- a/host_configuration_scripts/3dsmax/3dsmax-2025-vray-and-aec-plugins/README.md
+++ b/host_configuration_scripts/3dsmax/3dsmax-2025-vray-and-aec-plugins/README.md
@@ -24,6 +24,7 @@ This script can be adapted for other compatible versions by updating the variabl
 1. Create an S3 bucket in your AWS account.
 2. Download the 3ds Max installer from Autodesk, zip up the installer following [these steps](/host_configuration_scripts/3dsmax/README.md#creating-a-3ds-max-installer-archive-in-zip-format), and upload it to your S3 bucket.
 3. Download the V-Ray for 3ds Max 2025 installer from Chaos and upload it to your S3 bucket.
+    - WARNING: Do not rename the V-Ray installer executable. The installer may silently fail if you give it a new name after downloading it from the Chaos Group website
 4. Download the Forest Pack installer from iToo Software and upload it to your S3 bucket.
 5. Download the RailClone installer from iToo Software and upload it to your S3 bucket.
 6. Download the FloorGenerator and MultiTexture plugin files and upload them to your S3 bucket.

--- a/host_configuration_scripts/3dsmax/3dsmax-2025-vray-and-tyflow/3dsmax-2025-vray-and-tyflow.ps1
+++ b/host_configuration_scripts/3dsmax/3dsmax-2025-vray-and-tyflow/3dsmax-2025-vray-and-tyflow.ps1
@@ -32,7 +32,8 @@ Start-Process "C:\3dsmax_setup\Setup.exe" -ArgumentList '-q' -Wait
 
 Write-Host ' --- Installing V-Ray for 3dsMax 2025 --- '
 
-aws s3 cp --no-progress "$VRAY_FOR_3DSMAX2025_INSTALLER_EXE_S3_URI" C:\3dsmax_setup\vray.exe
+$VRAY_INSTALLER = Split-Path "$VRAY_FOR_3DSMAX2025_INSTALLER_EXE_S3_URI" -Leaf
+aws s3 cp --no-progress "$VRAY_FOR_3DSMAX2025_INSTALLER_EXE_S3_URI" "C:\3dsmax_setup\$VRAY_INSTALLER"
 @"
 <DefValues>
 <Value Name="INSTALL_TYPE" DataType="value">1</Value>
@@ -46,7 +47,7 @@ aws s3 cp --no-progress "$VRAY_FOR_3DSMAX2025_INSTALLER_EXE_S3_URI" C:\3dsmax_se
 <Value Name="VISIT_SPOT3D" DataType="value">0</Value>
 </DefValues>
 "@ | Out-File -FilePath "C:\3dsmax_setup\config.xml" -Encoding UTF8
-Start-Process "C:\3dsmax_setup\vray.exe" -ArgumentList '-gui=0','-configFile=C:\3dsmax_setup\config.xml','-quiet=1' -Wait
+Start-Process "C:\3dsmax_setup\$VRAY_INSTALLER" -ArgumentList '-gui=0','-configFile=C:\3dsmax_setup\config.xml','-quiet=1' -Wait
 
 Write-Host ' --- Installing tyFlow Plugin --- '
 
@@ -67,6 +68,9 @@ Write-Host ' --- Configuring environment for V-Ray for 3dsMax 2025 --- '
 [System.Environment]::SetEnvironmentVariable('VRAY_FOR_3DSMAX2025_MAIN', 'C:\ProgramData\Autodesk\ApplicationPlugins\VRay3dsMax2025\bin\', 'Machine')
 [System.Environment]::SetEnvironmentVariable('VRAY_FOR_3DSMAX2025_PLUGINS', 'C:\ProgramData\Autodesk\ApplicationPlugins\VRay3dsMax2025\bin\plugins\', 'Machine')
 [System.Environment]::SetEnvironmentVariable('VRAY_MDL_PATH_3DSMAX2025', "$VRAY_FOR_3DSMAX2025_INSTALL_ROOT\mdl", 'Machine')
+
+# V-Ray introduced Cloud Licensing in 7.30.02 which must be disabled for UBL to work
+Start-Process "C:\ProgramData\Autodesk\ApplicationPlugins\VRay3dsMax2025\utils\setvrlservice.exe" -ArgumentList '-cloud-server=0' -Wait -ErrorAction SilentlyContinue
 
 Write-Host ' --- Installing Deadline Cloud for 3dsMax --- '
 

--- a/host_configuration_scripts/3dsmax/3dsmax-2025-vray-and-tyflow/README.md
+++ b/host_configuration_scripts/3dsmax/3dsmax-2025-vray-and-tyflow/README.md
@@ -12,6 +12,7 @@ tyFlow is a powerful particle system and physics simulation plugin for 3ds Max, 
 1. Create an S3 bucket in your AWS account.
 2. Download the 3ds Max installer from Autodesk, zip up the installer following [these steps](/host_configuration_scripts/3dsmax/README.md#creating-a-3ds-max-installer-archive-in-zip-format), and upload it to your S3 bucket.
 3. Download the V-Ray for 3ds Max 2025 installer from Chaos and upload it to your S3 bucket.
+    - WARNING: Do not rename the V-Ray installer executable. The installer may silently fail if you give it a new name after downloading it from the Chaos Group website
 4. Download the tyFlow plugin file and upload it to your S3 bucket.
 5. Configure the Windows Service Managed fleet's host configuration using [3dsmax-2025-vray-and-tyflow.ps1](./3dsmax-2025-vray-and-tyflow.ps1).
     - Note that there are placeholder variables at the start of the script marked with `TODO`. Please replace the values with ones matching your configuration.

--- a/host_configuration_scripts/3dsmax/3dsmax-2027-and-vray-and-tyflow/3dsmax-2027-and-vray-and-tyflow.ps1
+++ b/host_configuration_scripts/3dsmax/3dsmax-2027-and-vray-and-tyflow/3dsmax-2027-and-vray-and-tyflow.ps1
@@ -30,7 +30,8 @@ Start-Process "C:\3dsmax_setup\Setup.exe" -ArgumentList '-q' -Wait
 
 Write-Host ' --- Installing V-Ray for 3ds Max 2027 --- '
 
-aws s3 cp --no-progress "$VRAY_FOR_3DSMAX2027_INSTALLER_EXE_S3_URI" C:\3dsmax_setup\vray.exe
+$VRAY_INSTALLER = Split-Path "$VRAY_FOR_3DSMAX2027_INSTALLER_EXE_S3_URI" -Leaf
+aws s3 cp --no-progress "$VRAY_FOR_3DSMAX2027_INSTALLER_EXE_S3_URI" "C:\3dsmax_setup\$VRAY_INSTALLER"
 @"
 <DefValues>
 <Value Name="INSTALL_TYPE" DataType="value">1</Value>
@@ -44,7 +45,7 @@ aws s3 cp --no-progress "$VRAY_FOR_3DSMAX2027_INSTALLER_EXE_S3_URI" C:\3dsmax_se
 <Value Name="VISIT_SPOT3D" DataType="value">0</Value>
 </DefValues>
 "@ | Out-File -FilePath "C:\3dsmax_setup\config.xml" -Encoding UTF8
-Start-Process "C:\3dsmax_setup\vray.exe" -ArgumentList '-gui=0','-configFile=C:\3dsmax_setup\config.xml','-quiet=1' -Wait
+Start-Process "C:\3dsmax_setup\$VRAY_INSTALLER" -ArgumentList '-gui=0','-configFile=C:\3dsmax_setup\config.xml','-quiet=1' -Wait
 
 Write-Host ' --- Installing tyFlow Plugin --- '
 
@@ -66,6 +67,9 @@ Write-Host ' --- Configuring environment for V-Ray for 3ds Max 2027 --- '
 [System.Environment]::SetEnvironmentVariable('VRAY_FOR_3DSMAX2027_MAIN', 'C:\ProgramData\Autodesk\ApplicationPlugins\VRay3dsMax2027\bin\', 'Machine')
 [System.Environment]::SetEnvironmentVariable('VRAY_FOR_3DSMAX2027_PLUGINS', 'C:\ProgramData\Autodesk\ApplicationPlugins\VRay3dsMax2027\bin\plugins\', 'Machine')
 [System.Environment]::SetEnvironmentVariable('VRAY_MDL_PATH_3DSMAX2027', "$VRAY_FOR_3DSMAX2027_INSTALL_ROOT\mdl", 'Machine')
+
+# V-Ray introduced Cloud Licensing in 7.30.02 which must be disabled for UBL to work
+Start-Process "C:\ProgramData\Autodesk\ApplicationPlugins\VRay3dsMax2027\utils\setvrlservice.exe" -ArgumentList '-cloud-server=0' -Wait -ErrorAction SilentlyContinue
 
 Write-Host ' --- Installing Deadline Cloud for 3ds Max --- '
 

--- a/host_configuration_scripts/3dsmax/3dsmax-2027-and-vray-and-tyflow/README.md
+++ b/host_configuration_scripts/3dsmax/3dsmax-2027-and-vray-and-tyflow/README.md
@@ -6,6 +6,7 @@ This sample host configuration script configures your Service Managed Fleet with
 1. Create an S3 bucket in your AWS account.
 2. Download the 3ds Max installer from Autodesk, zip up the installer, and upload it to your S3 bucket.
 3. Download the V-Ray for 3ds Max 2027 installer from Chaos and upload it to your S3 bucket.
+    - WARNING: Do not rename the V-Ray installer executable. The installer may silently fail if you give it a new name after downloading it from the Chaos Group website
 4. Download the tyFlow plugin file for 3ds Max 2027 and upload it to your S3 bucket.
 5. Configure the Windows Service Managed fleet's host configuration using [3dsmax-2027-and-vray-and-tyflow.ps1](./3dsmax-2027-and-vray-and-tyflow.ps1).
     - Replace the `TODO` variables at the top with your S3 URIs.

--- a/host_configuration_scripts/3dsmax/3dsmax-2027-and-vray/3dsmax-2027-and-vray.ps1
+++ b/host_configuration_scripts/3dsmax/3dsmax-2027-and-vray/3dsmax-2027-and-vray.ps1
@@ -27,7 +27,8 @@ Start-Process "C:\3dsmax_setup\Setup.exe" -ArgumentList '-q' -Wait
 
 Write-Host ' --- Installing V-Ray for 3ds Max 2027 --- '
 
-aws s3 cp --no-progress "$VRAY_FOR_3DSMAX2027_INSTALLER_EXE_S3_URI" C:\3dsmax_setup\vray.exe
+$VRAY_INSTALLER = Split-Path "$VRAY_FOR_3DSMAX2027_INSTALLER_EXE_S3_URI" -Leaf
+aws s3 cp --no-progress "$VRAY_FOR_3DSMAX2027_INSTALLER_EXE_S3_URI" "C:\3dsmax_setup\$VRAY_INSTALLER"
 @"
 <DefValues>
 <Value Name="INSTALL_TYPE" DataType="value">1</Value>
@@ -41,7 +42,7 @@ aws s3 cp --no-progress "$VRAY_FOR_3DSMAX2027_INSTALLER_EXE_S3_URI" C:\3dsmax_se
 <Value Name="VISIT_SPOT3D" DataType="value">0</Value>
 </DefValues>
 "@ | Out-File -FilePath "C:\3dsmax_setup\config.xml" -Encoding UTF8
-Start-Process "C:\3dsmax_setup\vray.exe" -ArgumentList '-gui=0','-configFile=C:\3dsmax_setup\config.xml','-quiet=1' -Wait
+Start-Process "C:\3dsmax_setup\$VRAY_INSTALLER" -ArgumentList '-gui=0','-configFile=C:\3dsmax_setup\config.xml','-quiet=1' -Wait
 
 Write-Host ' --- Configuring environment for 3ds Max 2027 --- '
 
@@ -55,6 +56,9 @@ Write-Host ' --- Configuring environment for V-Ray for 3ds Max 2027 --- '
 [System.Environment]::SetEnvironmentVariable('VRAY_FOR_3DSMAX2027_MAIN', 'C:\ProgramData\Autodesk\ApplicationPlugins\VRay3dsMax2027\bin\', 'Machine')
 [System.Environment]::SetEnvironmentVariable('VRAY_FOR_3DSMAX2027_PLUGINS', 'C:\ProgramData\Autodesk\ApplicationPlugins\VRay3dsMax2027\bin\plugins\', 'Machine')
 [System.Environment]::SetEnvironmentVariable('VRAY_MDL_PATH_3DSMAX2027', "$VRAY_FOR_3DSMAX2027_INSTALL_ROOT\mdl", 'Machine')
+
+# V-Ray introduced Cloud Licensing in 7.30.02 which must be disabled for UBL to work
+Start-Process "C:\ProgramData\Autodesk\ApplicationPlugins\VRay3dsMax2027\utils\setvrlservice.exe" -ArgumentList '-cloud-server=0' -Wait -ErrorAction SilentlyContinue
 
 Write-Host ' --- Installing Deadline Cloud for 3ds Max --- '
 

--- a/host_configuration_scripts/3dsmax/3dsmax-2027-and-vray/README.md
+++ b/host_configuration_scripts/3dsmax/3dsmax-2027-and-vray/README.md
@@ -6,6 +6,7 @@ This sample host configuration script configures your Service Managed Fleet with
 1. Create an S3 bucket in your AWS account.
 2. Download the 3ds Max installer from Autodesk, zip up the installer, and upload it to your S3 bucket.
 3. Download the V-Ray for 3ds Max 2027 installer from Chaos and upload it to your S3 bucket.
+    - WARNING: Do not rename the V-Ray installer executable. The installer may silently fail if you give it a new name after downloading it from the Chaos Group website
 4. Configure the Windows Service Managed fleet's host configuration using [3dsmax-2027-and-vray.ps1](./3dsmax-2027-and-vray.ps1).
     - Replace the `TODO` variables at the top with your S3 URIs.
 5. Save the fleet configuration.

--- a/host_configuration_scripts/3dsmax/3dsmax-2027-vray-and-aec-plugins/3dsmax-2027-vray-and-aec-plugins.ps1
+++ b/host_configuration_scripts/3dsmax/3dsmax-2027-vray-and-aec-plugins/3dsmax-2027-vray-and-aec-plugins.ps1
@@ -41,8 +41,9 @@ Start-Process "C:\3dsmax_setup\Setup.exe" -ArgumentList '-q' -Wait
 
 Write-Host ' --- Downloading all installers and plugins --- '
 
+$VRAY_INSTALLER = Split-Path "$VRAY_FOR_3DSMAX2027_INSTALLER_EXE_S3_URI" -Leaf
 Write-Host 'Downloading V-Ray installer...'
-aws s3 cp --no-progress "$VRAY_FOR_3DSMAX2027_INSTALLER_EXE_S3_URI" C:\3dsmax_setup\vray.exe
+aws s3 cp --no-progress "$VRAY_FOR_3DSMAX2027_INSTALLER_EXE_S3_URI" "C:\3dsmax_setup\$VRAY_INSTALLER"
 Write-Host 'Downloading Forest Pack installer...'
 aws s3 cp --no-progress "$FOREST_PACK_INSTALLER_EXE_S3_URI" C:\3dsmax_setup\forestpack.exe
 Write-Host 'Downloading RailClone installer...'
@@ -75,7 +76,7 @@ Write-Host ' --- Installing V-Ray for 3ds Max 2027 --- '
 <Value Name="VISIT_SPOT3D" DataType="value">0</Value>
 </DefValues>
 "@ | Out-File -FilePath "C:\3dsmax_setup\config.xml" -Encoding UTF8
-Start-Process "C:\3dsmax_setup\vray.exe" -ArgumentList '-gui=0','-configFile=C:\3dsmax_setup\config.xml','-quiet=1' -Wait
+Start-Process "C:\3dsmax_setup\$VRAY_INSTALLER" -ArgumentList '-gui=0','-configFile=C:\3dsmax_setup\config.xml','-quiet=1' -Wait
 
 Write-Host ' --- Installing Forest Pack --- '
 
@@ -97,6 +98,9 @@ Write-Host ' --- Configuring environment for V-Ray for 3ds Max 2027 --- '
 [System.Environment]::SetEnvironmentVariable('VRAY_FOR_3DSMAX2027_MAIN', 'C:\ProgramData\Autodesk\ApplicationPlugins\VRay3dsMax2027\bin\', 'Machine')
 [System.Environment]::SetEnvironmentVariable('VRAY_FOR_3DSMAX2027_PLUGINS', 'C:\ProgramData\Autodesk\ApplicationPlugins\VRay3dsMax2027\bin\plugins\', 'Machine')
 [System.Environment]::SetEnvironmentVariable('VRAY_MDL_PATH_3DSMAX2027', "$VRAY_FOR_3DSMAX2027_INSTALL_ROOT\mdl", 'Machine')
+
+# V-Ray introduced Cloud Licensing in 7.30.02 which must be disabled for UBL to work
+Start-Process "C:\ProgramData\Autodesk\ApplicationPlugins\VRay3dsMax2027\utils\setvrlservice.exe" -ArgumentList '-cloud-server=0' -Wait -ErrorAction SilentlyContinue
 
 Write-Host ' --- Configuring environment for Forest Pack --- '
 

--- a/host_configuration_scripts/3dsmax/3dsmax-2027-vray-and-aec-plugins/README.md
+++ b/host_configuration_scripts/3dsmax/3dsmax-2027-vray-and-aec-plugins/README.md
@@ -6,6 +6,7 @@ This sample host configuration script configures your Service Managed Fleet with
 1. Create an S3 bucket in your AWS account.
 2. Download the 3ds Max installer from Autodesk, zip up the installer, and upload it to your S3 bucket.
 3. Download the V-Ray for 3ds Max 2027 installer from Chaos and upload it to your S3 bucket.
+    - WARNING: Do not rename the V-Ray installer executable. The installer may silently fail if you give it a new name after downloading it from the Chaos Group website
 4. Download the Forest Pack and RailClone installers from iToo Software and upload them to your S3 bucket.
 5. Download the FloorGenerator and MultiTexture plugin files and upload them to your S3 bucket.
 6. Configure the Windows Service Managed fleet's host configuration using [3dsmax-2027-vray-and-aec-plugins.ps1](./3dsmax-2027-vray-and-aec-plugins.ps1).


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The host configuration scripts for 3ds Max + V-Ray were failing or not resulting in successful renders.

### What was the solution? (How)

Edited the host configuration scripts to stop renaming the V-Ray installer and to add a line that disables Cloud Licensing to unblock UBL.

### What is the impact of this change?

Users should be able to render with 3ds Max and V-Ray on SMF again

### How was this change tested?

I tested against 3ds Max 2026 and various versions of V-Ray ranging from 7.0 to 7.40. I've not had time to go through all versions of 3ds Max, or all the different host config scripts variations.

Successful render from 3ds Max 2026 and Vray 7.30.02: 
<img width="1279" height="719" alt="image" src="https://github.com/user-attachments/assets/a836195b-4447-40eb-9955-106cc7bd9d28" />


### Was this change documented?

The change comes with updated readmes and code comments that help to explain the change.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*