### PR TITLE
feat(mtoa-2027): add conda recipe for mtoa 2027

### DIFF
--- a/conda_recipes/README.md
+++ b/conda_recipes/README.md
@@ -17,7 +17,7 @@ building new packages for either Linux or Windows into it on AWS Deadline Cloud.
 
 ## Recipe index
 
-This table covers all 52 immediate user-selectable recipe directories in `conda_recipes/`.
+This table covers all 53 immediate user-selectable recipe directories in `conda_recipes/`.
 
 | Sample | What it demonstrates | Start here when |
 |---|---|---|

--- a/conda_recipes/README.md
+++ b/conda_recipes/README.md
@@ -56,6 +56,7 @@ This table covers all 52 immediate user-selectable recipe directories in `conda_
 | [Bifrost for Maya 2026](maya-bifrost-2026/) | Packaging Autodesk Bifrost for Maya | Maya 2026 jobs use Bifrost graphs or simulations |
 | [Arnold for Maya 2025](maya-mtoa-2025/) | Packaging MtoA against the Maya 2025 package | Maya 2025 jobs render with Arnold |
 | [Arnold for Maya 2026](maya-mtoa-2026/) | Packaging MtoA against the Maya 2026 package | Maya 2026 jobs render with Arnold |
+| [Arnold for Maya 2027](maya-mtoa-2027/) | Packaging MtoA against the Maya 2027 package | Maya 2027 jobs render with Arnold |
 | [Maya OpenJD adaptor](maya-openjd/) | Packaging the Maya integration adaptor | Maya jobs need OpenJD session integration |
 | [Redshift for Maya 2025](maya-redshift-2025/) | Packaging Redshift 2025 for supported Maya versions | Maya jobs use Redshift 2025 |
 | [Redshift for Maya 2026](maya-redshift-2026/) | Packaging Redshift 2026 for supported Maya versions | Maya jobs use Redshift 2026 |

--- a/conda_recipes/maya-mtoa-2027/README.md
+++ b/conda_recipes/maya-mtoa-2027/README.md
@@ -1,0 +1,14 @@
+# Maya to Arnold 2027 conda build recipe
+
+This recipe needs the same source archives as the [Maya 2027 recipe](../maya-2027).
+See the [README from the maya-2027 package recipe](../maya-2027/README.md) for
+instructions on how to acquire or create them, and details about how a conda package
+for a Maya plugin can integrate.
+
+## Build Notes
+The build script uses patchelf to set relative paths (RPATH) for shared libraries. The paths 
+(e.g., '$ORIGIN/../../maya2027/lib') are relative to the Maya installation directory structure. 
+If the Maya installation directory layout is modified, these paths in build.sh may need to be updated to match the new layout.
+
+Symlinks are created to make utilities accessible from the command line. 
+Additional symlinks may be needed if new utilities are added in future versions.

--- a/conda_recipes/maya-mtoa-2027/deadline-cloud.yaml
+++ b/conda_recipes/maya-mtoa-2027/deadline-cloud.yaml
@@ -1,0 +1,11 @@
+condaPlatforms:
+  - platform: linux-64
+    defaultSubmit: true
+    sourceArchiveFilename:
+    - Autodesk_Maya_2027_Linux_64bit.tgz
+    sourceDownloadInstructions: 'Download the Autodesk_Maya_2027_Linux_64bit.tgz full download file from Autodesk.'
+    buildTool: rattler-build
+jobParameters:
+  # conda-forge is used to get patchelf on Linux
+  - name: CondaChannels
+    value: conda-forge

--- a/conda_recipes/maya-mtoa-2027/recipe/build.sh
+++ b/conda_recipes/maya-mtoa-2027/recipe/build.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+set -xeuo pipefail
+
+# Get the version number without the update
+MAYA_VERSION=${PKG_VERSION%.*}
+
+# This is where to install MtoA within the installation prefix
+MTOA_ROOT="usr/autodesk/maya-mtoa-$MAYA_VERSION"
+
+# Change the current directory to the installation prefix
+mkdir -p "$PREFIX/$MTOA_ROOT"
+cd "$PREFIX/$MTOA_ROOT"
+
+# Extract the MtoA package file into the installation prefix.
+#
+# In Maya 2027 the Arnold payload ships as Packages/package.tgz, where earlier
+# releases used Packages/package.zip.
+tar -xzf "$SRC_DIR/installer/Packages/package.tgz"
+
+# Remove the licensing installers, they're not needed on the farm
+rm -r $PREFIX/$MTOA_ROOT/license/installer
+# Remove the docs, they're not needed on the farm
+rm -r $PREFIX/$MTOA_ROOT/docs
+
+# Add a relative RPATH from MtoA into Maya using patchelf, which is part of
+# the conda-build virtual environment. This is so we can follow the recommendation
+# of https://docs.conda.io/projects/conda-build/en/latest/resources/use-shared-libraries.html
+# to never use LD_LIBRARY_PATH in Conda environments.
+patchelf --add-rpath '$ORIGIN/../../maya2027/lib' $PREFIX/$MTOA_ROOT/bin/libai_renderview.so
+
+# Add RPATH for libraries in $MTOA_ROOT/procedurals to $MAYA_LOCATION/plug-ins/xgen/lib for libAdskSeExpr.so
+for file in "$PREFIX/$MTOA_ROOT/procedurals"/*.so; do
+    patchelf --set-rpath '$ORIGIN/../../maya2027/plug-ins/xgen/lib' "$file"
+done
+
+# Create symlinks for utilities allowing them to be run directly from the command line
+mkdir -p $PREFIX/bin
+ln -r -s $PREFIX/$MTOA_ROOT/bin/kick $PREFIX/bin/kick
+ln -r -s $PREFIX/$MTOA_ROOT/bin/oslc $PREFIX/bin/oslc
+ln -r -s $PREFIX/$MTOA_ROOT/bin/oslinfo $PREFIX/bin/oslinfo
+ln -r -s $PREFIX/$MTOA_ROOT/bin/maketx $PREFIX/bin/maketx
+ln -r -s $PREFIX/$MTOA_ROOT/bin/noice $PREFIX/bin/noice
+
+# Create the mtoa.mod file so Maya loads the plugin.
+#
+# The maya package has set the Maya module path to include virtual environment-equivalents of
+# the system module paths, so this is the usual installation location after the virtual environment
+# prefix.
+mkdir -p "$PREFIX/usr/autodesk/modules/maya/$MAYA_VERSION"
+cat <<EOF > "$PREFIX/usr/autodesk/modules/maya/$MAYA_VERSION/mtoa.mod"
++ mtoa any $PREFIX/$MTOA_ROOT
+MAYA_CUSTOM_TEMPLATE_PATH +:= scripts/mtoa/ui/templates
+MAYA_SCRIPT_PATH +:= scripts/mtoa/mel
+MAYA_RENDER_DESC_PATH += $PREFIX/$MTOA_ROOT
+MAYA_PXR_PLUGINPATH_NAME += $PREFIX/$MTOA_ROOT/usd
+ARNOLD_PLUGIN_PATH += $PREFIX/$MTOA_ROOT/shaders
+EOF

--- a/conda_recipes/maya-mtoa-2027/recipe/meta.yaml
+++ b/conda_recipes/maya-mtoa-2027/recipe/meta.yaml
@@ -1,0 +1,35 @@
+# See https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html for information
+# about this file.
+
+{% set version = "2027.0" %}
+{% set major_version = "2027" %}
+{% set minor_version = "0" %}
+
+package:
+  name: maya-mtoa
+  version: {{ version }}
+
+source:
+- url: archive_files/Autodesk_Maya_{{ major_version }}_Linux_64bit.tgz
+  sha256: c713ce176972268284a740bff6d346e01e03511c9bf0f090128f63f001ac8cf6
+  folder: installer
+
+build:
+  number: 0
+  # These build options for repackaging an application
+  # https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html
+  binary_relocation: False
+  detect_binary_files_with_prefix: False
+  missing_dso_whitelist:
+  - "**"
+
+requirements:
+  build:
+    - maya =={{ version }}.*
+  run:
+    - maya =={{ version }}.*
+
+about:
+  home: https://help.autodesk.com/view/ARNOL/ENU/?guid=arnold_for_maya_am_Arnold_for_Maya_User_Guide_html
+  license: Commercial
+  summary: Autodesk Arnold is an advanced cross-platform rendering library, or API, developed by Solid Angle and used by a number of prominent organizations in film, television, and animation, including Sony Pictures Imageworks. It was developed as a photo-realistic, physically-based ray tracing alternative to traditional scanline-based rendering software for CG animation.

--- a/conda_recipes/maya-mtoa-2027/recipe/recipe.yaml
+++ b/conda_recipes/maya-mtoa-2027/recipe/recipe.yaml
@@ -1,0 +1,50 @@
+# Recipe in rattler-build format.
+# See https://prefix-dev.github.io/rattler-build/latest/
+
+context:
+  version: "2027.0"
+  major_version: "2027"
+  minor_version: "0"
+
+package:
+  name: maya-mtoa
+  version: ${{ version }}
+
+source:
+  path: ../../archive_files/Autodesk_Maya_${{ major_version }}_Linux_64bit.tgz
+  sha256: c713ce176972268284a740bff6d346e01e03511c9bf0f090128f63f001ac8cf6
+  target_directory: installer
+
+build:
+  number: 0
+  # These build options for repackaging an application
+  # https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html
+  prefix_detection:
+    ignore_binary_files: True
+  dynamic_linking:
+    binary_relocation: False
+    missing_dso_allowlist:
+    - "**"
+
+requirements:
+  build:
+    - maya ${{ version }}.*
+    - patchelf
+  run:
+    - maya ${{ version }}.*
+
+tests:
+  - script:
+    # Maya's Python interpreter
+    - mayapy --help
+    # Confirm that the mtoa plugin is available in mayapy
+    # - mayapy -c 'import maya.standalone; maya.standalone.initialize(); import mtoa; from maya.cmds import arnoldRender; print("Hello from mayapy"); print(dir(mtoa)); maya.standalone.uninitialize()'
+    - mayapy -c 'import maya.standalone; maya.standalone.initialize(); import mtoa; print("Hello from mayapy"); print(dir(mtoa)); maya.standalone.uninitialize()'
+    # The maya -batch command
+    - maya -batch -command 'print "Hello from maya -batch"; quit -exitCode 0 -force'
+
+
+about:
+  homepage: https://www.autodesk.com/products/maya/overview
+  license: LicenseRef-AutodeskEULA
+  summary: Maya is professional 3D software for creating realistic characters and blockbuster-worthy effects.

--- a/conda_recipes/maya-mtoa-2027/recipe/recipe.yaml
+++ b/conda_recipes/maya-mtoa-2027/recipe/recipe.yaml
@@ -38,13 +38,11 @@ tests:
     # Maya's Python interpreter
     - mayapy --help
     # Confirm that the mtoa plugin is available in mayapy
-    # - mayapy -c 'import maya.standalone; maya.standalone.initialize(); import mtoa; from maya.cmds import arnoldRender; print("Hello from mayapy"); print(dir(mtoa)); maya.standalone.uninitialize()'
     - mayapy -c 'import maya.standalone; maya.standalone.initialize(); import mtoa; print("Hello from mayapy"); print(dir(mtoa)); maya.standalone.uninitialize()'
     # The maya -batch command
     - maya -batch -command 'print "Hello from maya -batch"; quit -exitCode 0 -force'
 
-
 about:
-  homepage: https://www.autodesk.com/products/maya/overview
+  homepage: https://help.autodesk.com/view/ARNOL/ENU/?guid=arnold_for_maya_am_Arnold_for_Maya_User_Guide_html
   license: LicenseRef-AutodeskEULA
-  summary: Maya is professional 3D software for creating realistic characters and blockbuster-worthy effects.
+  summary: Autodesk Arnold is an advanced cross-platform rendering library, or API, developed by Solid Angle and used by a number of prominent organizations in film, television, and animation, including Sony Pictures Imageworks. It was developed as a photo-realistic, physically-based ray tracing alternative to traditional scanline-based rendering software for CG animation.


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Adding support for Maya to Arnold 2027.

  ### What was the solution? (How)

  Added `maya-mtoa-2027`, based on `maya-mtoa-2026`. Three changes are more than a version bump and worth review:

  - The 2027 download is `Autodesk_Maya_2027_Linux_64bit.tgz` — the 2026 archive had an `_ML_` infix.
  - The Arnold payload ships as `Packages/package.tgz` in 2027 where 2026 used `Packages/package.zip`, so extraction changed from `unzip` to `tar -xzf`. The `maya-2027` recipe makes the same change.
  - `patchelf` is now declared in build requirements with a `CondaChannels: conda-forge` job parameter. `build.sh` has always called it, but neither 2026 nor this recipe declared it — it resolved only because the outer build environment happens to provide it.

  ### What is the impact of this change?

  New recipe only; no existing recipe changes. Note that testing this against an adaptor-based job also requires the `mayapy` wrapper fix in `maya-2027` (#280), without which any Maya 2027 job in an environment containing the `maya-openjd` stack segfaults.

New recipe only; no existing recipe changes. Testing it with an adaptor-based job also needs the `mayapy` wrapper fix in `maya-2027` (#280): without it, any Maya 2027 job whose environment also contains conda-provided Python 3.13 package segfaults (e.g. `maya-openjd`).

  ### How was this change tested?

  - `./submit-package-job maya-mtoa-2027` builds and publishes successfully.
  - Submitted `turntable_with_maya_arnold` with `CondaPackages="maya=2027 maya-mtoa=2027 maya-openjd=0.15.13 ffmpeg"`; Arnold rendered and the job completed.

  ### Was this change documented?

  Yes. The recipe's `README.md` is updated for 2027, and `conda_recipes/README.md` gains an "Arnold for Maya 2027" row (with the table count updated).

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*