### PR TITLE
fix(maya-2027): make mayapy load Maya's own libpython

### DIFF
--- a/conda_recipes/maya-2027/recipe/build.sh
+++ b/conda_recipes/maya-2027/recipe/build.sh
@@ -94,8 +94,6 @@ ln -r -s $PREFIX/$MAYA_ROOT/bin/Render $PREFIX/bin/Render
 # where mayapy can silently load another package's libpython3.13 (the maya-openjd adaptor
 # stack installs one) and crash. Exec'ing the real path keeps the lookup inside the
 # installation.
-#
-# Do not revert to a symlink. bin/maya and bin/Render resolve symlinks themselves.
 cat > $PREFIX/bin/mayapy <<EOF
 #!/bin/sh
 exec "$PREFIX/$MAYA_ROOT/bin/mayapy" "\$@"

--- a/conda_recipes/maya-2027/recipe/build.sh
+++ b/conda_recipes/maya-2027/recipe/build.sh
@@ -85,8 +85,22 @@ mkdir -p $PREFIX/bin
 ln -r -s $PREFIX/$MAYA_ROOT/bin/maya$MAYA_VERSION $PREFIX/bin/maya$MAYA_VERSION
 ln -r -s $PREFIX/$MAYA_ROOT/bin/maya$MAYA_VERSION $PREFIX/bin/maya
 ln -r -s $PREFIX/$MAYA_ROOT/bin/mayapy.bin $PREFIX/bin/mayapy.bin
-ln -r -s $PREFIX/$MAYA_ROOT/bin/mayapy $PREFIX/bin/mayapy
 ln -r -s $PREFIX/$MAYA_ROOT/bin/Render $PREFIX/bin/Render
+
+# Expose mayapy through a wrapper script instead of a symlink.
+#
+# Autodesk's bin/mayapy looks for Maya's libraries in ../lib relative to the directory it
+# was invoked from, so exec'ing a symlink in $PREFIX/bin sends the lookup to $PREFIX/lib,
+# where mayapy can silently load another package's libpython3.13 (the maya-openjd adaptor
+# stack installs one) and crash. Exec'ing the real path keeps the lookup inside the
+# installation.
+#
+# Do not revert to a symlink. bin/maya and bin/Render resolve symlinks themselves.
+cat > $PREFIX/bin/mayapy <<EOF
+#!/bin/sh
+exec "$PREFIX/$MAYA_ROOT/bin/mayapy" "\$@"
+EOF
+chmod +x $PREFIX/bin/mayapy
 
 # Use thin client licensing configuration to use the ProductInformation.pit from the Arnold installation.
 #


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
  `mayapy` from the `maya-2027` package segfaults when the conda environment also contains another Python 3.13 which any job using the `maya-openjd` adaptor does, since it pulls in conda-forge `python`. In `turntable_with_maya_arnold`, `PrepareSceneFile` died with exit code `-11` i.e.`SIGSEGV`.

 Autodesk's `bin/mayapy` is a launcher script that sets `LD_LIBRARY_PATH` to `../lib` relative to the directory it was invoked from, without resolving symlinks. Reached through the symlink this recipe created at `$PREFIX/bin/mayapy`, it pointed at `$PREFIX/lib` instead of Maya's own `lib`, so Maya loaded conda's `libpython3.13.so.1.0` and its stdlib extensions bound to a foreign CPython build. Maya 2026 bundles Python 3.11, so the sonames never collided there.

  ### What was the solution? (How)
  Replace the symlink with a wrapper that `exec`s Maya's real `bin/mayapy`, keeping the launcher's library lookup inside the Maya installation. `bin/maya` and `bin/Render` resolve symlinks themselves and are unchanged.

  ### What is the impact of this change?
  Adaptor-based Maya 2027 jobs now run. `$PREFIX/bin/mayapy` becomes a script rather than a symlink, at the cost of one extra `exec`. No RPATHs, activation scripts, or other packages change, and conda's Python is still used by the adaptor daemon in its own process.

  ### How was this change tested?
Rebuilt `maya-2027` and re-ran `turntable_with_maya_arnold` with `maya=2027 maya-mtoa=2027 maya-openjd=0.15.13 ffmpeg`; the step that previously segfaulted now completes.

  ### Was this change documented?
  A comment above the wrapper in `build.sh` records why `mayapy` isn't a symlink.