### PR TITLE
docs: suggest updating repo description/topics for new software support

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,6 +14,7 @@ Fixes: *<insert link to GitHub issue here>*
 ### Was this change documented?
 
 - If applicable, has the sample's description been updated?
+- If the change adds support for new software or a new kind of workload, say so here so a maintainer can add it to the repository description or topics, where people searching GitHub will find it.
 
 ---
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The repository description and topics list are the main way someone searching GitHub for a specific application (Maya, CARLA, RELION, and so on) or a kind of workload finds these samples. Both are already maintained: the description names the workload categories, and there are topics for individual applications like `blender`, `houdini`, `nuke`, `carla`, and `mujuco`.

Nothing in the contribution flow reminds anyone to extend that metadata. A PR can add a fully working sample for software the repository has never covered, get merged, and remain invisible to the searches that would have found it.

### What was the solution? (How)

Add one bullet to the "Was this change documented?" section of the pull request template asking the contributor to call out when a change adds support for new software or a new kind of workload, so a maintainer can update the repository description or topics. Repository metadata is not editable through a PR, so the template asks the contributor to flag it rather than change it.

### What is the impact of this change?

New-software PRs surface the metadata gap while a maintainer is already looking at the change. No effect on existing samples, validation, or CI.

### How was this change tested?

- `python3 scripts/validate_repository.py` — 35 unit tests pass, 163 Markdown files link-checked, "Repository validation passed".
- `vale .github/PULL_REQUEST_TEMPLATE.md` — 0 errors, 0 warnings, 0 suggestions.
- The rendered template is visible in the description of this PR, which was written against it.

### Was this change documented?

The change is itself documentation. `CONTRIBUTING.md` and `AGENTS.md` describe the code and index updates a contribution needs; neither covers repository-level metadata, which is a maintainer action rather than a checklist item, so the prompt lives in the PR template only.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*