### PR TITLE
fix: cache Wan2.2 weights on the fleet's persistent volume

### DIFF
--- a/job_bundles/wan22_video_generation/README.md
+++ b/job_bundles/wan22_video_generation/README.md
@@ -17,16 +17,19 @@ This job bundle uses the [diffusers](https://github.com/huggingface/diffusers)
 Hugging Face at runtime, so nothing is redistributed in this repository.
 
 The job has a single step, `GenerateVideo`, whose task parameter space is
-`1-NumClips`. Workers download the checkpoint once per session into a
-worker-local cache, then render their assigned clips and write MP4 files into
-the output directory.
+`1-NumClips`. Workers download the checkpoint into a cache on the fleet's
+persistent volume, then render their assigned clips and write MP4 files into
+the output directory. Because that volume outlives individual workers, later
+workers reuse the checkpoint instead of downloading it again.
 
 ## Prerequisites
 
 - AWS Deadline Cloud farm with a GPU-enabled Linux queue
 - [Deadline Cloud CLI](https://github.com/aws-deadline/deadline-cloud) installed
 - Worker with an NVIDIA GPU, **24 GB VRAM minimum**, and **64 GiB of system memory**
-- At least 60 GiB of free space on a real (non-tmpfs) disk for the model cache
+- At least 60 GiB free for the model cache. Enabling persistent storage on the
+  fleet is recommended so workers share one download. See
+  [Model cache location](#model-cache-location).
 
 No Hugging Face token is required, because the Wan2.2 repositories are ungated.
 
@@ -63,7 +66,7 @@ Verified end to end on an NVIDIA L4 at both reduced and default settings.
 | `Seed` | -1 | Base seed, offset per clip; -1 derives from clip index |
 | `NegativePrompt` | *(empty)* | Empty uses the tuned default from the model card |
 | `ModelId` | `Wan-AI/Wan2.2-TI2V-5B-Diffusers` | Hugging Face repo ID |
-| `HFCacheDir` | `/var/tmp/wan22_hf_cache` | Worker-local model cache |
+| `HFCacheDir` | *(empty)* | Model cache; empty uses the fleet's persistent volume |
 
 ### Resolution and frame count constraints
 
@@ -90,11 +93,25 @@ near those dimensions gives the best results.
 
 ### Model cache location
 
-`HFCacheDir` must point at a real disk. Deadline Cloud service-managed fleet
-workers mount `/tmp` as a **RAM-backed tmpfs** that is too small for a 34 GiB
-checkpoint. Pointing the cache there fails partway through the download with
-`No space left on device`. The default `/var/tmp/wan22_hf_cache` is on the root
-volume, which has ample space.
+With `HFCacheDir` empty, the script picks the cache location at runtime:
+
+1. The fleet's [persistent volume](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/volumes.html),
+   via the `DEADLINE_PERSISTENT_MOUNT` path Deadline Cloud sets on workers when
+   the fleet has persistent storage enabled. **Prefer this.** Only that volume
+   survives worker replacement, so later workers reuse the checkpoint instead of
+   downloading it again. The default 250 GiB volume is well above the 60 GiB
+   needed here.
+2. Otherwise `/var/tmp/wan22_hf_cache`, which on a Linux service-managed fleet
+   worker is on the root EBS volume. The job runs fine, but that volume is
+   discarded with the worker, so every new worker re-downloads all ~34 GiB. The
+   log names the fallback path when it is used.
+
+Setting `HFCacheDir` to an explicit path overrides both. It needs 60 GiB free on
+a real disk. Not `/tmp`: on a Linux service-managed fleet worker that is a
+RAM-backed tmpfs limited to half of system memory, or about 32 GiB on this job's
+64 GiB worker, so the download dies with `No space left on device`. This follows
+the [Amazon Linux 2023 default](https://docs.aws.amazon.com/linux/al2023/ug/compare-al2-al2023-tmp.html)
+that service-managed fleet workers are built on.
 
 `HFCacheDir` is deliberately a `STRING` rather than a `PATH` parameter so the
 downloaded weights stay out of job attachments and are never uploaded back to
@@ -120,7 +137,7 @@ script also runs standalone:
 ```bash
 WAN_PROMPT="a red fox in a snowy forest" \
 WAN_OUTPUT_DIR=./out \
-WAN_HF_CACHE_DIR=/var/tmp/wan22_hf_cache \
+WAN_HF_CACHE_DIR=~/wan22_hf_cache \
   python generate_video.py --clip-index 1
 ```
 
@@ -188,10 +205,11 @@ memory ceiling during decode. Without it, full-resolution renders complete every
 denoising step and then run out of memory in the VAE.
 
 Because a multi-clip job spreads tasks across workers, wall-clock time for
-`NumClips=8` on eight workers is close to the time for one clip, plus each
-worker's one-time setup. Note that the setup cost is per worker, not per job:
-the cache is local to a worker, so eight workers each download the checkpoint
-once. Tasks that share a worker reuse it and start generating immediately.
+`NumClips=8` on eight workers is close to the time for one clip, plus setup.
+Tasks sharing a worker reuse its cache and start generating immediately. Each
+persistent volume serves one worker at a time, so eight concurrent workers each
+download the checkpoint once. Later workers that pick up a warm volume skip it.
+Without persistent storage, every worker downloads it.
 
 ## Licensing
 

--- a/job_bundles/wan22_video_generation/generate_video.py
+++ b/job_bundles/wan22_video_generation/generate_video.py
@@ -40,11 +40,61 @@ def _configure_hf_cache(cache_dir: str) -> Path:
 
 
 # The TI2V-5B checkpoint is ~34 GiB on disk, and Xet needs room for its staging
-# chunks on top of that. Deadline Cloud workers mount /tmp as a RAM-backed
-# tmpfs, so a cache placed there both competes with the model for memory and
-# hits ENOSPC partway through the download. Fail early with a clear message
-# instead of dying 20 GiB in.
+# chunks on top of that. Fail early with a clear message instead of dying 20 GiB
+# in. Note that Linux service-managed fleet workers mount /tmp as a RAM-backed
+# tmpfs limited to half of system memory (the Amazon Linux 2023 default), so on
+# the 64 GiB worker this job requires it tops out near 32 GiB and cannot hold the
+# checkpoint at all.
 MIN_CACHE_FREE_GIB = 60
+
+# Set by Deadline Cloud on service-managed fleet workers when the fleet has
+# persistent storage enabled, holding the volume's mount path.
+PERSISTENT_MOUNT_ENV = "DEADLINE_PERSISTENT_MOUNT"
+
+# Subdirectory created under the persistent mount for this sample's weights.
+CACHE_SUBDIR = "wan22_hf_cache"
+
+# Used when the fleet has no persistent volume. On a Linux service-managed fleet
+# worker /var/tmp is on the root EBS volume, so it is a real disk with room for
+# the checkpoint, unlike the tmpfs at /tmp. It just does not outlive the worker.
+FALLBACK_CACHE_DIR = f"/var/tmp/{CACHE_SUBDIR}"
+
+
+def _resolve_cache_dir(explicit: str) -> str:
+    """Choose where the ~34 GiB checkpoint is cached.
+
+    An explicit --hf-cache-dir (or WAN_HF_CACHE_DIR) always wins. Otherwise the
+    cache goes on the fleet's persistent volume when there is one, because only
+    that volume survives worker replacement; the root volume is discarded, so
+    caching there re-downloads 34 GiB on every new worker.
+
+    Without a persistent volume the job still runs, falling back to the root
+    volume. That is correct for space and merely slower across workers, so it is
+    logged rather than treated as an error.
+    """
+    if explicit:
+        return explicit
+
+    mount = os.environ.get(PERSISTENT_MOUNT_ENV, "")
+    if mount:
+        resolved = str(Path(mount) / CACHE_SUBDIR)
+        print(
+            f"Caching weights on the fleet's persistent volume: {resolved} "
+            f"(from {PERSISTENT_MOUNT_ENV}={mount}). The checkpoint is reused by "
+            "later workers instead of being downloaded again.",
+            flush=True,
+        )
+        return resolved
+
+    print(
+        f"{PERSISTENT_MOUNT_ENV} is not set, so this fleet has no persistent "
+        f"volume. Caching weights on the root volume at {FALLBACK_CACHE_DIR}, "
+        "which has room but is discarded when a worker is replaced: every new "
+        "worker downloads the ~34 GiB checkpoint again. Enable persistent "
+        "storage on the fleet to avoid that.",
+        flush=True,
+    )
+    return FALLBACK_CACHE_DIR
 
 
 def _cached_bytes(cache_dir: str) -> int:
@@ -167,10 +217,12 @@ def _check_cache_space(cache_dir: str, model_id: str) -> None:
         raise SystemExit(
             f"Only {free_gib:.1f} GiB free at {cache_dir} with {cached_gib:.1f} "
             f"GiB already cached, but the Wan2.2 checkpoint needs at least "
-            f"{MIN_CACHE_FREE_GIB} GiB including download staging space. Point "
-            "--hf-cache-dir at a real disk; on Deadline Cloud service-managed "
-            "fleets /tmp is a RAM-backed tmpfs, so prefer a path under /var/tmp "
-            "or the session directory."
+            f"{MIN_CACHE_FREE_GIB} GiB including download staging space. If this "
+            "is the fleet's persistent volume, raise its size; if it is the root "
+            "volume, raise the fleet's root EBS volume size; otherwise point "
+            "HFCacheDir (--hf-cache-dir) at a disk with more room. Avoid /tmp, "
+            "which Linux service-managed fleet workers mount as a RAM-backed "
+            "tmpfs limited to half of system memory."
         )
 
 
@@ -346,14 +398,18 @@ def main():
     parser.add_argument(
         "--hf-cache-dir",
         default=_env_default("WAN_HF_CACHE_DIR"),
-        help="Directory for the HuggingFace hub cache, shared across tasks.",
+        help=(
+            "Directory for the HuggingFace hub cache, shared across tasks. "
+            "Defaults to a directory on the fleet's persistent volume, using the "
+            f"{PERSISTENT_MOUNT_ENV} environment variable Deadline Cloud sets on "
+            "workers when the fleet has persistent storage enabled."
+        ),
     )
     args = parser.parse_args()
 
     for name, value in (
         ("--prompt (WAN_PROMPT)", args.prompt),
         ("--output-dir (WAN_OUTPUT_DIR)", args.output_dir),
-        ("--hf-cache-dir (WAN_HF_CACHE_DIR)", args.hf_cache_dir),
     ):
         if not value:
             raise SystemExit(f"{name} is required but was empty.")
@@ -377,7 +433,10 @@ def main():
     except OSError as exc:
         raise SystemExit(f"Output directory {output_dir} is not writable: {exc}")
 
-    cache_dir = _configure_hf_cache(args.hf_cache_dir)
+    # An empty --hf-cache-dir is not an error: it means "use the fleet's
+    # persistent volume". Resolved after the cheap parameter checks so a bad
+    # width or frame count is reported before any storage complaint.
+    cache_dir = _configure_hf_cache(_resolve_cache_dir(args.hf_cache_dir))
     _check_cache_space(cache_dir, args.model_id)
 
     # Imported after HF_HOME is set.

--- a/job_bundles/wan22_video_generation/template.yaml
+++ b/job_bundles/wan22_video_generation/template.yaml
@@ -148,13 +148,17 @@ parameterDefinitions:
     label: HuggingFace Cache Directory
     groupLabel: Model Settings
   description: >
-    Worker-local directory for the ~34 GiB model download. Deliberately a STRING
-    rather than a PATH so the weights stay out of job attachments and are never
-    uploaded back. Reused across tasks in a session, so only the first task on a
-    worker pays the download cost. Must live on a real disk: Deadline Cloud
-    service-managed fleet workers mount /tmp as a RAM-backed tmpfs that is far
-    too small for this checkpoint.
-  default: "/var/tmp/wan22_hf_cache"
+    Where the ~34 GiB model download is cached. Leave empty to cache on the
+    fleet's persistent volume when it has one, located through the
+    DEADLINE_PERSISTENT_MOUNT variable Deadline Cloud sets on workers, and
+    otherwise on the root volume under /var/tmp. Only the persistent volume
+    survives worker replacement, so it is what lets a later worker reuse the
+    checkpoint rather than downloading it again. Set a path to cache elsewhere; it
+    needs 60 GiB free on a real disk, not under /tmp, which Linux service-managed
+    fleet workers mount as a RAM-backed tmpfs limited to half of system memory.
+    Deliberately a STRING rather than a PATH so the weights stay out of job
+    attachments and are never uploaded back.
+  default: ""
 
 - name: GenerateScript
   type: PATH


### PR DESCRIPTION
Follow-up to #269, addressing review feedback on the model cache.

## Problem

`HFCacheDir` defaulted to `/var/tmp/wan22_hf_cache`, on the worker's **root** volume. Deadline Cloud only preserves a fleet's [persistent volume](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/volumes.html) across worker replacement, so enabling persistent storage still re-downloaded the ~34 GiB checkpoint on every new worker. Setting `HF_HOME` explicitly also opted out of persistence the sample would otherwise inherit, since Deadline Cloud points the worker's home directory at that volume.

The tmpfs warning was wrong about the cause. Linux service-managed fleet workers mount `/tmp` as a RAM-backed tmpfs limited to half of system memory, which is what broke the download: this job needs a 64 GiB worker, so `/tmp` tops out near 32 GiB. `/var/tmp` is on the root EBS volume, so the old default was right for space and wrong for persistence.

## Change

`HFCacheDir` now defaults to empty and resolves at runtime:

1. Explicit `HFCacheDir` / `--hf-cache-dir` wins
2. Else `$DEADLINE_PERSISTENT_MOUNT/wan22_hf_cache`, reused across workers
3. Else `/var/tmp/wan22_hf_cache`, logging that each new worker re-downloads

Fleets without persistent storage keep working, they just log the cost. `HFCacheDir` stays a `STRING` so weights remain out of job attachments.

## Testing

Submitted to a GPU queue (NVIDIA L4), identical parameters, no template edits between runs:

| Fleet config | Volume seen | Cache path |
|---|---|---|
| No persistent storage | 249.9 GiB total | `/var/tmp/wan22_hf_cache` (root EBS) |
| Persistent storage (200 GiB) | 199.9 GiB total | `/mnt/persistent/wan22_hf_cache` |

Both SUCCEEDED with a valid H.264 MP4 (640x352, 17 frames). The volume sizes confirm each cached on the intended disk. `validate_repository.py` (35 tests), `openjd check`, and `vale` pass.

Cross-worker cache *reuse* is not covered by a live run, since both runs got a fresh worker and empty volume (`0.0 GiB already cached`).
