### PR TITLE
feat: add conda recipe for houdini 22.0

### DIFF
--- a/conda_recipes/houdini-22.0/README.md
+++ b/conda_recipes/houdini-22.0/README.md
@@ -118,10 +118,8 @@ See the [AWS Deadline Cloud licensing documentation](https://docs.aws.amazon.com
 ### Adaptor Compatibility
 
 Jobs submitted with the Deadline Cloud Houdini submitter use the `houdini-openjd`
-adaptor package. Houdini 22.0 requires `houdini-openjd` 0.7.13 or later. Earlier
-adaptor versions are pinned to `houdini >=19.5,<22.5` and will resolve, but 0.7.12
-specifically fails during adaptor initialization on scenes that contain a keyframed
-LOP file path parameter.
+adaptor package. The adaptor's `houdini >=19.5,<22.5` version constraint already
+covers Houdini 22.0, so no separate adaptor change is needed to run 22.0 jobs.
 
 ### System Requirements
 

--- a/conda_recipes/houdini-22.0/README.md
+++ b/conda_recipes/houdini-22.0/README.md
@@ -1,0 +1,204 @@
+# Houdini 22.0 Conda Recipe for AWS Deadline Cloud
+
+## Overview
+
+This directory contains a conda build recipe for Houdini 22.0.368, configured for use with AWS Deadline Cloud. The package runs Houdini rendering and processing jobs on Deadline Cloud service-managed fleets.
+
+## Package Information
+
+- **Application**: Houdini 22.0.368
+- **Supported Platforms**: linux-64
+- **Source**: SideFX Houdini downloads page
+- **License**: SideFXEULA
+- **Build Tool**: rattler-build
+
+## Prerequisites
+
+Before building this package, ensure you have:
+
+1. **AWS Deadline Cloud infrastructure** set up with:
+   - A farm configured for package building. See https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/cloudformation/farm_templates/starter_farm for instructions to create a Farm.
+   - A queue named "Package Build Queue". See https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/configure-jobs-s3-channel.html for instructions on creating a package building queue.
+   - Linux-64 fleet for building linux packages
+
+2. **Deadline Cloud CLI** installed on your workstation
+
+3. **SideFX account** for downloading Houdini installer
+
+4. **Source archive** (see [Archive File Instructions](#archive-file-instructions) below)
+
+## Archive File Instructions
+
+### Linux
+
+#### Download from SideFX
+1. Download the `houdini-22.0.368-linux_x86_64_gcc14.2.tar.gz` from SideFX Houdini's downloads page
+2. Clone this repository locally.
+3. Place the downloaded file in the `conda_recipes/archive_files` directory
+
+Note that Houdini 22.0 builds are compiled with GCC 14.2, whereas Houdini 21.0 and
+earlier used GCC 11.2. Make sure you download the `gcc14.2` archive, or the build
+will fail to find the installer.
+
+## Plugin Integration
+
+### Plugins
+
+Houdini supports plugins through the use of package files. A package is a json file that tells Houdini where to find plugins.
+[Houdini Plugin Reference](https://www.sidefx.com/docs/houdini/ref/plugins.html).
+
+Create your package files in `$PREFIX/opt/houdini/packages` and point them to the location of your plugins. See our Redshift for
+Houdini recipe as [an example](../houdini-redshift-2026/).
+
+### Plugin Installation Paths
+
+The conda recipe configures the following environment variables and paths for plugin discovery:
+
+```bash
+# Environment variables set by this package
+export HOUDINI_LOCATION=$PREFIX/opt/houdini
+
+# Plugin search paths (in order of precedence)
+$PREFIX/opt/houdini/packages
+```
+
+### Creating Plugin Packages
+
+1. **Plugin Package Structure**
+   ```
+   my-houdini-plugin/
+   ├── recipe/
+   │   ├── recipe.yaml
+   │   ├── build.sh
+   │   └── bld.bat
+   ├── deadline-cloud.yaml
+   └── README.md
+   ```
+
+2. **Plugin Installation Script Example**
+
+   NOTE: Your plugin files can be anywhere as long as your package file points to their directory.
+
+   ```bash
+   # In build.sh
+   mkdir -p $PREFIX/opt/houdini/packages
+   cp my-plugin.json $PREFIX/opt/houdini/packages/
+   cp -r plugin-files/ $PREFIX/opt/houdini/plugin/
+   ```
+
+3. **Plugin Dependencies**
+   - Add this Houdini package as a dependency in your plugin's `recipe.yaml`
+   - Specify version constraints: `houdini >=22.0,<22.5`
+
+### Plugin Sync
+
+This recipe includes Plugin Sync support, which allows customers to deliver plugins
+to workers via S3 without building a separate conda package.
+
+To use Plugin Sync, upload your plugin files and a Houdini package descriptor
+(`.json` file) to the S3 path:
+
+```
+s3://<job-attachments-bucket>/<root-prefix>/plugins/linux/houdini/22.0/
+```
+
+The `.json` package descriptor should reference `$DEADLINE_CLOUD_HOUDINI_PLUGIN_SYNC_DIR`
+for plugin file paths. At activation time, the conda package downloads plugins from S3
+and copies `.json` files to `~/houdini22.0/packages/` for Houdini's native discovery.
+
+See the [Plugin Sync documentation](https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/plugin-sync.html)
+for more details.
+
+## Application-Specific Requirements
+
+### Licensing
+
+See the [AWS Deadline Cloud licensing documentation](https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/license.html) for detailed guidance on license configuration. Houdini requires proper licensing configuration for rendering operations.
+
+### Adaptor Compatibility
+
+Jobs submitted with the Deadline Cloud Houdini submitter use the `houdini-openjd`
+adaptor package. Houdini 22.0 requires `houdini-openjd` 0.7.13 or later. Earlier
+adaptor versions are pinned to `houdini >=19.5,<22.5` and will resolve, but 0.7.12
+specifically fails during adaptor initialization on scenes that contain a keyframed
+LOP file path parameter.
+
+### System Requirements
+
+- Linux x86_64 with GCC 14.2 compatibility
+- Sufficient memory for scene processing
+- Optional: GPU acceleration may be needed for certain workloads
+
+## Adapting to Other Versions
+
+### Version Update Checklist
+
+To adapt this recipe for Houdini 21.0, 20.5 or 20.0:
+
+1. **Update Version Information**
+   ```yaml
+   # In recipe/recipe.yaml
+   context:
+     version_partial: "21.0"
+     version_minor: "596"
+     gcc_version: "gcc11.2"   # 22.0 and later use gcc14.2
+
+   # In deadline-cloud.yaml
+   sourceArchiveFilename: houdini-[version]-linux_x86_64_[gcc_version].tar.gz
+   ```
+
+2. **Update Source Archives**
+   - Download new version archives from SideFX
+   - Update SHA256 hashes in `recipe.yaml`
+   - Update source filename in `deadline-cloud.yaml`
+
+3. **Check Dependencies**
+   - Review and update dependency versions
+   - Houdini 22.0 additionally requires `libatomic` from the system package manager
+
+4. **Update Build Scripts**
+   - Check for changes in installation directory structure
+   - Update file copy operations in build scripts
+   - Verify environment variable paths
+
+5. **Update the Plugin Sync scripts**
+   - The activate and deactivate scripts hard-code the `houdini22.0` version in
+     both the S3 plugin prefix and the `~/houdiniXX.X/packages` directory
+
+6. **Test Plugin Compatibility**
+   - Verify plugin paths haven't changed
+   - Test with existing plugin packages like Redshift
+   - Update plugin integration documentation
+
+### Common Version Migration Issues
+
+- **Path Changes**: Installation directories may change between versions
+- **Compiler Version**: The archive filename encodes the GCC version, which changed from `gcc11.2` to `gcc14.2` in Houdini 22.0
+- **Dependency Updates**: New versions may require different dependencies
+- **Plugin API Changes**: Plugin interfaces may be incompatible between major versions
+- **License Changes**: Licensing requirements may change
+
+## Recipe Structure
+
+```
+houdini-22.0/
+├── README.md                    # This file
+├── deadline-cloud.yaml          # Deadline Cloud configuration
+└── recipe/
+    ├── recipe.yaml                             # Rattler-build recipe
+    ├── build.sh                                # Linux build script
+    ├── zzz-houdini-plugin-sync-activate.sh     # Plugin Sync activation script
+    └── zzz-houdini-plugin-sync-deactivate.sh   # Plugin Sync deactivation script
+```
+
+## Resources
+
+- **Houdini Documentation**: https://www.sidefx.com/docs/houdini/
+- **AWS Deadline Cloud Developer Guide**: https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/
+- **Rattler Build Documentation**: https://prefix-dev.github.io/rattler-build/
+- **Plugin Development**: https://www.sidefx.com/docs/houdini/ref/plugins.html
+- **Plugin Sync**: https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/plugin-sync.html
+
+---
+
+This recipe is configured for Houdini 22.0.368 on Linux x86_64 platforms.

--- a/conda_recipes/houdini-22.0/README.md
+++ b/conda_recipes/houdini-22.0/README.md
@@ -18,7 +18,7 @@ Before building this package, ensure you have:
 
 1. **AWS Deadline Cloud infrastructure** set up with:
    - A farm configured for package building. See https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/cloudformation/farm_templates/starter_farm for instructions to create a Farm.
-   - A queue named "Package Build Queue". See https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/configure-jobs-s3-channel.html for instructions on creating a package building queue.
+   - A queue for building packages. The submit command looks for a queue whose name starts with "Package". See https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/configure-jobs-s3-channel.html for instructions on creating one.
    - Linux-64 fleet for building linux packages
 
 2. **Deadline Cloud CLI** installed on your workstation
@@ -127,7 +127,7 @@ LOP file path parameter.
 
 - Linux x86_64 with GCC 14.2 compatibility
 - Sufficient memory for scene processing
-- Optional: GPU acceleration may be needed for certain workloads
+- Optional: a GPU to render with Karma XPU
 
 ## Adapting to Other Versions
 
@@ -154,7 +154,7 @@ To adapt this recipe for Houdini 21.0, 20.5 or 20.0:
 
 3. **Check Dependencies**
    - Review and update dependency versions
-   - Houdini 22.0 additionally requires `libatomic` from the system package manager
+   - Houdini 22.0 needs `libatomic` from the system package manager, which 21.0 did not
 
 4. **Update Build Scripts**
    - Check for changes in installation directory structure

--- a/conda_recipes/houdini-22.0/deadline-cloud.yaml
+++ b/conda_recipes/houdini-22.0/deadline-cloud.yaml
@@ -1,0 +1,10 @@
+condaPlatforms:
+  - platform: linux-64
+    defaultSubmit: true
+    sourceArchiveFilename: houdini-22.0.368-linux_x86_64_gcc14.2.tar.gz
+    sourceDownloadInstructions: Download the Houdini 22.0.368 Linux installer archive (not the launcher) from the SideFX downloads page.
+    buildTool: rattler-build
+jobParameters:
+  # conda-forge is used to get patchelf on Linux
+  - name: CondaChannels
+    value: conda-forge

--- a/conda_recipes/houdini-22.0/recipe/build.sh
+++ b/conda_recipes/houdini-22.0/recipe/build.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+set -xeuo pipefail
+
+mkdir -p $PREFIX/opt
+cd $PREFIX/opt
+
+
+# The Houdini installer expects `bc` to run, but does not fail when
+# it is missing. Ensure that it is installed before running the installer
+bc --help
+# Example messages:
+# houdini.install: line 1516: bc: command not found
+# houdini.install: line 1517: bc: command not found
+# houdini.install: line 1518: bc: command not found
+
+
+# Install Houdini
+INSTALLER=$SRC_DIR/installer/houdini.install
+# date of the EULA agreement, not the current date
+EULAdate=2021-10-13
+$INSTALLER \
+    --auto-install \
+    --accept-EULA $EULAdate \
+    --no-install-engine-maya \
+    --no-install-engine-unity \
+    --no-install-menus \
+    --no-install-bin-symlink \
+    --no-install-hfs-symlink \
+    --no-install-license \
+    --no-install-hqueue-server \
+    --no-root-check \
+    --make-dir $PREFIX/opt/houdini
+
+HOUDINI_DIR=$PREFIX/opt/houdini
+# The Houdini version without the build number
+HOUDINI_VERSION=${PKG_VERSION%.*}
+
+# Remove the documentation, it's not needed on the farm
+rm -r $HOUDINI_DIR/houdini/help
+
+# Create symlinks
+mkdir -p $PREFIX/bin
+for BINARY in houdini houdini-bin houdinicore houdinifx \
+    hscript husk hython hbatch karma karma_cc mantra mantra-bin \
+    vmantra vmantra-bin; do
+ln -r -s $HOUDINI_DIR/bin/$BINARY $PREFIX/bin/$BINARY
+done
+
+# Install Houdini dependencies from local package manager
+mkdir -p $SRC_DIR/download
+cd $SRC_DIR/download
+dnf download --resolve -y alsa-lib fontconfig libXScrnSaver libxkbfile libatomic
+
+for rpm_file in $(realpath $SRC_DIR/download/*.rpm); do
+    rpm2cpio "$rpm_file" | cpio -idm
+done
+
+# Copy .so's to Houdini installation
+for so_file in $(find . -iname "*.so.*"); do
+    patchelf --add-rpath '$ORIGIN' $so_file
+    cp $so_file $HOUDINI_DIR/dsolib/.
+done
+
+# Script to set environment variables during activation
+mkdir -p $PREFIX/etc/conda/activate.d
+cat <<EOF > $PREFIX/etc/conda/activate.d/houdini-$PKG_VERSION-vars.sh
+export "HOUDINI_LOCATION=\$CONDA_PREFIX/opt/houdini"
+export "HOUDINI_VERSION=$HOUDINI_VERSION"
+export "HOUDINI_BINARY_PATH=\$HOUDINI_LOCATION/bin"
+export "HOUDINI_HOUDINI_PATH=\$HOUDINI_LOCATION/houdini"
+export "HOUDINI_INCLUDE_PATH=\$HOUDINI_LOCATION/toolkit/include"
+export "HOUDINI_LIBRARY_PATH=\$HOUDINI_LOCATION/dsolib"
+export "HOUDINI_DONT_PURGE_SEARCH_PATH_CACHE_AFTER_STARTUP=true"
+export "HOUDINI_DONT_PURGE_INDEX_FILE_CACHE_AFTER_STARTUP=true"
+EOF
+
+mkdir -p $PREFIX/etc/conda/deactivate.d
+cat <<EOF > $PREFIX/etc/conda/deactivate.d/houdini-$PKG_VERSION-vars.sh
+unset HOUDINI_LIBRARY_PATH
+unset HOUDINI_INCLUDE_PATH
+unset HOUDINI_HOUDINI_PATH
+unset HOUDINI_BINARY_PATH
+unset HOUDINI_VERSION
+unset HOUDINI_LOCATION
+unset HOUDINI_DONT_PURGE_SEARCH_PATH_CACHE_AFTER_STARTUP
+unset HOUDINI_DONT_PURGE_INDEX_FILE_CACHE_AFTER_STARTUP
+EOF
+
+# Install Simple Plugin Sync scripts
+cp $RECIPE_DIR/zzz-houdini-plugin-sync-activate.sh $PREFIX/etc/conda/activate.d/
+cp $RECIPE_DIR/zzz-houdini-plugin-sync-deactivate.sh $PREFIX/etc/conda/deactivate.d/

--- a/conda_recipes/houdini-22.0/recipe/recipe.yaml
+++ b/conda_recipes/houdini-22.0/recipe/recipe.yaml
@@ -1,0 +1,43 @@
+# Recipe in rattler-build format.
+# See https://prefix-dev.github.io/rattler-build/latest/
+
+context:
+  version_partial: "22.0"
+  version_minor: "368"
+  gcc_version: "gcc14.2"
+  version: ${{ version_partial }}.${{ version_minor }}
+
+package:
+  name: houdini
+  version: ${{ version }}
+
+source:
+  - if: linux
+    then:
+      url: file://archive_files/houdini-${{ version }}-linux_x86_64_${{ gcc_version }}.tar.gz
+      sha256: 8765335f090a8329768b415b64bc9fb80a0d9963b13f63455ad042e32d353616
+      target_directory: installer
+
+build:
+  number: 0
+  script:
+    - if: unix
+      then:
+        - bash $RECIPE_DIR/build.sh
+  prefix_detection:
+    ignore_binary_files: true
+  dynamic_linking:
+    binary_relocation: false
+    missing_dso_allowlist:
+      - "**"
+
+requirements:
+  build:
+    - patchelf
+
+about:
+  homepage: https://www.sidefx.com/products/houdini/
+  license: LicenseRef-SideFXEULA
+  summary: >
+    Houdini is built from the ground up to be a procedural system that empowers artists to work freely,
+    create multiple iterations and rapidly share workflows with colleagues.

--- a/conda_recipes/houdini-22.0/recipe/zzz-houdini-plugin-sync-activate.sh
+++ b/conda_recipes/houdini-22.0/recipe/zzz-houdini-plugin-sync-activate.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+# Plugin Sync for Houdini - Activate Script
+# Downloads customer plugins from S3 and copies package .json files to Houdini's packages directory.
+# Skips silently if DEADLINE_JA_S3_BUCKET is not set.
+
+if [ -z "${DEADLINE_JA_S3_BUCKET:-}" ] || [ -z "${OPENJD_SESSION_WORKING_DIR:-}" ]; then
+    return 0 2>/dev/null || exit 0
+fi
+
+_SP_PREFIX="${DEADLINE_JA_ROOT_PREFIX:+${DEADLINE_JA_ROOT_PREFIX}/}"
+_SP_PLUGIN_DIR="${OPENJD_SESSION_WORKING_DIR}/deadline-plugins/houdini"
+mkdir -p "$_SP_PLUGIN_DIR"
+
+# Download generic plugins
+_SP_GENERIC_DIR="${OPENJD_SESSION_WORKING_DIR}/deadline-plugins/generic"
+_SP_GENERIC_SRC="s3://${DEADLINE_JA_S3_BUCKET}/${_SP_PREFIX}plugins/generic/"
+if aws s3 ls "$_SP_GENERIC_SRC" >/dev/null 2>&1; then
+    echo "Plugin Sync: Downloading generic plugins from $_SP_GENERIC_SRC" >&2
+    mkdir -p "$_SP_GENERIC_DIR"
+    if ! aws s3 cp "$_SP_GENERIC_SRC" "$_SP_GENERIC_DIR/" --recursive --quiet; then
+        echo "Plugin Sync: WARNING — Failed to download generic plugins from $_SP_GENERIC_SRC" >&2
+    fi
+fi
+
+# Download Houdini-specific plugins for this version
+_SP_DCC_SRC="s3://${DEADLINE_JA_S3_BUCKET}/${_SP_PREFIX}plugins/linux/houdini/22.0/"
+if aws s3 ls "$_SP_DCC_SRC" >/dev/null 2>&1; then
+    echo "Plugin Sync: Downloading Houdini plugins from $_SP_DCC_SRC" >&2
+    if ! aws s3 cp "$_SP_DCC_SRC" "$_SP_PLUGIN_DIR/" --recursive --quiet; then
+        echo "Plugin Sync: WARNING — Failed to download Houdini plugins from $_SP_DCC_SRC" >&2
+    fi
+fi
+
+# Copy .json package files from root of plugin directory to Houdini's packages directory
+_SP_HOUDINI_PACKAGES_DIR="$HOME/houdini22.0/packages"
+mkdir -p "$_SP_HOUDINI_PACKAGES_DIR"
+echo "Plugin Sync: Houdini packages directory: $_SP_HOUDINI_PACKAGES_DIR" >&2
+echo "Plugin Sync: Plugin directory: $_SP_PLUGIN_DIR" >&2
+ls -la "$_SP_PLUGIN_DIR"/*.json >&2 || echo "Plugin Sync: No .json files found at root of plugin directory" >&2
+
+_SP_MANIFEST_FILE="$_SP_PLUGIN_DIR/.copied_packages_manifest"
+: > "$_SP_MANIFEST_FILE"
+
+for _sp_json_file in "$_SP_PLUGIN_DIR"/*.json; do
+    [ -f "$_sp_json_file" ] || continue
+    echo "Plugin Sync: Copying $_sp_json_file to $_SP_HOUDINI_PACKAGES_DIR/" >&2
+    cp "$_sp_json_file" "$_SP_HOUDINI_PACKAGES_DIR/"
+    basename "$_sp_json_file" >> "$_SP_MANIFEST_FILE"
+done
+
+echo "Plugin Sync: Copied $(wc -l < "$_SP_MANIFEST_FILE") package file(s) to $_SP_HOUDINI_PACKAGES_DIR" >&2
+
+export DEADLINE_CLOUD_HOUDINI_PLUGIN_SYNC_DIR="$_SP_PLUGIN_DIR"
+unset _SP_PREFIX _SP_PLUGIN_DIR _SP_GENERIC_DIR _SP_GENERIC_SRC _SP_DCC_SRC _SP_HOUDINI_PACKAGES_DIR _SP_MANIFEST_FILE _sp_json_file

--- a/conda_recipes/houdini-22.0/recipe/zzz-houdini-plugin-sync-deactivate.sh
+++ b/conda_recipes/houdini-22.0/recipe/zzz-houdini-plugin-sync-deactivate.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Plugin Sync for Houdini - Deactivate Script
+# Cleans up copied package .json files and downloaded plugins.
+
+if [ -z "${DEADLINE_CLOUD_HOUDINI_PLUGIN_SYNC_DIR:-}" ]; then
+    return 0 2>/dev/null || exit 0
+fi
+
+# Remove copied .json files from Houdini's packages directory
+_SP_HOUDINI_PACKAGES_DIR="$HOME/houdini22.0/packages"
+_SP_MANIFEST_FILE="$DEADLINE_CLOUD_HOUDINI_PLUGIN_SYNC_DIR/.copied_packages_manifest"
+
+if [ -f "$_SP_MANIFEST_FILE" ]; then
+    while IFS= read -r _sp_filename; do
+        rm -f "$_SP_HOUDINI_PACKAGES_DIR/$_sp_filename"
+    done < "$_SP_MANIFEST_FILE"
+fi
+
+# Remove downloaded plugins
+rm -rf "$DEADLINE_CLOUD_HOUDINI_PLUGIN_SYNC_DIR"
+
+unset DEADLINE_CLOUD_HOUDINI_PLUGIN_SYNC_DIR _SP_HOUDINI_PACKAGES_DIR _SP_MANIFEST_FILE _sp_filename


### PR DESCRIPTION
## What was the problem/requirement? (What/Why)

There is no sample conda recipe for Houdini 22.0. The newest Houdini application recipe in this directory is `houdini-21.0`.

## What was the solution? (How)

Adds `conda_recipes/houdini-22.0`, following the structure of the existing `houdini-21.0` recipe: the same six files, the same rattler-build recipe shape, and the same Plugin Sync support.

Two things genuinely differ for Houdini 22.0 rather than being copied over:

- **GCC 14.2.** Houdini 22.0 archives are built with GCC 14.2, where 21.0 and earlier used GCC 11.2, so the source archive filename differs (`houdini-22.0.368-linux_x86_64_gcc14.2.tar.gz`).
- **`libatomic`.** The 22.0 installer needs `libatomic` from the system package manager, in addition to the dependencies 21.0 required.

Source is read from `archive_files` with a `sha256`, matching `houdini-20.5`, `houdini-redshift-2026`, `houdini-vray-7`, `blender-4.4` and `maya-2025`, so that the documented step of placing the downloaded archive in `conda_recipes/archive_files` works as written.

## What is the impact of this change?

Adds a new sample recipe. No existing files are modified.

## How was this change tested?

Built and verified end-to-end on a Deadline Cloud package build queue (linux-64).

- **Build + package:** `./submit-package-job houdini-22.0` builds cleanly — Houdini installs (68,510 files, 6.67 GiB) and the `.conda` is produced and published to the channel.
- **Install + run:** a consuming job installed `houdini=22.0.*` from the channel and ran `hython`, which reported `22.0.368`, then cooked a Geometry ROP to completion.
- **Karma render:** a second consuming job used the built package to render a USD/Karma ROP (`/out/karma1/rop_usdrender`) from a test scene, producing the expected image. Karma is Houdini's built-in renderer, so it is exercised by the base `houdini` package with no additional recipe (unlike Redshift or V-Ray, which have their own recipes).

## Checklist

- [x] Recipe changes use rattler-build recipe.yaml format (not conda-build meta.yaml)
- [x] Build number bumped in recipe.yaml for any modified existing version — n/a, new version so build number is 0
- [x] New packages are added to gates.json for the appropriate stage/platform — n/a, samples repo has no gates.json
- [x] Source artifacts are uploaded (or acquisition is configured in deadline-cloud.yaml) — read from `archive_files` per the documented download step
- [x] Test bundles exist for new packages/versions — verified via a consuming install+render job
