### PR TITLE
ci: add Security Scan stub (zizmor via reusable org workflow)

### DIFF
--- a/.github/workflows/claude_pr_review.yml
+++ b/.github/workflows/claude_pr_review.yml
@@ -11,7 +11,7 @@
 # workflow_run identifiers and the role-ARN secret.
 name: Claude PR Review
 
-on:
+on: # zizmor: ignore[dangerous-triggers] -- workflow_run is intentional and safe here; see the header comment above (runs from default branch, fork PRs cannot alter behavior/secrets)
   workflow_run:
     workflows: ["Claude PR Review (collect)"]
     types:

--- a/.github/workflows/on_opened_pr.yml
+++ b/.github/workflows/on_opened_pr.yml
@@ -1,6 +1,9 @@
 name: On Opened PR
 
-on:
+on: # zizmor: ignore[dangerous-triggers]
+  # workflow_run is intentional: it runs from the default branch with this
+  # repo's context (never a fork's copy), and only consumes the PR artifact via
+  # the reusable extract-PR-details workflow. A fork PR cannot alter behavior.
   workflow_run:
     workflows: ["Record PR"]
     types:

--- a/.github/workflows/security_scan.yml
+++ b/.github/workflows/security_scan.yml
@@ -1,0 +1,21 @@
+name: "Security Scan"
+
+on:
+  push:
+    branches: [ "mainline", "feature_*", "patch_*" ]
+  pull_request:
+    branches: [ "mainline", "feature_*", "patch_*" ]
+  schedule:
+    - cron: '0 8 * * MON'
+
+jobs:
+  Scan:
+    name: Scan
+    # Central, extensible security-scan workflow (currently zizmor). New checks
+    # added there apply here automatically — no change needed to this stub.
+    uses: aws-deadline/.github/.github/workflows/reusable_security_scan.yml@mainline
+    permissions:
+      # The reusable workflow checks out this repo and fetches the central
+      # zizmor config, and reports findings to the run log / PR annotations
+      # (not the Security tab), so it only needs read access.
+      contents: read


### PR DESCRIPTION
## What

Adds `.github/workflows/security_scan.yml`, a thin stub that calls the central reusable Security Scan workflow (`aws-deadline/.github/.github/workflows/reusable_security_scan.yml@mainline`). The reusable workflow runs zizmor with the org-central config and gates PRs on **high**-severity findings. New checks added centrally apply here automatically — no per-repo change needed.

## Zizmor fixes (to make CI green)

Ran `zizmor --min-severity high` against `.github/`. Findings:

- **dangerous-triggers (2)** — `claude_pr_review.yml` and `on_opened_pr.yml` both use the `workflow_run` trigger. These run from the default branch with this repo's context (never a fork's copy), and fork PRs cannot alter behavior or access secrets. Suppressed with inline `# zizmor: ignore[dangerous-triggers]` plus justification comments.

No `unpinned-uses` findings: every `uses:` ref in this repo points at an internal `aws-deadline/*@mainline` reusable workflow, which the central config allows as a ref-pin.

After fixes: `zizmor --min-severity high` reports **0 findings**.

## Commits
1. `ci: fix all high-severity zizmor findings in workflows`
2. `ci: add Security Scan stub calling the reusable org workflow`