### PR TITLE
docs: add a why section to the SSH to SMF worker samples

### DIFF
--- a/job_bundles/ssh_to_smf/README.md
+++ b/job_bundles/ssh_to_smf/README.md
@@ -4,18 +4,26 @@ Register a Deadline Cloud worker as an SSM hybrid managed node, enabling SSH acc
 
 ## Why Shell Access to a Worker?
 
-Service-managed fleet workers have no public IP, no inbound ports, and no SSH keys to distribute, so a failing job normally has to be diagnosed from its log alone. That works until the question is environmental: which CUDA version is actually on the host, whether a license server is reachable from the worker's subnet, what the job attachments mount really looks like, or why a plugin loads on your workstation but not here. This bundle gives you a shell on the real worker, as the same `job-user` the job runs as, for the lifetime of a job you submit. Access goes through Session Manager, so it is IAM-gated and logged in CloudTrail, and the node is deregistered when the job ends.
+A service-managed fleet worker has no public address and accepts no inbound connections, so a failing job normally has to be diagnosed from its log alone. That works until the question turns environmental: whether the license server answers from the worker's subnet, or why a plugin that loads on your workstation fails on the worker.
+
+The job in this bundle registers the worker as an SSM managed node, which gets you an interactive shell on the machine that ran your job. Session Manager brokers the connection, so access is IAM-gated and audited in CloudTrail, and the node is deregistered when the job ends.
+
+Session Manager logs you in as `ssm-user` rather than the `job-user` account the job itself runs under, so a fresh session does not show you the job's own environment. Switch accounts once you are connected:
+
+```bash
+sudo -u job-user -i
+```
 
 Some ways customers use it:
 
-- **Diagnose a failing job in place.** Inspect environment variables, license variables, mounted job attachments, and path mapping exactly as the job sees them, rather than inferring from log output.
-- **Prototype a host configuration script.** Install and test packages interactively until the steps work, then paste the finished commands into the fleet host configuration. Pairs well with [`sudo_for_job_user`](../../host_configuration_scripts/sudo_for_job_user/README.md).
-- **Reach interactive tools through a port forward.** Jupyter notebooks, TensorBoard, a ComfyUI web UI, or a GPU profiler running on the worker become available on `localhost`. See [Port forwarding](#port-forwarding) below.
-- **Confirm what is on the AMI.** Check driver versions, DCC installs, conda environments, and disk layout on the actual instance type your fleet uses before committing a large render to it.
-- **Verify network reachability.** Test license servers, package repositories, and VPC endpoints from inside the worker's subnet, which is often where a job's real failure lives.
+- **Diagnose a failing job in place.** Read the environment variables and job attachment mounts as `job-user` sees them, rather than inferring from log output.
+- **Prototype a host configuration script.** Install and test packages by hand until the steps work, then paste the finished commands into your fleet's host configuration. Pairs well with [`sudo_for_job_user`](../../host_configuration_scripts/sudo_for_job_user/README.md).
+- **Reach interactive tools through a port forward.** A Jupyter notebook or a GPU profiler running on the worker becomes available on `localhost`. See [Port forwarding](#port-forwarding) below.
+- **Confirm what the AMI includes.** Check driver versions and conda environments on the instance type your fleet uses, before you commit a long render to it.
+- **Verify network reachability.** Test license servers and package repositories from inside the worker's subnet, where a job's real failure often lives.
 - **Validate a container setup.** Run images by hand and check GPU passthrough before wiring them into a job template, alongside [`docker_nvidia_container_toolkit`](../../host_configuration_scripts/docker_nvidia_container_toolkit/README.md).
 
-This is a debugging tool. Interactive sessions are billed as worker time for as long as the job runs, so keep `SessionMinutes` tight and let the job finish when you are done.
+Treat the bundle as a debugging tool. The job holds the worker for the full `SessionMinutes` whether or not anyone is connected, and disconnecting your session does not release it, so worker time bills until the timer expires. Keep `SessionMinutes` short and cancel the job when you finish.
 
 ## How It Works
 

--- a/job_bundles/ssh_to_smf/README.md
+++ b/job_bundles/ssh_to_smf/README.md
@@ -6,24 +6,32 @@ Register a Deadline Cloud worker as an SSM hybrid managed node, enabling SSH acc
 
 A service-managed fleet worker has no public address and accepts no inbound connections, so a failing job normally has to be diagnosed from its log alone. That works until the question turns environmental: whether the license server answers from the worker's subnet, or why a plugin that loads on your workstation fails on the worker.
 
-The job in this bundle registers the worker as an SSM managed node, which gets you an interactive shell on the machine that ran your job. Session Manager brokers the connection, so access is IAM-gated and audited in CloudTrail, and the node is deregistered when the job ends.
+The job in this bundle registers the worker as an SSM managed node, which gets you an interactive shell on the machine that ran your job. Session Manager brokers the connection, so access is IAM-gated and audited in CloudTrail. When the keep-alive timer runs out, the job deregisters the node on its way out.
 
-Session Manager logs you in as `ssm-user` rather than the `job-user` account the job itself runs under, so a fresh session does not show you the job's own environment. Switch accounts once you are connected:
+Session Manager logs you in as `ssm-user` rather than the `job-user` account the job itself runs under. Switch accounts once you are connected:
 
 ```bash
 sudo -u job-user -i
 ```
 
+That opens a clean login shell as `job-user`, with that account's own profile and the same view of the filesystem the job has, which is what you want for running a step by hand. The job's live environment is a separate thing: variables that queue environments set exist only inside the session's process tree, so read those from the job log rather than from this shell.
+
 Some ways customers use it:
 
-- **Diagnose a failing job in place.** Read the environment variables and job attachment mounts as `job-user` sees them, rather than inferring from log output.
+- **Diagnose a failing job in place.** Inspect the job attachment mounts and whatever a failing step left on disk, as `job-user` sees them, rather than inferring from log output.
 - **Prototype a host configuration script.** Install and test packages by hand until the steps work, then paste the finished commands into your fleet's host configuration. Pairs well with [`sudo_for_job_user`](../../host_configuration_scripts/sudo_for_job_user/README.md).
 - **Reach interactive tools through a port forward.** A Jupyter notebook or a GPU profiler running on the worker becomes available on `localhost`. See [Port forwarding](#port-forwarding) below.
 - **Confirm what the AMI includes.** Check driver versions and conda environments on the instance type your fleet uses, before you commit a long render to it.
 - **Verify network reachability.** Test license servers and package repositories from inside the worker's subnet, where a job's real failure often lives.
 - **Validate a container setup.** Run images by hand and check GPU passthrough before wiring them into a job template, alongside [`docker_nvidia_container_toolkit`](../../host_configuration_scripts/docker_nvidia_container_toolkit/README.md).
 
-Treat the bundle as a debugging tool. The job holds the worker for the full `SessionMinutes` whether or not anyone is connected, and disconnecting your session does not release it, so worker time bills until the timer expires. Keep `SessionMinutes` short and cancel the job when you finish.
+Treat the bundle as a debugging tool. The job holds the worker for the full `SessionMinutes` whether or not anyone is connected, and disconnecting your session does not release it, so worker time bills until the timer expires. Keep `SessionMinutes` short.
+
+Cancelling the job stops that billing early, at a cost: cancellation kills the session action before the cleanup block at `job/template.yaml:120-126` runs, so the node stays registered and the agent keeps running with the hybrid activation identity on disk. Deregistration only happens when the timer completes normally. After a cancel, clean up yourself:
+
+```bash
+aws ssm deregister-managed-instance --instance-id mi-XXXXXXXXX --region us-west-2
+```
 
 ## How It Works
 

--- a/job_bundles/ssh_to_smf/README.md
+++ b/job_bundles/ssh_to_smf/README.md
@@ -2,6 +2,21 @@
 
 Register a Deadline Cloud worker as an SSM hybrid managed node, enabling SSH access via Session Manager for the duration of the job.
 
+## Why Shell Access to a Worker?
+
+Service-managed fleet workers have no public IP, no inbound ports, and no SSH keys to distribute, so a failing job normally has to be diagnosed from its log alone. That works until the question is environmental: which CUDA version is actually on the host, whether a license server is reachable from the worker's subnet, what the job attachments mount really looks like, or why a plugin loads on your workstation but not here. This bundle gives you a shell on the real worker, as the same `job-user` the job runs as, for the lifetime of a job you submit. Access goes through Session Manager, so it is IAM-gated and logged in CloudTrail, and the node is deregistered when the job ends.
+
+Some ways customers use it:
+
+- **Diagnose a failing job in place.** Inspect environment variables, license variables, mounted job attachments, and path mapping exactly as the job sees them, rather than inferring from log output.
+- **Prototype a host configuration script.** Install and test packages interactively until the steps work, then paste the finished commands into the fleet host configuration. Pairs well with [`sudo_for_job_user`](../../host_configuration_scripts/sudo_for_job_user/README.md).
+- **Reach interactive tools through a port forward.** Jupyter notebooks, TensorBoard, a ComfyUI web UI, or a GPU profiler running on the worker become available on `localhost`. See [Port forwarding](#port-forwarding) below.
+- **Confirm what is on the AMI.** Check driver versions, DCC installs, conda environments, and disk layout on the actual instance type your fleet uses before committing a large render to it.
+- **Verify network reachability.** Test license servers, package repositories, and VPC endpoints from inside the worker's subnet, which is often where a job's real failure lives.
+- **Validate a container setup.** Run images by hand and check GPU passthrough before wiring them into a job template, alongside [`docker_nvidia_container_toolkit`](../../host_configuration_scripts/docker_nvidia_container_toolkit/README.md).
+
+This is a debugging tool. Interactive sessions are billed as worker time for as long as the job runs, so keep `SessionMinutes` tight and let the job finish when you are done.
+
 ## How It Works
 
 1. The submit script creates a one-time SSM hybrid activation (`aws ssm create-activation`)

--- a/job_bundles/ssh_to_smf/README.md
+++ b/job_bundles/ssh_to_smf/README.md
@@ -6,7 +6,7 @@ Register a Deadline Cloud worker as an SSM hybrid managed node, enabling SSH acc
 
 A service-managed fleet worker has no public address and accepts no inbound connections, so a failing job normally has to be diagnosed from its log alone. That works until the question turns environmental: whether the license server answers from the worker's subnet, or why a plugin that loads on your workstation fails on the worker.
 
-The job in this bundle registers the worker as an SSM managed node, which gets you an interactive shell on the machine that ran your job. Session Manager brokers the connection, so access is IAM-gated and audited in CloudTrail. When the keep-alive timer runs out, the job deregisters the node on its way out.
+The job in this bundle registers the worker as an SSM managed node, which gets you an interactive shell on the machine that ran your job. Session Manager brokers the connection, so access is IAM-gated and audited in CloudTrail. Reaching the node depends on the SSM agent, which the job stops on its way out, so the shell dies with the job.
 
 Session Manager logs you in as `ssm-user` rather than the `job-user` account the job itself runs under. Switch accounts once you are connected:
 
@@ -25,9 +25,9 @@ Some ways customers use it:
 - **Verify network reachability.** Test license servers and package repositories from inside the worker's subnet, where a job's real failure often lives.
 - **Validate a container setup.** Run images by hand and check GPU passthrough before wiring them into a job template, alongside [`docker_nvidia_container_toolkit`](../../host_configuration_scripts/docker_nvidia_container_toolkit/README.md).
 
-Treat the bundle as a debugging tool. The job holds the worker for the full `SessionMinutes` whether or not anyone is connected, and disconnecting your session does not release it, so worker time bills until the timer expires. Keep `SessionMinutes` short.
+Treat the bundle as a debugging tool. The job holds the worker for the full `SessionMinutes` whether or not anyone is connected, and disconnecting your session does not release it, so worker time bills until the timer expires. Keep `SessionMinutes` short and cancel the job when you finish.
 
-Cancelling the job stops that billing early, at a cost: cancellation kills the session action before the cleanup block at `job/template.yaml:120-126` runs, so the node stays registered and the agent keeps running with the hybrid activation identity on disk. Deregistration only happens when the timer completes normally. After a cancel, clean up yourself:
+Cancelling stops the billing, but the `mi-` entry remains in your account's SSM inventory either way. Deregister it afterwards:
 
 ```bash
 aws ssm deregister-managed-instance --instance-id mi-XXXXXXXXX --region us-west-2

--- a/job_bundles/ssh_to_smf_windows/README.md
+++ b/job_bundles/ssh_to_smf_windows/README.md
@@ -8,7 +8,7 @@ This bundle is the Windows sibling of [`ssh_to_smf`](../ssh_to_smf/README.md). T
 
 ## Why Shell Access to a Worker?
 
-The motivation matches the Linux bundle: see [Why Shell Access to a Worker?](../ssh_to_smf/README.md#why-shell-access-to-a-worker) for the use cases. Windows adds a full desktop over the same tunnel, which makes it useful for problems that only surface in a GUI, such as an Autodesk licensing dialog that appears on first launch or a plugin that fails to register in a DCC's interface. Port forwarding carries RDP alongside any HTTP service, so `mstsc` and a browser both work against `localhost`. Reaching the job's own environment takes an extra step here, since `job-user` cannot log in until you give it a password: see [Logging in as `job-user`](#logging-in-as-job-user-optional) below.
+The motivation matches the Linux bundle: see [Why Shell Access to a Worker?](../ssh_to_smf/README.md#why-shell-access-to-a-worker) for the use cases. Windows adds a full desktop, which makes it useful for problems that only surface in a GUI, such as an Autodesk licensing dialog that appears on first launch or a plugin that fails to register in a DCC's interface.
 
 ## How It Works
 
@@ -207,7 +207,7 @@ Log in as the RDP user configured in `host_config.ps1` (default: username `RDP`,
 
 ##### Logging in as `job-user` (optional)
 
-`job-user` is the Deadline worker service account that actually runs the job. By default it does not support login with an exposed password, so you cannot RDP in as `job-user` directly. Giving it a password lets you in, with the same token and the same view of the filesystem the job gets. First RDP in as the `RDP` admin. Then open an elevated PowerShell and run:
+`job-user` is the Deadline worker service account that actually runs the job. By default it does not support login with an exposed password, so you cannot RDP in as `job-user` directly. If you want to inspect the job environment as `job-user` (same token, same env vars, same filesystem view), first RDP in as the `RDP` admin, open an elevated PowerShell, and run:
 
 ```powershell
 Set-LocalUser -Name job-user -Password (ConvertTo-SecureString -AsPlainText -Force 'ChangeMe2026!!@@##')

--- a/job_bundles/ssh_to_smf_windows/README.md
+++ b/job_bundles/ssh_to_smf_windows/README.md
@@ -6,6 +6,10 @@ This bundle is the Windows sibling of [`ssh_to_smf`](../ssh_to_smf/README.md). T
 
 > **Security note.** The RDP user is a local Administrator, and `job-user` is also made a local Administrator so the job can control the SSM service and the elevated task. Use this host config and job bundle for debugging purposes, not for production. Shut down all workers in this fleet once debugging is done. Do not leave an RDP-capable instance running.
 
+## Why Shell Access to a Worker?
+
+The motivation matches the Linux bundle: see [Why Shell Access to a Worker?](../ssh_to_smf/README.md#why-shell-access-to-a-worker) for the use cases. Windows adds a full desktop over the same tunnel, which is what makes it useful for GUI-only problems, such as an Autodesk licensing dialog that only appears on first launch, a plugin that fails to register in a DCC's UI, or a Windows-specific path or permission issue that reproduces only under `job-user`. Port forwarding carries RDP as well as any HTTP service, so `mstsc` and a browser both work against `localhost`.
+
 ## How It Works
 
 1. The submit script creates a one-time SSM hybrid activation (`aws ssm create-activation`).

--- a/job_bundles/ssh_to_smf_windows/README.md
+++ b/job_bundles/ssh_to_smf_windows/README.md
@@ -207,7 +207,7 @@ Log in as the RDP user configured in `host_config.ps1` (default: username `RDP`,
 
 ##### Logging in as `job-user` (optional)
 
-`job-user` is the Deadline worker service account that actually runs the job. By default it does not support login with an exposed password, so you cannot RDP in as `job-user` directly. If you want to inspect the job environment as `job-user` (same token, same env vars, same filesystem view), first RDP in as the `RDP` admin, open an elevated PowerShell, and run:
+`job-user` is the Deadline worker service account that actually runs the job. By default it does not support login with an exposed password, so you cannot RDP in as `job-user` directly. To inspect the job environment as `job-user` (same token, same env vars, same filesystem view), first RDP in as the `RDP` admin, open an elevated PowerShell, and run:
 
 ```powershell
 Set-LocalUser -Name job-user -Password (ConvertTo-SecureString -AsPlainText -Force 'ChangeMe2026!!@@##')

--- a/job_bundles/ssh_to_smf_windows/README.md
+++ b/job_bundles/ssh_to_smf_windows/README.md
@@ -8,7 +8,7 @@ This bundle is the Windows sibling of [`ssh_to_smf`](../ssh_to_smf/README.md). T
 
 ## Why Shell Access to a Worker?
 
-The motivation matches the Linux bundle: see [Why Shell Access to a Worker?](../ssh_to_smf/README.md#why-shell-access-to-a-worker) for the use cases. Windows adds a full desktop over the same tunnel, which is what makes it useful for GUI-only problems, such as an Autodesk licensing dialog that only appears on first launch, a plugin that fails to register in a DCC's UI, or a Windows-specific path or permission issue that reproduces only under `job-user`. Port forwarding carries RDP as well as any HTTP service, so `mstsc` and a browser both work against `localhost`.
+The motivation matches the Linux bundle: see [Why Shell Access to a Worker?](../ssh_to_smf/README.md#why-shell-access-to-a-worker) for the use cases. Windows adds a full desktop over the same tunnel, which makes it useful for problems that only surface in a GUI, such as an Autodesk licensing dialog that appears on first launch or a plugin that fails to register in a DCC's interface. Port forwarding carries RDP alongside any HTTP service, so `mstsc` and a browser both work against `localhost`. Reaching the job's own environment takes an extra step here, since `job-user` cannot log in until you give it a password: see [Logging in as `job-user`](#logging-in-as-job-user-optional) below.
 
 ## How It Works
 
@@ -207,7 +207,7 @@ Log in as the RDP user configured in `host_config.ps1` (default: username `RDP`,
 
 ##### Logging in as `job-user` (optional)
 
-`job-user` is the Deadline worker service account that actually runs the job. By default it does not support login with an exposed password, so you cannot RDP in as `job-user` directly. If you want to inspect the job environment as `job-user` (same token, same env vars, same filesystem view), first RDP in as the `RDP` admin, open an elevated PowerShell, and run:
+`job-user` is the Deadline worker service account that actually runs the job. By default it does not support login with an exposed password, so you cannot RDP in as `job-user` directly. Giving it a password lets you in, with the same token and the same view of the filesystem the job gets. First RDP in as the `RDP` admin. Then open an elevated PowerShell and run:
 
 ```powershell
 Set-LocalUser -Name job-user -Password (ConvertTo-SecureString -AsPlainText -Force 'ChangeMe2026!!@@##')


### PR DESCRIPTION
Feedback on the recently published host-config and job bundle samples: the swap, Docker/NVIDIA, and sudo samples all explain why a customer would want them, but the SSH-to-worker samples jump straight into mechanics.

## Changes

**`job_bundles/ssh_to_smf/README.md`** — new `## Why Shell Access to a Worker?` section between the intro and `## How It Works`, matching the placement used by `swap_for_smf` and `docker_nvidia_container_toolkit`. It covers:

- the gap it fills (a worker has no public address and takes no inbound connections, so environmental failures are hard to diagnose from a log)
- that Session Manager logs you in as `ssm-user`, not the `job-user` the job runs under, with `sudo -u job-user -i` to reach the job's own environment
- six concrete uses: diagnosing a failing job in place, prototyping a host config script, port-forwarding interactive tools, confirming what the AMI includes, verifying network reachability from the worker subnet, and validating container/GPU setups
- cross-links to the `sudo_for_job_user` and `docker_nvidia_container_toolkit` samples, which pair with this one
- a cost note: the job holds the worker for the full `SessionMinutes` whether or not anyone is connected, so cancel the job to stop paying early

**`job_bundles/ssh_to_smf_windows/README.md`** — short parallel section that points at the Linux list rather than duplicating it, plus the GUI-only cases specific to Windows (licensing dialogs, plugin registration in a DCC UI), and a pointer to the existing `job-user` login steps.

Docs only. No script or template changes.

## Review feedback addressed

The automated reviewer caught two factual errors in the first revision, both confirmed against the code and fixed in 3440678:

- The section claimed the shell runs as `job-user`. The SSH config in the same file uses `User ssm-user` (README.md:140), and the Windows sibling says the same (line 188).
- It advised letting the job finish to limit cost. `job/template.yaml:107-118` sleeps the full `SessionMinutes` with no check for a connected session, so cancelling the job is the only way to stop early.

Vale was failing on the first revision and now passes. That included one pre-existing tricolon in the Windows README (the `job-user` login paragraph), reported because the PR touches that file; the rewrite there is unrelated to the new section.