### PR TITLE
docs: add houdini-22.0 to the conda recipe index

### DIFF
--- a/conda_recipes/README.md
+++ b/conda_recipes/README.md
@@ -17,7 +17,7 @@ building new packages for either Linux or Windows into it on AWS Deadline Cloud.
 
 ## Recipe index
 
-This table covers all 51 immediate user-selectable recipe directories in `conda_recipes/`.
+This table covers all 52 immediate user-selectable recipe directories in `conda_recipes/`.
 
 | Sample | What it demonstrates | Start here when |
 |---|---|---|

--- a/conda_recipes/README.md
+++ b/conda_recipes/README.md
@@ -44,6 +44,7 @@ This table covers all 51 immediate user-selectable recipe directories in `conda_
 | [Deadline Cloud CLI](deadline/) | Building the `deadline` Python package and command line tools | Another package or worker environment needs the Deadline client |
 | [Houdini 20.5](houdini-20.5/) | Packaging Houdini 20.5 with plugin activation support | Your jobs require Houdini 20.5 |
 | [Houdini 21.0](houdini-21.0/) | Packaging Houdini 21.0 with Plugin Sync activation | Your jobs require Houdini 21 or frequently updated plugins |
+| [Houdini 22.0](houdini-22.0/) | Packaging Houdini 22.0 with Plugin Sync activation | Your jobs require Houdini 22 or frequently updated plugins |
 | [Redshift for Houdini 2025](houdini-redshift-2025/) | Packaging Redshift for Houdini 2025 | Houdini 20.5 jobs render with Redshift |
 | [Redshift for Houdini 2026](houdini-redshift-2026/) | Packaging Redshift for Houdini 2026 | Houdini 21 jobs render with Redshift |
 | [V-Ray 7 for Houdini](houdini-vray-7/) | Packaging V-Ray for Houdini | Houdini jobs render with V-Ray 7 |


### PR DESCRIPTION
## What was the problem/requirement? (What/Why)

The `houdini-22.0` conda recipe added in #281 was not added to the recipe index table in `conda_recipes/README.md`. That table lists the other recipes (Houdini 20.5, 21.0, the Redshift/V-Ray plugins, etc.), and the repository checklist calls for updating the nearest category table when a sample is added. Without the row, the recipe is undiscoverable from the collection README.

## What was the solution? (How)

Add a single table row for Houdini 22.0, next to the existing Houdini 21.0 entry.

## What is the impact of this change?

Documentation only — one row added to `conda_recipes/README.md`. No recipe or code changes.

## How was this change tested?

`vale conda_recipes/README.md` passes clean. The row matches the format and wording of the adjacent Houdini 20.5 / 21.0 rows and links to the existing `houdini-22.0/` directory.
