### PR TITLE
feat(terraform): add KNFSD cross-region NFS cache sample

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -9,6 +9,7 @@ This table covers every immediate sample directory below `terraform/farm_templat
 | Sample | What it demonstrates | Start here when |
 |---|---|---|
 | [Starter farm](farm_templates/starter_farm/) | A farm, queue, service-managed fleets, and package-build support using AWSCC resources | Your team manages infrastructure with Terraform |
+| [KNFSD cross-region cache](farm_templates/knfsd_xregion_cache/) | A service-managed fleet reading a distant NFS filer through a KNFSD read cache over a VPC resource endpoint, deployed cross-region to stand in for an on-premises origin | You cache reads from an on-premises or otherwise-distant filer for a render/simulation fleet |
 
 The starter farm can run rendering, reconstruction, and data-transformation jobs from the [job bundle index](../job_bundles/). It is the Terraform equivalent of the [CloudFormation starter farm](../cloudformation/farm_templates/starter_farm/) and includes support for [building custom Conda packages](../conda_recipes/).
 

--- a/terraform/farm_templates/knfsd_xregion_cache/.gitignore
+++ b/terraform/farm_templates/knfsd_xregion_cache/.gitignore
@@ -1,0 +1,8 @@
+# Local Terraform state and config
+.terraform/
+.terraform.lock.hcl
+terraform.tfvars
+*.tfstate
+*.tfstate.*
+*.plan
+crash.log

--- a/terraform/farm_templates/knfsd_xregion_cache/README.md
+++ b/terraform/farm_templates/knfsd_xregion_cache/README.md
@@ -1,0 +1,222 @@
+# KNFSD cross-region NFS cache for a service-managed fleet (Terraform)
+
+## What this sample demonstrates
+
+This Terraform configuration deploys an [AWS Deadline Cloud](https://aws.amazon.com/deadline-cloud/)
+**service-managed fleet (SMF)** whose workers read from a **distant NFS filer through a
+[KNFSD](https://github.com/awslabs/knfsd-file-cache) read cache**, connected with a
+[VPC resource endpoint](https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/smf-vpc.html).
+
+The filer — an [Amazon FSx for OpenZFS](https://docs.aws.amazon.com/fsx/latest/OpenZFSGuide/what-is-fsx.html)
+file system — is deployed in a **second AWS region** and reached over a VPC peering
+connection. That cross-region distance stands in for an **on-premises or otherwise-distant
+filer**, and is what makes a cache worth having: cache misses pay cross-region latency and
+inter-region data-transfer cost, while cache hits are served from the KNFSD proxy's RAM and
+local NVMe next to the workers.
+
+```
+   Region A (compute)                                   Region B (origin)
+ +-----------------------------+                      +----------------------+
+ | Deadline Cloud SMF workers  |   resource endpoint  |                      |
+ |   (AWS-managed VPC)         |  (Deadline-managed   |                      |
+ |        | mount NFS          |   private DNS)       |                      |
+ |        v                    |                      |                      |
+ |  VPC Lattice resource gw ---+-- VPC Lattice -------+  (your compute VPC)  |
+ |        |                    |                      |        |             |
+ |        v                    |                      |        | VPC peering |
+ |  KNFSD proxy (RAM L1 +      |---- NFSv3 over ------+--------+-----------> | FSx for OpenZFS
+ |   local NVMe L2 cache)      |     peering link     |        |             |  (distant filer)
+ +-----------------------------+                      +----------------------+
+```
+
+> **When is this pattern worth it?** KNFSD earns its place when the origin is **distant or
+> bandwidth-limited** (on-premises, cross-region, or a throughput-capped filer) **and** many
+> workers repeatedly read the same data (render/simulation asset libraries). For a filer in
+> the *same* region and AZ as the fleet, a cache adds a hop for little benefit — mount the
+> file system directly instead. This sample deploys cross-region specifically so the cache has
+> something to do; it is the reproducible stand-in for the on-premises case you cannot ship in
+> a repository.
+
+## Prerequisites
+
+1. [Terraform](https://www.terraform.io/downloads) >= 1.5 and `git` (Terraform clones the
+   KNFSD module from GitHub during `terraform init`).
+2. AWS credentials for an account where Deadline Cloud is available, with permissions across
+   **both** the compute and origin regions.
+3. [Packer](https://www.packer.io/) to build the KNFSD proxy AMI (see Setup step 1). There is
+   no public or managed KNFSD AMI.
+4. The [`deadline` CLI](https://pypi.org/project/deadline/) (`pip install deadline`) to submit
+   the seed and benchmark jobs.
+5. A Deadline Cloud monitor to view jobs (optional but recommended); see the
+   [starter farm README](../starter_farm/README.md).
+
+## How it works
+
+Service-managed fleet workers run in an AWS-managed VPC. The
+[VPC resource endpoints](https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/smf-vpc.html)
+feature lets them reach a resource in your VPC through VPC Lattice. This sample places a KNFSD
+caching proxy behind that endpoint, and points KNFSD at an FSx for OpenZFS filer in another
+region across a VPC peering connection.
+
+| Resource | Region | Description |
+|----------|--------|-------------|
+| `aws_vpc` / subnets / NAT / IGW (x2) | A + B | Non-overlapping compute and origin VPCs |
+| `aws_vpc_peering_connection` (+ accepter, routes) | A and B | Cross-region link the cache reads over |
+| `aws_fsx_openzfs_file_system` | B | The distant origin filer (NFSv3) |
+| `module.knfsd` (ASG + NLB and more) | A | KNFSD NFS caching proxy cluster |
+| `aws_vpclattice_resource_gateway` / `aws_vpclattice_resource_configuration` | A | The resource endpoint into the compute VPC |
+| `awscc_ram_resource_share` | A | Shares the resource configuration to `fleets.deadline.amazonaws.com` |
+| `awscc_deadline_farm` / `awscc_deadline_queue` / `awscc_deadline_fleet` / `awscc_deadline_queue_fleet_association` | A | The Deadline Cloud farm, queue, and SMF |
+| `aws_iam_role` (x2) + policies | A | Fleet and queue roles (see Troubleshooting for the required logs permission) |
+
+Some behaviors are load-bearing and easy to get wrong:
+
+- **The fleet role must grant `logs:CreateLogStream`** (plus `PutLogEvents` / `GetLogEvents`)
+  scoped to `/aws/deadline/<farmId>/*`. Without it, SMF workers register but the agent cannot
+  create its log stream, so workers get stuck in `CREATED`, never run jobs, and emit no logs.
+  The `AWSDeadlineCloud-FleetWorker` managed policy does **not** include CloudWatch Logs. This
+  sample adds the inline policy, mirroring the
+  [starter-farm fleet role](../../../cloudformation/farm_templates/starter_farm/deadline-cloud-starter-farm-template.yaml).
+- **Workers reach the share via a Deadline-managed name**, not the KNFSD or FSx DNS name:
+  `<resource_config_id>.resource-endpoints.deadline.<region>.amazonaws.com`.
+- **KNFSD re-exports the origin's export path verbatim.** FSx for OpenZFS exports `/fsx`, so
+  workers mount `<endpoint>:/fsx` — mounting `/` returns `access denied by server`.
+- **Cross-region wiring:** KNFSD points at the FSx file system's **private IP** (the primary
+  network interface's IP; `endpoint_ip_address` is only populated for Multi-AZ deployments) and
+  reads over the peering link, because the FSx private DNS name does not resolve across regions.
+  Traffic through the resource endpoint is one-way NAT, so the NFS mount uses
+  `nfsvers=3,proto=tcp,noresvport,nolock`.
+- Deadline Cloud resources are only in the **AWSCC** provider; in-place fleet configuration
+  updates can fail validation, so change fleet configuration with `terraform apply -replace`.
+
+## Setup
+
+### 1. Build the KNFSD proxy AMI (one-time, in the compute region)
+
+```bash
+git clone https://github.com/awslabs/knfsd-file-cache.git
+cd knfsd-file-cache/image
+cat > image.pkrvars.hcl <<EOF
+REGION = "us-west-2"   # your compute_region
+ARCH   = ["amd64"]     # match the fleet's x86_64 workers
+EOF
+packer init .
+packer build -var-file=image.pkrvars.hcl .
+# Note the resulting AMI ID for knfsd_proxy_ami.
+```
+
+### 2. Deploy the infrastructure
+
+```bash
+cp terraform.tfvars.example terraform.tfvars
+# edit: compute_region, origin_region, knfsd_proxy_ami
+
+terraform init      # clones the pinned KNFSD module from GitHub
+terraform apply
+```
+
+## Run or submit
+
+Seed the origin once, then run the fan-out read benchmark:
+
+```bash
+FARM=$(terraform output -raw farm_id)
+QUEUE=$(terraform output -raw queue_id)
+
+# Populate the distant filer with a synthetic asset library (run once).
+deadline bundle submit ./job_bundles/seed --farm-id "$FARM" --queue-id "$QUEUE"
+
+# Fan-out read benchmark: N concurrent tasks read the shared library.
+deadline bundle submit ./job_bundles/benchmark --farm-id "$FARM" --queue-id "$QUEUE" \
+  -p FanoutTasks=16 -p ReadFilesPerTask=200
+```
+
+### Measuring the cache benefit
+
+The cache's value shows up in three ways; measure at least the first two:
+
+1. **Origin offload (the clearest signal).** In CloudWatch, watch the FSx origin's
+   `DataReadBytes` as you increase `FanoutTasks`. With the cache, origin reads stay **flat**
+   after the working set is warm — the fleet's read fan-out is absorbed by KNFSD, not paid
+   cross-region every time.
+2. **Cold versus warm.** The first benchmark run (or first task on a fresh KNFSD node) pays
+   cross-region misses; re-running reads the same files from cache. Compare `throughput_MiBps`
+   and `seconds` in the task logs between the cold and warm runs.
+3. **Fan-out scaling.** Aggregate read throughput across tasks rises with `FanoutTasks` when
+   cached, but is capped by the origin's cross-region bandwidth when not.
+
+To compare **against no cache**, deploy a second fleet whose resource endpoint targets the FSx
+IP directly (skip the `module.knfsd` layer) and run the same benchmark; the direct-mount fleet
+reads cross-region on every access.
+
+#### Measured results
+
+A run of this sample (compute in `us-west-2`, origin FSx for OpenZFS in `us-east-1`, one
+`i3en.2xlarge` KNFSD node, a 2-worker Spot fleet, 16 tasks x 150 files x 16 MiB = 38.4 GiB of
+reads over the shared library):
+
+- **Per-task read throughput (cold to warm):** the first task to touch the working set ran at
+  about **19 MiB/s** (paying cross-region latency on every miss); once the set was warm in
+  KNFSD, tasks ran at about **230-600 MiB/s** — roughly a **13x-30x speedup** on the cached path.
+- **Origin offload:** during the benchmark window the FSx origin in `us-east-1` served about
+  **0 MiB** of `DataReadBytes` while the fleet read 38.4 GiB, because KNFSD absorbed the fan-out
+  from its RAM and NVMe cache.
+
+Your numbers will vary with region pair, instance type, working-set size, and fan-out width.
+The point is the *shape*: cold reads are slow and hit the distant origin; warm reads are fast
+and local, and the origin stays quiet.
+
+## Parameters and outputs
+
+Key input variables (see [`variables.tf`](variables.tf) for the full set and defaults):
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `compute_region` | `us-west-2` | Region A: KNFSD, resource endpoint, and the SMF |
+| `origin_region` | `us-east-1` | Region B: the FSx for OpenZFS origin (must differ) |
+| `knfsd_proxy_ami` | (required) | KNFSD AMI built in Setup step 1 |
+| `knfsd_instance_type` | `i3en.2xlarge` | KNFSD proxy instance (local NVMe for the L2 cache) |
+| `fleet_market_type` | `spot` | Fleet EC2 market type |
+
+Seed and benchmark job parameters are documented in
+[`job_bundles/seed/template.yaml`](job_bundles/seed/template.yaml) and
+[`job_bundles/benchmark/template.yaml`](job_bundles/benchmark/template.yaml).
+
+Outputs (see [`outputs.tf`](outputs.tf)) include `farm_id`, `queue_id`, `fleet_id`, the KNFSD
+NLB address, and the worker-facing `worker_resource_endpoint_dns_name`.
+
+## Security, cost, and cleanup
+
+This is an **advanced** sample and is not free to run: two regions, two VPCs with NAT gateways,
+a cross-region peering connection, an FSx for OpenZFS file system, a KNFSD EC2 instance
+(`i3en`/`i4i` for local NVMe), a Network Load Balancer, VPC Lattice, **and inter-region data
+transfer** for every cache miss.
+
+The example NFS export options (`no_root_squash`, world-writable demo mount) favor simplicity;
+tighten ownership and export ACLs on the origin for production use.
+
+```bash
+# Drain fleet workers first (set min/max to 0 via the console or update-fleet), then:
+terraform destroy
+```
+
+Deleting the VPC Lattice resource configuration can briefly fail while a Deadline-managed
+endpoint association is still releasing; re-run `terraform destroy` once and it completes.
+
+## Troubleshooting
+
+- **Workers stay in `CREATED` and never run jobs, with no logs.** The fleet role is missing
+  `logs:CreateLogStream`. This sample includes it; if you adapt the role, keep that permission.
+- **`mount.nfs: access denied by server`.** You are mounting the wrong export path. KNFSD
+  re-exports `/fsx`; mount `<endpoint>:/fsx`, not `/`.
+- **KNFSD exports nothing (`showmount -e localhost` is empty).** The proxy discovered the
+  origin at boot before the origin IP was available; terminate the KNFSD instance so the Auto
+  Scaling group relaunches one with the correct configuration.
+- **Fleet configuration change fails to apply in place.** Use `terraform apply -replace='awscc_deadline_fleet.this'`.
+
+## Related resources
+
+- [Connect VPC resources to your SMF with VPC resource endpoints](https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/smf-vpc.html)
+- [CloudFormation `smf_vpc_fsx` reference](../../../cloudformation/farm_templates/smf_vpc_fsx/)
+- [Terraform starter farm](../starter_farm/)
+- [KNFSD (awslabs/knfsd-file-cache)](https://github.com/awslabs/knfsd-file-cache) — Apache-2.0, referenced here and not vendored

--- a/terraform/farm_templates/knfsd_xregion_cache/deadline.tf
+++ b/terraform/farm_templates/knfsd_xregion_cache/deadline.tf
@@ -1,0 +1,106 @@
+# Layer 3b — Deadline Cloud: farm, queue, service-managed fleet.
+#
+# Deadline Cloud is not in the hashicorp/aws provider; it is exposed through the
+# AWSCC (Cloud Control) provider, which is generated from the CloudFormation
+# registry (AWS::Deadline::*). The AWSCC schema carries the resource-endpoints
+# field this example depends on:
+#   - service_managed_ec_2.vpc_configuration.resource_configuration_arns
+#     (resource endpoints -> reach the KNFSD NLB in your VPC)
+
+# ---- Farm ----------------------------------------------------------------
+
+resource "awscc_deadline_farm" "this" {
+  display_name = "${var.name_prefix}-farm"
+  description  = "Farm for the KNFSD + FSx for OpenZFS resource-endpoint example"
+}
+
+# ---- Queue ---------------------------------------------------------------
+
+resource "awscc_deadline_queue" "this" {
+  farm_id      = awscc_deadline_farm.this.farm_id
+  display_name = "${var.name_prefix}-queue"
+  description  = "Queue that runs jobs reading from the KNFSD-cached NFS share"
+
+  # Job run-as: use the worker agent's own OS user for simplicity in this example.
+  job_run_as_user = {
+    run_as = "WORKER_AGENT_USER"
+  }
+
+  role_arn = aws_iam_role.queue.arn
+}
+
+# ---- Service-managed fleet ----------------------------------------------
+
+resource "awscc_deadline_fleet" "this" {
+  farm_id          = awscc_deadline_farm.this.farm_id
+  display_name     = "${var.name_prefix}-smf"
+  description      = "Service-managed fleet reaching the KNFSD cache via a resource endpoint"
+  role_arn         = aws_iam_role.fleet.arn
+  min_worker_count = var.fleet_min_workers
+  max_worker_count = var.fleet_max_workers
+
+  # The fleet's vpc_configuration references the resource configuration, which
+  # the Deadline service can only see once the RAM share to
+  # fleets.deadline.amazonaws.com exists. Order fleet creation after the share.
+  depends_on = [awscc_ram_resource_share.deadline]
+
+  configuration = {
+    service_managed_ec_2 = {
+      instance_capabilities = {
+        cpu_architecture_type = "x86_64"
+        os_family             = var.deadline_worker_os
+        v_cpu_count = {
+          min = var.fleet_vcpu_min
+          max = var.fleet_vcpu_max
+        }
+        memory_mi_b = {
+          min = 8192
+          max = 32768
+        }
+      }
+
+      # Spot by default: the Deadline "OnDemand vCPUs per region" quota is small
+      # (50 by default) and easily exhausted on shared accounts, whereas the Spot
+      # vCPU quota is effectively unlimited. Spot is also the norm for render
+      # fleets. Override with fleet_market_type = "on-demand" if needed.
+      instance_market_options = {
+        type = var.fleet_market_type
+      }
+
+      # NEW (2025-07): resource endpoints. Attaching the VPC Lattice resource
+      # configuration ARN lets these AWS-managed SMF workers reach the KNFSD NLB
+      # in the customer VPC via VPC Lattice. The RAM share in lattice.tf must
+      # grant the fleets.deadline.amazonaws.com principal access to this ARN,
+      # or attachment fails.
+      vpc_configuration = {
+        resource_configuration_arns = [
+          aws_vpclattice_resource_configuration.knfsd_nfs.arn
+        ]
+      }
+    }
+  }
+
+  # Runs on every worker at startup: mount the KNFSD-cached NFS share.
+  #
+  # Workers reach the resource configuration through Deadline's managed private
+  # domain, NOT the KNFSD/FSx DNS name:
+  #   <resource_config_id>.resource-endpoints.deadline.<region>.amazonaws.com
+  host_configuration = {
+    script_timeout_seconds = 300
+    script_body = templatefile("${path.module}/templates/host-configuration.sh.tftpl", {
+      resource_config_id = aws_vpclattice_resource_configuration.knfsd_nfs.id
+      region             = var.compute_region
+      nfs_mount_path     = var.nfs_mount_path
+      # KNFSD re-exports the FSx OpenZFS export path verbatim; mount that path.
+      nfs_export_path = var.fsx_export_path
+    })
+  }
+}
+
+# ---- Associate the queue with the fleet ----------------------------------
+
+resource "awscc_deadline_queue_fleet_association" "this" {
+  farm_id  = awscc_deadline_farm.this.farm_id
+  queue_id = awscc_deadline_queue.this.queue_id
+  fleet_id = awscc_deadline_fleet.this.fleet_id
+}

--- a/terraform/farm_templates/knfsd_xregion_cache/fsx.tf
+++ b/terraform/farm_templates/knfsd_xregion_cache/fsx.tf
@@ -1,0 +1,92 @@
+# Layer 1 — Origin filer: Amazon FSx for OpenZFS, in the ORIGIN REGION (region B).
+#
+# FSx for OpenZFS is the distant origin that KNFSD caches. It natively serves
+# NFSv3 (KNFSD's primary re-export path) and behaves like a bounded-throughput
+# "filer" — exactly the workload a caching proxy is designed to offload. Here it
+# stands in for an on-premises or otherwise-distant filer: the KNFSD cache in
+# region A reaches it across the VPC peering link, so cache misses pay
+# cross-region latency and data-transfer cost while cache hits are served locally.
+#
+# NFS export options mirror the upstream knfsd-file-cache "examples/fsx-zfs" so
+# KNFSD's showmount-based export auto-discovery works.
+
+resource "aws_fsx_openzfs_file_system" "origin" {
+  provider                        = aws.origin
+  deployment_type                 = "SINGLE_AZ_1"
+  storage_capacity                = var.fsx_storage_capacity_gib
+  subnet_ids                      = [aws_subnet.origin.id]
+  throughput_capacity             = var.fsx_throughput_capacity_mbps
+  automatic_backup_retention_days = 0
+  copy_tags_to_volumes            = true
+  delete_options                  = ["DELETE_CHILD_VOLUMES_AND_SNAPSHOTS"]
+  security_group_ids              = [aws_security_group.fsx.id]
+  skip_final_backup               = true
+  storage_type                    = "SSD"
+
+  root_volume_configuration {
+    # "crossmnt" lets clients traverse into child volumes over a single mount.
+    # "no_root_squash" keeps this example simple; tighten for production.
+    nfs_exports {
+      client_configurations {
+        clients = "*"
+        options = ["rw", "crossmnt", "async", "no_root_squash"]
+      }
+    }
+    copy_tags_to_snapshots = true
+    data_compression_type  = "NONE"
+  }
+
+  tags = merge(var.tags, { Name = "${var.name_prefix}-fsx-origin" })
+}
+
+# SINGLE_AZ_1 FSx for OpenZFS does not populate `endpoint_ip_address` (that
+# attribute is only set for Multi-AZ, which has a floating management IP). The
+# file system's private IP is the primary network interface's IP, which we look
+# up here. KNFSD (in the compute region) reaches this IP over the peering link.
+data "aws_network_interface" "fsx" {
+  provider = aws.origin
+  id       = aws_fsx_openzfs_file_system.origin.network_interface_ids[0]
+}
+
+# Security group for the FSx origin (region B). Ingress allows NFS from the
+# COMPUTE VPC's CIDR, reached across the peering link — that is where the KNFSD
+# proxies live. FSx validates at creation time that the SG already permits NFS
+# on 2049, and the KNFSD SG is in another region/VPC, so we scope to the compute
+# CIDR rather than a referenced SG (also matches the upstream fsx-zfs example).
+resource "aws_security_group" "fsx" {
+  provider    = aws.origin
+  name_prefix = "${var.name_prefix}-fsx-origin-"
+  description = "FSx for OpenZFS origin - NFS from the compute VPC (KNFSD)"
+  vpc_id      = aws_vpc.origin.id
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = merge(var.tags, { Name = "${var.name_prefix}-fsx-origin-sg" })
+}
+
+# NFS + rpcbind + OpenZFS management ports, from the compute VPC CIDR.
+# Port set matches the upstream fsx-zfs example.
+locals {
+  fsx_ingress_ports = {
+    nfs_tcp        = { from = 2049, to = 2049, proto = "tcp" }
+    nfs_udp        = { from = 2049, to = 2049, proto = "udp" }
+    rpcbind_tcp    = { from = 111, to = 111, proto = "tcp" }
+    rpcbind_udp    = { from = 111, to = 111, proto = "udp" }
+    openzfs_mgmt_t = { from = 20001, to = 20003, proto = "tcp" }
+    openzfs_mgmt_u = { from = 20001, to = 20003, proto = "udp" }
+  }
+}
+
+resource "aws_vpc_security_group_ingress_rule" "fsx_from_compute" {
+  provider = aws.origin
+  for_each = local.fsx_ingress_ports
+
+  security_group_id = aws_security_group.fsx.id
+  cidr_ipv4         = var.compute_vpc_cidr
+  from_port         = each.value.from
+  to_port           = each.value.to
+  ip_protocol       = each.value.proto
+  description       = "NFS/rpcbind/openzfs-mgmt from compute VPC (${each.key})"
+}

--- a/terraform/farm_templates/knfsd_xregion_cache/fsx.tf
+++ b/terraform/farm_templates/knfsd_xregion_cache/fsx.tf
@@ -37,6 +37,12 @@ resource "aws_fsx_openzfs_file_system" "origin" {
   }
 
   tags = merge(var.tags, { Name = "${var.name_prefix}-fsx-origin" })
+
+  # FSx validates at creation time that its security group already permits
+  # inbound NFS on 2049. The ingress rules are separate resources that only
+  # depend on the SG, not on this file system, so without an explicit ordering
+  # Terraform may create FSx before the rules exist and fail nondeterministically.
+  depends_on = [aws_vpc_security_group_ingress_rule.fsx_from_compute]
 }
 
 # SINGLE_AZ_1 FSx for OpenZFS does not populate `endpoint_ip_address` (that

--- a/terraform/farm_templates/knfsd_xregion_cache/iam.tf
+++ b/terraform/farm_templates/knfsd_xregion_cache/iam.tf
@@ -74,8 +74,10 @@ resource "aws_iam_role_policy" "fleet_worker_logs" {
 }
 
 # ---- Queue role ----------------------------------------------------------
-# Session role handed to jobs. Scoped to S3 job attachments + logs here; extend
-# as your jobs need (e.g. read from other buckets).
+# Session role handed to jobs. This example grants only CloudWatch Logs, which
+# is all the bundled seed/benchmark jobs need (they run embedded scripts and
+# read/write the NFS mount; the queue has no job attachments). If you enable job
+# attachments or read other data, add the S3 permissions your jobs require.
 
 data "aws_iam_policy_document" "queue_assume" {
   statement {

--- a/terraform/farm_templates/knfsd_xregion_cache/iam.tf
+++ b/terraform/farm_templates/knfsd_xregion_cache/iam.tf
@@ -1,0 +1,125 @@
+# IAM roles for the Deadline Cloud fleet workers and the queue.
+
+data "aws_partition" "current" {}
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
+
+# ---- Fleet worker role ---------------------------------------------------
+# Assumed by the Deadline Cloud service on behalf of workers.
+
+data "aws_iam_policy_document" "fleet_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["credentials.deadline.amazonaws.com"]
+    }
+    # Confused-deputy scoping, per the canonical starter-farm fleet role.
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+    condition {
+      test     = "ArnEquals"
+      variable = "aws:SourceArn"
+      values   = [awscc_deadline_farm.this.arn]
+    }
+  }
+}
+
+resource "aws_iam_role" "fleet" {
+  name               = "${var.name_prefix}-fleet-role"
+  assume_role_policy = data.aws_iam_policy_document.fleet_assume.json
+  tags               = var.tags
+}
+
+# Baseline worker permissions. AWSDeadlineCloud-FleetWorker grants the Deadline
+# API actions (UpdateWorker, AssumeQueueRoleForWorker, etc.) but NOT CloudWatch
+# Logs access — that must be granted separately (see below).
+resource "aws_iam_role_policy_attachment" "fleet_worker" {
+  role       = aws_iam_role.fleet.name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AWSDeadlineCloud-FleetWorker"
+}
+
+# FleetWorkerLogs: the worker agent's first action after registering is to
+# create its CloudWatch log stream. Without logs:CreateLogStream the agent's
+# initialization fails and the worker never leaves CREATED — this is the
+# missing piece. Mirrors the fleetRole in the Deadline Cloud starter-farm
+# reference template.
+data "aws_iam_policy_document" "fleet_worker_logs" {
+  statement {
+    sid       = "CreateLogStream"
+    effect    = "Allow"
+    actions   = ["logs:CreateLogStream"]
+    resources = ["arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:*:/aws/deadline/${awscc_deadline_farm.this.farm_id}/*"]
+    condition {
+      test     = "ForAnyValue:StringEquals"
+      variable = "aws:CalledVia"
+      values   = ["deadline.amazonaws.com"]
+    }
+  }
+  statement {
+    sid       = "WorkerAndSessionLogs"
+    effect    = "Allow"
+    actions   = ["logs:PutLogEvents", "logs:GetLogEvents"]
+    resources = ["arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:*:/aws/deadline/${awscc_deadline_farm.this.farm_id}/*"]
+  }
+}
+
+resource "aws_iam_role_policy" "fleet_worker_logs" {
+  name   = "${var.name_prefix}-fleet-worker-logs"
+  role   = aws_iam_role.fleet.id
+  policy = data.aws_iam_policy_document.fleet_worker_logs.json
+}
+
+# ---- Queue role ----------------------------------------------------------
+# Session role handed to jobs. Scoped to S3 job attachments + logs here; extend
+# as your jobs need (e.g. read from other buckets).
+
+data "aws_iam_policy_document" "queue_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["credentials.deadline.amazonaws.com"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+    condition {
+      test     = "ArnEquals"
+      variable = "aws:SourceArn"
+      values   = [awscc_deadline_farm.this.arn]
+    }
+  }
+}
+
+resource "aws_iam_role" "queue" {
+  name               = "${var.name_prefix}-queue-role"
+  assume_role_policy = data.aws_iam_policy_document.queue_assume.json
+  tags               = var.tags
+}
+
+data "aws_iam_policy_document" "queue" {
+  statement {
+    sid    = "Logs"
+    effect = "Allow"
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "logs:GetLogEvents",
+    ]
+    resources = [
+      "arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/deadline/*"
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "queue" {
+  name   = "${var.name_prefix}-queue-policy"
+  role   = aws_iam_role.queue.id
+  policy = data.aws_iam_policy_document.queue.json
+}

--- a/terraform/farm_templates/knfsd_xregion_cache/job_bundles/benchmark/template.yaml
+++ b/terraform/farm_templates/knfsd_xregion_cache/job_bundles/benchmark/template.yaml
@@ -1,0 +1,87 @@
+# Benchmark job — reads the seeded asset library through the KNFSD-cached mount
+# and reports read throughput and latency. Designed to show the cache's value:
+#
+#   FAN-OUT: the task runs once per value in the Fanout range parameter, so N
+#   tasks read the SAME shared library concurrently across the fleet's workers.
+#   Without a cache, those reads contend on the cross-region origin's bandwidth;
+#   with KNFSD, they are served from the proxy's RAM (L1) / local NVMe (L2).
+#
+#   COLD vs WARM: the first task on a given KNFSD node populates the cache
+#   (miss -> cross-region fetch); subsequent tasks/workers reading the same
+#   files hit the cache. Compare early vs later task timings, and watch the
+#   FSx origin's throughput in CloudWatch stay flat as fan-out grows.
+#
+#   deadline bundle submit ./job_bundles/benchmark \
+#     --farm-id <farm> --queue-id <queue> \
+#     -p NfsMountPath=/mnt/knfsd -p FanoutTasks=16 -p ReadFilesPerTask=200
+
+specificationVersion: "jobtemplate-2023-09"
+name: KNFSD-Xregion-Benchmark
+
+parameterDefinitions:
+  - name: NfsMountPath
+    type: STRING
+    default: /mnt/knfsd
+    description: Worker path where the KNFSD-cached share is mounted.
+  - name: FanoutTasks
+    type: INT
+    default: 16
+    description: Number of concurrent reader tasks (the fan-out width).
+  - name: ReadFilesPerTask
+    type: INT
+    default: 200
+    description: How many asset files each task reads.
+
+steps:
+  - name: FanoutRead
+    parameterSpace:
+      taskParameterDefinitions:
+        - name: TaskIndex
+          type: INT
+          range: "1-{{ Param.FanoutTasks }}"
+    script:
+      actions:
+        onRun:
+          command: bash
+          args: ["{{ Task.File.Run }}"]
+      embeddedFiles:
+        - name: Run
+          type: TEXT
+          runnable: true
+          data: |
+            #!/usr/bin/env bash
+            set -euo pipefail
+
+            LIB="{{ Param.NfsMountPath }}/assets"
+            N={{ Param.ReadFilesPerTask }}
+            TASK={{ Task.Param.TaskIndex }}
+
+            if [ ! -d "$LIB" ]; then
+              echo "ERROR: $LIB not found — run the seed job first, and confirm the mount."
+              exit 1
+            fi
+
+            # Each task reads a rotating window of the shared library so tasks
+            # overlap heavily (drives cache reuse) but don't all read identically.
+            mapfile -t FILES < <(ls -1 "$LIB"/asset_*.dat | sort)
+            total="${#FILES[@]}"
+            [ "$total" -gt 0 ] || { echo "ERROR: no asset files in $LIB"; exit 1; }
+
+            echo "=== Task $TASK: reading $N of $total shared files from $LIB ==="
+            start_ns=$(date +%s%N)
+            bytes=0
+            for k in $(seq 0 $((N - 1))); do
+              idx=$(( (TASK * 7 + k) % total ))
+              f="${FILES[$idx]}"
+              # Drop nothing locally on purpose: we want to measure the KNFSD
+              # path. The worker's own page cache is cold per fresh Spot host.
+              sz=$(stat -c%s "$f")
+              dd if="$f" of=/dev/null bs=4M status=none
+              bytes=$((bytes + sz))
+            done
+            end_ns=$(date +%s%N)
+
+            secs=$(awk "BEGIN{print ($end_ns-$start_ns)/1e9}")
+            mib=$(awk "BEGIN{print $bytes/1048576}")
+            mibps=$(awk "BEGIN{print $mib/$secs}")
+            echo "RESULT task=$TASK files=$N bytes_MiB=$mib seconds=$secs throughput_MiBps=$mibps"

--- a/terraform/farm_templates/knfsd_xregion_cache/job_bundles/seed/template.yaml
+++ b/terraform/farm_templates/knfsd_xregion_cache/job_bundles/seed/template.yaml
@@ -1,0 +1,73 @@
+# Seed job — populates the KNFSD-cached share with a synthetic "asset library"
+# that resembles a render/VFX read workload:
+#   - many medium files (textures / geo caches): the re-read HOT set
+#   - a few large files (sim caches / EXR sequences): throughput-bound reads
+#
+# Run this ONCE before benchmarking. It writes through KNFSD to the cross-region
+# FSx origin, so later benchmark reads can be served from the KNFSD cache.
+#
+#   deadline bundle submit ./job_bundles/seed \
+#     --farm-id <farm> --queue-id <queue> \
+#     -p NfsMountPath=/mnt/knfsd -p LibraryFileCount=2000 -p LibraryFileMiB=16 \
+#     -p LargeFileCount=4 -p LargeFileMiB=4096
+
+specificationVersion: "jobtemplate-2023-09"
+name: KNFSD-Xregion-Seed
+
+parameterDefinitions:
+  - name: NfsMountPath
+    type: STRING
+    default: /mnt/knfsd
+    description: Worker path where the KNFSD-cached share is mounted.
+  - name: LibraryFileCount
+    type: INT
+    default: 2000
+    description: Number of medium "asset" files in the shared hot set.
+  - name: LibraryFileMiB
+    type: INT
+    default: 16
+    description: Size (MiB) of each medium asset file.
+  - name: LargeFileCount
+    type: INT
+    default: 4
+    description: Number of large sequence/sim files.
+  - name: LargeFileMiB
+    type: INT
+    default: 4096
+    description: Size (MiB) of each large file.
+
+steps:
+  - name: SeedAssetLibrary
+    script:
+      actions:
+        onRun:
+          command: bash
+          args: ["{{ Task.File.Run }}"]
+      embeddedFiles:
+        - name: Run
+          type: TEXT
+          runnable: true
+          data: |
+            #!/usr/bin/env bash
+            set -euo pipefail
+
+            LIB="{{ Param.NfsMountPath }}/assets"
+            BIG="{{ Param.NfsMountPath }}/sequences"
+            mkdir -p "$LIB" "$BIG"
+
+            echo "Seeding $LIB with {{ Param.LibraryFileCount }} x {{ Param.LibraryFileMiB }} MiB asset files"
+            for i in $(seq 1 {{ Param.LibraryFileCount }}); do
+              f="$LIB/asset_$(printf '%05d' "$i").dat"
+              [ -f "$f" ] || dd if=/dev/urandom of="$f" bs=1M count={{ Param.LibraryFileMiB }} status=none
+            done
+
+            echo "Seeding $BIG with {{ Param.LargeFileCount }} x {{ Param.LargeFileMiB }} MiB sequence files"
+            for i in $(seq 1 {{ Param.LargeFileCount }}); do
+              f="$BIG/seq_$(printf '%03d' "$i").dat"
+              [ -f "$f" ] || dd if=/dev/urandom of="$f" bs=1M count={{ Param.LargeFileMiB }} status=none
+            done
+
+            sync
+            echo "Seed complete:"
+            echo "  assets:    $(ls -1 "$LIB" | wc -l) files, $(du -sh "$LIB" | cut -f1)"
+            echo "  sequences: $(ls -1 "$BIG" | wc -l) files, $(du -sh "$BIG" | cut -f1)"

--- a/terraform/farm_templates/knfsd_xregion_cache/knfsd.tf
+++ b/terraform/farm_templates/knfsd_xregion_cache/knfsd.tf
@@ -1,0 +1,53 @@
+# Layer 2 — Caching proxy: awslabs/knfsd-file-cache.
+#
+# The KNFSD module deploys an Auto Scaling Group of NFS re-export proxies fronted
+# by a Network Load Balancer (TRAFFIC_MODE = "loadbalancer"). Each proxy mounts
+# the FSx origin over NFSv3 and re-exports it, caching in RAM (L1) and on local
+# NVMe via FS-Cache (L2). We front it with the NLB because VPC Lattice resource
+# configurations target a stable IP/DNS, and the NLB gives us exactly that.
+#
+# The module is pinned to a released tag. Terraform shallow-clones the whole repo
+# for a git source, so `terraform init` needs network + git access to GitHub.
+
+module "knfsd" {
+  source = "github.com/awslabs/knfsd-file-cache//deployment/terraform-module-knfsd?ref=v1.1.0-beta.1"
+
+  SUBNET         = aws_subnet.compute.id
+  PROXY_AMI      = var.knfsd_proxy_ami
+  PROXY_BASENAME = var.name_prefix
+  INSTANCE_TYPE  = var.knfsd_instance_type
+  KNFSD_NODES    = var.knfsd_node_count
+
+  # NLB front end so Lattice has a stable target. The module creates the NLB,
+  # target groups, and a private Route 53 CNAME.
+  TRAFFIC_MODE = "loadbalancer"
+
+  # Point the cache at the FSx origin by its private IP, reached across the VPC
+  # peering link. We use the IP — not the DNS name — because FSx's private
+  # Route 53 name does not resolve from the compute region; the IP is routable
+  # over peering. For SINGLE_AZ_1 the IP is the primary ENI's private IP (the
+  # endpoint_ip_address attribute is only populated for Multi-AZ deployments).
+  # KNFSD auto-detects exports via `showmount -e <ip>` (NFSv3).
+  EXPORT_HOST_AUTO_DETECT = data.aws_network_interface.fsx.private_ip
+  EXPORT_OPTIONS          = "insecure"
+  NFS_MOUNT_VERSION       = "3"
+  DISABLED_NFS_VERSIONS   = "4.0,4.1,4.2"
+
+  # FSID assignment. "external" (the module default) provisions an RDS database
+  # and a Lambda so a MULTI-node cluster hands out consistent FSIDs. This
+  # single-node example uses "local", which needs neither — avoiding the RDS
+  # cost and the Lambda's alpine/Docker build. Set to "external" if you scale
+  # KNFSD_NODES above 1 and need FSID stability across nodes.
+  FSID_MODE = var.knfsd_fsid_mode
+
+  INSTANCE_TAGS = merge(var.tags, { Name = "${var.name_prefix}-knfsd-proxy" })
+
+  # KNFSD runs `showmount` against the origin at launch, so the origin and the
+  # full cross-region network path (peering + routes both ways) must exist first.
+  depends_on = [
+    aws_fsx_openzfs_file_system.origin,
+    aws_vpc_peering_connection_accepter.xregion,
+    aws_route_table.compute_private,
+    aws_route_table.origin,
+  ]
+}

--- a/terraform/farm_templates/knfsd_xregion_cache/lattice.tf
+++ b/terraform/farm_templates/knfsd_xregion_cache/lattice.tf
@@ -1,0 +1,120 @@
+# Layer 3a — The bridge: VPC Lattice resource gateway + resource configuration
+#                        + AWS RAM share to the Deadline Cloud service.
+#
+# Deadline Cloud service-managed fleet (SMF) workers run in an AWS-managed VPC,
+# not yours. The "resource endpoints" feature (launched 2025-07, powered by AWS
+# PrivateLink/VPC Lattice) lets those workers reach resources in YOUR VPC.
+#
+# This wiring follows the official reference template:
+#   github.com/aws-deadline/deadline-cloud-samples
+#     -> cloudformation/farm_templates/smf_vpc_fsx
+#
+# Three objects are required:
+#   1. A VPC Lattice *resource gateway* (ingress point in your VPC).
+#   2. A VPC Lattice *resource configuration* targeting the KNFSD NLB.
+#   3. An AWS RAM *resource share* granting the Deadline service principal
+#      (fleets.deadline.amazonaws.com) access to the resource configuration.
+# The fleet then references the resource configuration ARN (see deadline.tf).
+#
+# IMPORTANT — how workers reach it: workers do NOT use the KNFSD/FSx DNS name.
+# Deadline exposes a managed private domain per resource configuration:
+#   <resource_config_id>.resource-endpoints.deadline.<region>.amazonaws.com
+# That is the hostname the fleet host-configuration script mounts (deadline.tf).
+
+# The resource gateway is the in-VPC ingress point Lattice uses to reach targets.
+# The reference template spans multiple subnets/AZs; this single-subnet example
+# keeps the gateway, KNFSD, and FSx in one AZ. For production, give the gateway
+# subnets in every AZ your resource might live in.
+resource "aws_vpclattice_resource_gateway" "knfsd" {
+  name               = "${var.name_prefix}-rgw"
+  vpc_id             = aws_vpc.compute.id
+  subnet_ids         = [aws_subnet.compute.id]
+  security_group_ids = [aws_security_group.resource_gateway.id]
+  ip_address_type    = "IPV4"
+
+  tags = merge(var.tags, { Name = "${var.name_prefix}-rgw" })
+}
+
+# The gateway ENIs must be allowed to reach the KNFSD NLB across the NFS RPC
+# port set that KNFSD's load balancer exposes.
+resource "aws_security_group" "resource_gateway" {
+  name        = "${var.name_prefix}-rgw-sg"
+  description = "VPC Lattice resource gateway to KNFSD NLB (NFS RPC ports)"
+  vpc_id      = aws_vpc.compute.id
+
+  tags = merge(var.tags, { Name = "${var.name_prefix}-rgw-sg" })
+}
+
+# KNFSD's NLB listens on the full NFSv3 RPC port set (TCP+UDP):
+#   111 (rpcbind), 2049 (nfsd), 20048 (mountd), 20050-20055 (lockd/statd/cb).
+# We open the contiguous span 111 + 2049 + 20048-20055 for simplicity.
+locals {
+  knfsd_nfs_port_ranges = ["111", "2049", "20048-20055"]
+}
+
+resource "aws_vpc_security_group_egress_rule" "rgw_to_knfsd_tcp" {
+  for_each                     = toset(local.knfsd_nfs_port_ranges)
+  security_group_id            = aws_security_group.resource_gateway.id
+  referenced_security_group_id = module.knfsd.knfsd_security_group_id
+  from_port                    = tonumber(split("-", each.value)[0])
+  to_port                      = tonumber(element(split("-", each.value), length(split("-", each.value)) - 1))
+  ip_protocol                  = "tcp"
+  description                  = "NFS RPC (tcp ${each.value}) to KNFSD NLB"
+}
+
+# Allow the resource gateway to reach the KNFSD NLB. In loadbalancer mode the
+# module's knfsd_security_group_id is the NLB's SG.
+resource "aws_vpc_security_group_ingress_rule" "knfsd_from_rgw_tcp" {
+  for_each                     = toset(local.knfsd_nfs_port_ranges)
+  security_group_id            = module.knfsd.knfsd_security_group_id
+  referenced_security_group_id = aws_security_group.resource_gateway.id
+  from_port                    = tonumber(split("-", each.value)[0])
+  to_port                      = tonumber(element(split("-", each.value), length(split("-", each.value)) - 1))
+  ip_protocol                  = "tcp"
+  description                  = "NFS RPC (tcp ${each.value}) from VPC Lattice resource gateway"
+}
+
+# The resource configuration exposes the KNFSD NLB by its private IP over the
+# NFS RPC port set. Its ARN is what the Deadline Cloud fleet references. The
+# reference template targets an IpResource (not DNS), which is simpler and
+# avoids in-VPC DNS-resolution setup.
+resource "aws_vpclattice_resource_configuration" "knfsd_nfs" {
+  name                        = "${var.name_prefix}-knfsd-nfs"
+  resource_gateway_identifier = aws_vpclattice_resource_gateway.knfsd.id
+
+  port_ranges = local.knfsd_nfs_port_ranges
+  protocol    = "TCP"
+
+  resource_configuration_definition {
+    ip_resource {
+      ip_address = module.knfsd.loadbalancer_ipaddress
+    }
+  }
+
+  # Required so the configuration can be shared (via RAM) into the Deadline
+  # service network.
+  allow_association_to_shareable_service_network = true
+
+  tags = merge(var.tags, { Name = "${var.name_prefix}-knfsd-nfs" })
+}
+
+# AWS RAM share granting the Deadline Cloud service principal access to the
+# resource configuration. Without this, the fleet cannot attach the endpoint.
+#
+# This uses the AWSCC provider (not hashicorp/aws) because sharing to a SERVICE
+# principal (fleets.deadline.amazonaws.com) requires both the `principals` and
+# `sources` arguments together — exactly as the reference CloudFormation
+# template does. The hashicorp/aws ram_principal_association resource models
+# only account/org principals and has no `sources` field.
+resource "awscc_ram_resource_share" "deadline" {
+  name = "${var.name_prefix}-deadline-share"
+  # Must allow "external" principals: a service principal
+  # (fleets.deadline.amazonaws.com) is not an in-organization principal, so a
+  # share restricted to the org is rejected with "can only be shared within
+  # your AWS Organization". The reference CloudFormation template leaves this at
+  # its permissive default for the same reason.
+  allow_external_principals = true
+  resource_arns             = [aws_vpclattice_resource_configuration.knfsd_nfs.arn]
+  principals                = ["fleets.deadline.amazonaws.com"]
+  sources                   = [data.aws_caller_identity.current.account_id]
+}

--- a/terraform/farm_templates/knfsd_xregion_cache/network.tf
+++ b/terraform/farm_templates/knfsd_xregion_cache/network.tf
@@ -1,0 +1,142 @@
+# Cross-region networking.
+#
+# Two purpose-built VPCs with non-overlapping CIDRs (default VPCs can't be used
+# here — every region's default VPC is 172.31.0.0/16, and you cannot peer
+# overlapping CIDRs), joined by a cross-region VPC peering connection:
+#
+#   Compute VPC (region A, ${var.compute_vpc_cidr})  <-- peering -->  Origin VPC (region B, ${var.origin_vpc_cidr})
+#     KNFSD + Lattice + fleet                                            FSx for OpenZFS
+#
+# The peering link is the "long, expensive" path that a read cache is meant to
+# absorb. KNFSD mounts FSx over this link; workers then read from KNFSD locally.
+
+# ---- Compute VPC (region A) ----------------------------------------------
+
+resource "aws_vpc" "compute" {
+  cidr_block           = var.compute_vpc_cidr
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+  tags                 = merge(var.tags, { Name = "${var.name_prefix}-compute-vpc" })
+}
+
+resource "aws_subnet" "compute" {
+  vpc_id                  = aws_vpc.compute.id
+  cidr_block              = cidrsubnet(var.compute_vpc_cidr, 8, 1)
+  availability_zone       = "${var.compute_region}${var.compute_az_suffix}"
+  map_public_ip_on_launch = false
+  tags                    = merge(var.tags, { Name = "${var.name_prefix}-compute-subnet" })
+}
+
+resource "aws_internet_gateway" "compute" {
+  vpc_id = aws_vpc.compute.id
+  tags   = merge(var.tags, { Name = "${var.name_prefix}-compute-igw" })
+}
+
+# NAT so the KNFSD instances (private subnet) can reach the internet for the
+# worker agent bootstrap, package installs, etc.
+resource "aws_eip" "compute_nat" {
+  domain = "vpc"
+  tags   = merge(var.tags, { Name = "${var.name_prefix}-compute-nat-eip" })
+}
+
+resource "aws_subnet" "compute_public" {
+  vpc_id                  = aws_vpc.compute.id
+  cidr_block              = cidrsubnet(var.compute_vpc_cidr, 8, 0)
+  availability_zone       = "${var.compute_region}${var.compute_az_suffix}"
+  map_public_ip_on_launch = true
+  tags                    = merge(var.tags, { Name = "${var.name_prefix}-compute-public" })
+}
+
+resource "aws_nat_gateway" "compute" {
+  allocation_id = aws_eip.compute_nat.id
+  subnet_id     = aws_subnet.compute_public.id
+  tags          = merge(var.tags, { Name = "${var.name_prefix}-compute-nat" })
+  depends_on    = [aws_internet_gateway.compute]
+}
+
+resource "aws_route_table" "compute_public" {
+  vpc_id = aws_vpc.compute.id
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.compute.id
+  }
+  tags = merge(var.tags, { Name = "${var.name_prefix}-compute-public-rt" })
+}
+
+resource "aws_route_table_association" "compute_public" {
+  subnet_id      = aws_subnet.compute_public.id
+  route_table_id = aws_route_table.compute_public.id
+}
+
+resource "aws_route_table" "compute_private" {
+  vpc_id = aws_vpc.compute.id
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.compute.id
+  }
+  # Reach the origin VPC over the peering connection.
+  route {
+    cidr_block                = var.origin_vpc_cidr
+    vpc_peering_connection_id = aws_vpc_peering_connection.xregion.id
+  }
+  tags = merge(var.tags, { Name = "${var.name_prefix}-compute-private-rt" })
+}
+
+resource "aws_route_table_association" "compute_private" {
+  subnet_id      = aws_subnet.compute.id
+  route_table_id = aws_route_table.compute_private.id
+}
+
+# ---- Origin VPC (region B) -----------------------------------------------
+
+resource "aws_vpc" "origin" {
+  provider             = aws.origin
+  cidr_block           = var.origin_vpc_cidr
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+  tags                 = merge(var.tags, { Name = "${var.name_prefix}-origin-vpc" })
+}
+
+resource "aws_subnet" "origin" {
+  provider          = aws.origin
+  vpc_id            = aws_vpc.origin.id
+  cidr_block        = cidrsubnet(var.origin_vpc_cidr, 8, 1)
+  availability_zone = "${var.origin_region}${var.origin_az_suffix}"
+  tags              = merge(var.tags, { Name = "${var.name_prefix}-origin-subnet" })
+}
+
+resource "aws_route_table" "origin" {
+  provider = aws.origin
+  vpc_id   = aws_vpc.origin.id
+  # Return path to the compute VPC over the peering connection.
+  route {
+    cidr_block                = var.compute_vpc_cidr
+    vpc_peering_connection_id = aws_vpc_peering_connection.xregion.id
+  }
+  tags = merge(var.tags, { Name = "${var.name_prefix}-origin-rt" })
+}
+
+resource "aws_route_table_association" "origin" {
+  provider       = aws.origin
+  subnet_id      = aws_subnet.origin.id
+  route_table_id = aws_route_table.origin.id
+}
+
+# ---- Cross-region VPC peering --------------------------------------------
+
+# Requester lives in the compute region; peer is the origin VPC in region B.
+resource "aws_vpc_peering_connection" "xregion" {
+  vpc_id      = aws_vpc.compute.id
+  peer_vpc_id = aws_vpc.origin.id
+  peer_region = var.origin_region
+  auto_accept = false # cross-region peering cannot auto-accept in one call
+  tags        = merge(var.tags, { Name = "${var.name_prefix}-xregion-peering" })
+}
+
+# Accepter runs in the origin region.
+resource "aws_vpc_peering_connection_accepter" "xregion" {
+  provider                  = aws.origin
+  vpc_peering_connection_id = aws_vpc_peering_connection.xregion.id
+  auto_accept               = true
+  tags                      = merge(var.tags, { Name = "${var.name_prefix}-xregion-peering-accepter" })
+}

--- a/terraform/farm_templates/knfsd_xregion_cache/outputs.tf
+++ b/terraform/farm_templates/knfsd_xregion_cache/outputs.tf
@@ -1,0 +1,44 @@
+output "farm_id" {
+  description = "Deadline Cloud farm ID. Use with the deadline CLI (--farm-id)."
+  value       = awscc_deadline_farm.this.farm_id
+}
+
+output "queue_id" {
+  description = "Deadline Cloud queue ID. Submit jobs here (--queue-id)."
+  value       = awscc_deadline_queue.this.queue_id
+}
+
+output "fleet_id" {
+  description = "Service-managed fleet ID."
+  value       = awscc_deadline_fleet.this.fleet_id
+}
+
+output "fsx_origin_dns_name" {
+  description = "FSx for OpenZFS origin DNS name (the filer KNFSD caches)."
+  value       = aws_fsx_openzfs_file_system.origin.dns_name
+}
+
+output "knfsd_nlb_dns_name" {
+  description = "Private DNS name of the KNFSD Network Load Balancer."
+  value       = module.knfsd.dns_name
+}
+
+output "knfsd_nlb_ip_address" {
+  description = "Private IP of the KNFSD NLB (target of the Lattice resource config)."
+  value       = module.knfsd.loadbalancer_ipaddress
+}
+
+output "resource_configuration_arn" {
+  description = "VPC Lattice resource configuration ARN attached to the fleet."
+  value       = aws_vpclattice_resource_configuration.knfsd_nfs.arn
+}
+
+output "worker_resource_endpoint_dns_name" {
+  description = "Deadline-managed private DNS name SMF workers use to reach the KNFSD share."
+  value       = "${aws_vpclattice_resource_configuration.knfsd_nfs.id}.resource-endpoints.deadline.${var.compute_region}.amazonaws.com"
+}
+
+output "worker_nfs_mount_path" {
+  description = "Path where workers mount the KNFSD-cached share."
+  value       = var.nfs_mount_path
+}

--- a/terraform/farm_templates/knfsd_xregion_cache/templates/host-configuration.sh.tftpl
+++ b/terraform/farm_templates/knfsd_xregion_cache/templates/host-configuration.sh.tftpl
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# Deadline Cloud fleet host configuration script.
+# Runs once, with administrator privileges, as each service-managed fleet
+# worker starts up.
+#
+# Responsibility: mount the KNFSD-cached NFS share, reached via the Deadline
+# Cloud VPC resource endpoint:
+#   <resource_config_id>.resource-endpoints.deadline.<region>.amazonaws.com
+#
+# IMPORTANT: this script is written to be NON-FATAL. A hung or failed NFS mount
+# must never prevent the worker from starting or block it until the host-config
+# timeout — that just recycles the worker with no diagnostics. So we do NOT use
+# `set -e`, we bound the mount with `timeout`, and we always exit 0. If the
+# mount fails, the worker still comes up and the job task reports the problem.
+
+NFS_HOST="${resource_config_id}.resource-endpoints.deadline.${region}.amazonaws.com"
+MOUNT_PATH="${nfs_mount_path}"
+# KNFSD re-exports the origin's export PATH verbatim (e.g. FSx OpenZFS exports
+# /fsx). Mounting the wrong path (e.g. "/") returns "access denied by server".
+EXPORT_PATH="${nfs_export_path}"
+
+echo "[host-config] Ensuring NFS client tooling is present"
+if command -v dnf >/dev/null 2>&1; then
+  dnf install -y nfs-utils || true
+elif command -v yum >/dev/null 2>&1; then
+  yum install -y nfs-utils || true
+elif command -v apt-get >/dev/null 2>&1; then
+  apt-get update -y && apt-get install -y nfs-common || true
+fi
+
+echo "[host-config] Creating mount point $MOUNT_PATH"
+mkdir -p "$MOUNT_PATH"
+
+# Resolve the endpoint first so we can distinguish DNS vs mount failures.
+echo "[host-config] Resolving $NFS_HOST"
+getent hosts "$NFS_HOST" || echo "[host-config] WARN: could not resolve $NFS_HOST"
+
+# Mount options for the resource-endpoint path:
+#   nfsvers=3   KNFSD re-exports the FSx for OpenZFS origin over NFSv3.
+#   proto=tcp   The resource endpoint is TCP; do not attempt UDP.
+#   soft/retry=0/timeo=100  Fail fast instead of hanging (this is startup).
+#   noresvport  Traffic is NAT'd from non-privileged source ports.
+#   nolock      NLM lock/callback traffic cannot traverse the one-way NAT.
+echo "[host-config] Mounting KNFSD share $NFS_HOST:$EXPORT_PATH at $MOUNT_PATH"
+if timeout 90 mount -t nfs \
+     -o nfsvers=3,proto=tcp,soft,retry=0,timeo=100,retrans=2,noresvport,nolock \
+     "$NFS_HOST:$EXPORT_PATH" "$MOUNT_PATH"; then
+  echo "[host-config] MOUNT OK"
+  mount | grep -E "$MOUNT_PATH|:/" || true
+  # The task runs as an unprivileged session user (job-user). FSx OpenZFS root
+  # volume is root-owned by default, so make it world-readable/writable for the
+  # demo. For production, manage ownership/permissions on the origin instead.
+  chmod 0777 "$MOUNT_PATH" 2>/dev/null || echo "[host-config] NOTE: could not chmod $MOUNT_PATH (read-only or perms)"
+else
+  rc=$?
+  echo "[host-config] MOUNT FAILED (rc=$rc) — worker will still start; task will report missing mount"
+fi
+
+echo "[host-config] Done"
+exit 0

--- a/terraform/farm_templates/knfsd_xregion_cache/terraform.tfvars.example
+++ b/terraform/farm_templates/knfsd_xregion_cache/terraform.tfvars.example
@@ -1,0 +1,26 @@
+# Copy to terraform.tfvars and fill in. All values below are examples.
+
+# Region A — KNFSD cache, VPC Lattice resource endpoint, and the SMF live here.
+compute_region = "us-west-2"
+
+# Region B — the FSx for OpenZFS origin filer. MUST differ from compute_region;
+# the cross-region distance is what the cache absorbs (stands in for on-prem).
+origin_region = "us-east-1"
+
+name_prefix = "dl-knfsd-xr"
+
+# Build this first with Packer from awslabs/knfsd-file-cache, in compute_region
+# (see README "Build the KNFSD proxy AMI").
+knfsd_proxy_ami = "ami-0123456789abcdef0"
+
+# Optional overrides:
+# compute_vpc_cidr             = "10.10.0.0/16"   # must not overlap origin_vpc_cidr
+# origin_vpc_cidr              = "10.20.0.0/16"
+# compute_az_suffix            = "a"
+# origin_az_suffix             = "a"
+# knfsd_instance_type          = "i3en.2xlarge"
+# knfsd_node_count             = 1
+# fsx_storage_capacity_gib     = 1024
+# fsx_throughput_capacity_mbps = 512
+# fleet_max_workers            = 2
+# fleet_market_type            = "spot"

--- a/terraform/farm_templates/knfsd_xregion_cache/variables.tf
+++ b/terraform/farm_templates/knfsd_xregion_cache/variables.tf
@@ -104,13 +104,13 @@ variable "fsx_throughput_capacity_mbps" {
 }
 
 variable "deadline_worker_os" {
-  description = "Operating system family for the Deadline Cloud service-managed fleet workers."
+  description = "Operating system family for the SMF workers. Only LINUX is supported: the host configuration is a bash script (mount, dnf/apt-get, chmod) that cannot run on Windows."
   type        = string
   default     = "LINUX"
 
   validation {
-    condition     = contains(["LINUX", "WINDOWS"], var.deadline_worker_os)
-    error_message = "deadline_worker_os must be LINUX or WINDOWS. This example's host configuration script targets LINUX."
+    condition     = contains(["LINUX"], var.deadline_worker_os)
+    error_message = "deadline_worker_os must be LINUX. This sample's host configuration script only supports Linux workers."
   }
 }
 

--- a/terraform/farm_templates/knfsd_xregion_cache/variables.tf
+++ b/terraform/farm_templates/knfsd_xregion_cache/variables.tf
@@ -1,0 +1,172 @@
+variable "compute_region" {
+  description = "Region A — KNFSD cache, VPC Lattice resource endpoint, and the Deadline Cloud service-managed fleet. Must be a region where Deadline Cloud is available."
+  type        = string
+  default     = "us-west-2"
+}
+
+variable "origin_region" {
+  description = "Region B — the FSx for OpenZFS origin filer. Must differ from compute_region; the inter-region distance is what the cache absorbs."
+  type        = string
+  default     = "us-east-1"
+
+  validation {
+    condition     = var.origin_region != var.compute_region
+    error_message = "origin_region must differ from compute_region for a cross-region cache demonstration."
+  }
+}
+
+variable "compute_az_suffix" {
+  description = "AZ letter for the compute subnet (KNFSD is single-subnet), e.g. \"a\"."
+  type        = string
+  default     = "a"
+}
+
+variable "origin_az_suffix" {
+  description = "AZ letter for the origin subnet, e.g. \"a\"."
+  type        = string
+  default     = "a"
+}
+
+variable "compute_vpc_cidr" {
+  description = "CIDR for the compute VPC (region A). Must not overlap origin_vpc_cidr."
+  type        = string
+  default     = "10.10.0.0/16"
+}
+
+variable "origin_vpc_cidr" {
+  description = "CIDR for the origin VPC (region B). Must not overlap compute_vpc_cidr."
+  type        = string
+  default     = "10.20.0.0/16"
+}
+
+variable "name_prefix" {
+  description = "Prefix applied to created resource names. Keep short; some names must be globally unique per account."
+  type        = string
+  default     = "dl-knfsd-xr"
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9][a-zA-Z0-9-]{0,20}[a-zA-Z0-9]$", var.name_prefix))
+    error_message = "name_prefix must be 2-22 chars, alphanumeric or hyphen, and not start/end with a hyphen."
+  }
+}
+
+variable "knfsd_proxy_ami" {
+  description = <<-EOT
+    AMI ID of the KNFSD proxy image built with Packer from awslabs/knfsd-file-cache
+    (see image/ in that repo), built in compute_region. There is no public/managed
+    AMI; you must build it first. See the README "Build the KNFSD AMI" step.
+  EOT
+  type        = string
+
+  validation {
+    condition     = can(regex("^ami-[0-9a-f]{8}([0-9a-f]{9})?$", var.knfsd_proxy_ami))
+    error_message = "knfsd_proxy_ami must be a valid AMI ID."
+  }
+}
+
+variable "knfsd_instance_type" {
+  description = "EC2 instance type for KNFSD proxies. i3en/i4i families give local NVMe for the L2 (FS-Cache) tier."
+  type        = string
+  default     = "i3en.2xlarge"
+}
+
+variable "knfsd_node_count" {
+  description = "Number of KNFSD proxy nodes in the cluster."
+  type        = number
+  default     = 1
+}
+
+variable "knfsd_fsid_mode" {
+  description = <<-EOT
+    How KNFSD assigns FSIDs: "local", "static", or "external". "external" adds an
+    RDS database + Lambda for multi-node FSID consistency; use "local" for a
+    single node (default) to avoid that overhead.
+  EOT
+  type        = string
+  default     = "local"
+
+  validation {
+    condition     = contains(["local", "static", "external"], var.knfsd_fsid_mode)
+    error_message = "knfsd_fsid_mode must be local, static, or external."
+  }
+}
+
+variable "fsx_storage_capacity_gib" {
+  description = "FSx for OpenZFS storage capacity in GiB."
+  type        = number
+  default     = 1024
+}
+
+variable "fsx_throughput_capacity_mbps" {
+  description = "FSx for OpenZFS throughput capacity in MB/s. Allowed: 64,128,256,512,1024,2048,3072,4096."
+  type        = number
+  default     = 512
+}
+
+variable "deadline_worker_os" {
+  description = "Operating system family for the Deadline Cloud service-managed fleet workers."
+  type        = string
+  default     = "LINUX"
+
+  validation {
+    condition     = contains(["LINUX", "WINDOWS"], var.deadline_worker_os)
+    error_message = "deadline_worker_os must be LINUX or WINDOWS. This example's host configuration script targets LINUX."
+  }
+}
+
+variable "fleet_min_workers" {
+  description = "Minimum worker count for the service-managed fleet."
+  type        = number
+  default     = 0
+}
+
+variable "fleet_max_workers" {
+  description = "Maximum worker count for the service-managed fleet."
+  type        = number
+  default     = 2
+}
+
+variable "fleet_market_type" {
+  description = "EC2 market type for fleet workers: \"spot\" or \"on-demand\". Spot avoids the small OnDemand vCPU quota."
+  type        = string
+  default     = "spot"
+
+  validation {
+    condition     = contains(["spot", "on-demand"], var.fleet_market_type)
+    error_message = "fleet_market_type must be spot or on-demand."
+  }
+}
+
+variable "fleet_vcpu_min" {
+  description = "Minimum vCPUs per fleet worker instance."
+  type        = number
+  default     = 2
+}
+
+variable "fleet_vcpu_max" {
+  description = "Maximum vCPUs per fleet worker instance."
+  type        = number
+  default     = 8
+}
+
+variable "nfs_mount_path" {
+  description = "Absolute path on workers where the KNFSD-cached NFS share is mounted."
+  type        = string
+  default     = "/mnt/knfsd"
+}
+
+variable "fsx_export_path" {
+  description = <<-EOT
+    The NFS export path KNFSD re-exports (verbatim from the FSx origin). FSx for
+    OpenZFS exports its root volume at /fsx, so workers mount <endpoint>:/fsx —
+    NOT ":/". Mounting the wrong path returns "access denied by server".
+  EOT
+  type        = string
+  default     = "/fsx"
+}
+
+variable "tags" {
+  description = "Additional tags applied to resources created directly by this example."
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/farm_templates/knfsd_xregion_cache/versions.tf
+++ b/terraform/farm_templates/knfsd_xregion_cache/versions.tf
@@ -1,0 +1,37 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      # Matches the version range used by the upstream knfsd-file-cache
+      # examples so the vendored module resolves a single AWS provider.
+      version = "~> 6.55.0"
+    }
+    # Deadline Cloud is not in the hashicorp/aws provider. The AWSCC (Cloud
+    # Control) provider exposes AWS::Deadline::* resources, including the
+    # vpc_configuration.resource_configuration_arns field this example uses.
+    awscc = {
+      source  = "hashicorp/awscc"
+      version = ">= 1.30.0"
+    }
+  }
+}
+
+# Compute region (region A): KNFSD cluster, VPC Lattice resource endpoint, and
+# the Deadline Cloud service-managed fleet live here.
+provider "aws" {
+  region = var.compute_region
+}
+
+provider "awscc" {
+  region = var.compute_region
+}
+
+# Origin region (region B): the FSx for OpenZFS filer lives here, reached by the
+# KNFSD cache across a VPC peering connection. This distance is what makes the
+# cache worth having — it stands in for an on-premises or otherwise-distant filer.
+provider "aws" {
+  alias  = "origin"
+  region = var.origin_region
+}


### PR DESCRIPTION
Add a Terraform sample that deploys a Deadline Cloud service-managed fleet whose workers read a distant NFS filer through a KNFSD read cache over a VPC resource endpoint. The FSx for OpenZFS origin is deployed in a second region and reached over VPC peering, standing in for an on-premises or otherwise distant filer so the cache has a measurable benefit.

Includes seed and fan-out benchmark job bundles and a README documenting the measurement methodology and measured cold-vs-warm / origin-offload results. Updates the terraform category index table.

Measured results (us-west-2 compute → us-east-1 origin, 1× i3en.2xlarge, 38.4 GiB read)

    Per-task read throughput cold→warm: ~19 → 230–600 MiB/s (13–30×)
    Origin offload: FSx origin served ~0 MiB while the fleet read 38.4 GiB

### How was this change tested?

scripts/validate_repository.py passes; terraform fmt -check + validate clean

Deployed end-to-end and ran the seed + benchmark jobs to produce the numbers above

### Was this change documented?

- For instance, if applicable, has the sample's description been updated?

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*